### PR TITLE
fix(webhooks): allow owner update/delete for global webhooks

### DIFF
--- a/server/extensions/webhooks/api/delete.ts
+++ b/server/extensions/webhooks/api/delete.ts
@@ -1,12 +1,8 @@
-// DELETE /api/v1/webhooks/:id — remove a webhook; caller must be owner or workspace ADMIN+.
+// DELETE /api/v1/webhooks/:id — remove a webhook; caller must be the owner.
 // webhook_deliveries are cascade-deleted by DB foreign key constraint.
 import { db } from '../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../auth/middlewares/authentication';
-import {
-  requireWorkspaceMembership,
-  hasRole,
-  type WorkspaceScopedRequest,
-} from '../../../middlewares/permissionManager';
+import { canManageWebhook } from './mods/webhookPermissions';
 
 export async function handleDeleteWebhook(req: Request, webhookId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
@@ -20,17 +16,11 @@ export async function handleDeleteWebhook(req: Request, webhookId: string): Prom
     );
   }
 
-  const scopedReq = req as WorkspaceScopedRequest;
-  const membershipError = await requireWorkspaceMembership(scopedReq, webhook.workspace_id);
-  if (membershipError) return membershipError;
-
   const userId = (req as AuthenticatedRequest).currentUser!.id;
-  const isOwner = webhook.created_by === userId;
-  const isAdminOrAbove = scopedReq.callerRole ? hasRole(scopedReq.callerRole, 'ADMIN') : false;
 
-  if (!isOwner && !isAdminOrAbove) {
+  if (!canManageWebhook({ webhookCreatedBy: webhook.created_by, currentUserId: userId })) {
     return Response.json(
-      { name: 'insufficient-permissions', data: { message: 'Only the webhook owner or an admin can delete this webhook' } },
+      { name: 'insufficient-permissions', data: { message: 'Only the webhook owner can delete this webhook' } },
       { status: 403 },
     );
   }

--- a/server/extensions/webhooks/api/mods/webhookPermissions.ts
+++ b/server/extensions/webhooks/api/mods/webhookPermissions.ts
@@ -1,0 +1,15 @@
+type CanManageWebhookParams = {
+  webhookCreatedBy: string;
+  currentUserId: string;
+};
+
+/**
+ * Global webhooks are no longer workspace-scoped.
+ * Only the webhook creator can update/delete their webhook.
+ */
+export function canManageWebhook({
+  webhookCreatedBy,
+  currentUserId,
+}: CanManageWebhookParams): boolean {
+  return webhookCreatedBy === currentUserId;
+}

--- a/server/extensions/webhooks/api/update.ts
+++ b/server/extensions/webhooks/api/update.ts
@@ -1,13 +1,9 @@
 // PATCH /api/v1/webhooks/:id — update label, endpointUrl, eventTypes, or isActive.
-// Caller must be the webhook owner or a workspace OWNER/ADMIN.
+// Caller must be the webhook owner.
 import { db } from '../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../auth/middlewares/authentication';
-import {
-  requireWorkspaceMembership,
-  hasRole,
-  type WorkspaceScopedRequest,
-} from '../../../middlewares/permissionManager';
 import { WEBHOOK_EVENT_TYPES, type WebhookEventType } from '../common/eventTypes';
+import { canManageWebhook } from './mods/webhookPermissions';
 import { isEndpointAllowed } from './ssrfGuard';
 
 export async function handleUpdateWebhook(req: Request, webhookId: string): Promise<Response> {
@@ -22,17 +18,11 @@ export async function handleUpdateWebhook(req: Request, webhookId: string): Prom
     );
   }
 
-  const scopedReq = req as WorkspaceScopedRequest;
-  const membershipError = await requireWorkspaceMembership(scopedReq, webhook.workspace_id);
-  if (membershipError) return membershipError;
-
   const userId = (req as AuthenticatedRequest).currentUser!.id;
-  const isOwner = webhook.created_by === userId;
-  const isAdminOrAbove = scopedReq.callerRole ? hasRole(scopedReq.callerRole, 'ADMIN') : false;
 
-  if (!isOwner && !isAdminOrAbove) {
+  if (!canManageWebhook({ webhookCreatedBy: webhook.created_by, currentUserId: userId })) {
     return Response.json(
-      { name: 'insufficient-permissions', data: { message: 'Only the webhook owner or an admin can update this webhook' } },
+      { name: 'insufficient-permissions', data: { message: 'Only the webhook owner can update this webhook' } },
       { status: 403 },
     );
   }

--- a/tests/unit/webhooks/webhookPermissions.test.ts
+++ b/tests/unit/webhooks/webhookPermissions.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'bun:test';
+
+import { canManageWebhook } from '../../../server/extensions/webhooks/api/mods/webhookPermissions';
+
+describe('canManageWebhook', () => {
+  it('allows the creator of the webhook', () => {
+    expect(
+      canManageWebhook({
+        webhookCreatedBy: 'user-1',
+        currentUserId: 'user-1',
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects non-owners', () => {
+    expect(
+      canManageWebhook({
+        webhookCreatedBy: 'user-1',
+        currentUserId: 'user-2',
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- fix webhook `PATCH /api/v1/webhooks/:id` and `DELETE /api/v1/webhooks/:id` authorization for global webhooks
- remove stale workspace membership/admin checks from update/delete handlers
- add `canManageWebhook()` helper and wire both handlers through it
- add unit tests for owner vs non-owner authorization decision

## Root cause
After webhooks were made global (`workspace_id` nullable), update/delete still called `requireWorkspaceMembership(...)` using `webhook.workspace_id`, which rejects with `insufficient-role` when `workspace_id` is null.

## Validation
- `bun test tests/unit/webhooks/webhookPermissions.test.ts`
- `bun test tests/integration/webhooks/api-crud.test.ts tests/unit/webhooks/webhookPermissions.test.ts`
- local API smoke:
  - create webhook -> 201
  - patch webhook -> 200
  - delete webhook -> 200

## Notes
- independent review run: no security concerns, no logic errors
