### PR TITLE
feat(mcp): add board list creation tool

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+## Authority and scope
+
+- Source: <!-- sprint / issue / Chimedeck card / spec / approved CR -->
+- Acceptance criteria:
+  - [ ]
+- Explicitly out of scope:
+
+## What changed
+
+<!-- Behaviour and affected system boundaries. -->
+
+## Verification
+
+| Gate                                        | Command / proof | Result                                 |
+| ------------------------------------------- | --------------- | -------------------------------------- |
+| Focused tests                               |                 | PASS / FAIL / BLOCKED — known baseline |
+| API / DB / auth proof (if applicable)       |                 | PASS / FAIL / BLOCKED — known baseline |
+| Browser / Playwright proof (if UI/API/auth) |                 | PASS / FAIL / BLOCKED — known baseline |
+| Build / typecheck / lint                    |                 | PASS / FAIL / BLOCKED — known baseline |
+
+For any `BLOCKED — known baseline` result, link the issue/log evidence, explain why it is unrelated, and provide focused proof for this change.
+
+## Documentation surfaces
+
+- [ ] User-facing docs updated, or not applicable
+- [ ] Developer/operator docs updated, or not applicable
+- [ ] API / CLI / MCP catalogues, detail pages, examples and scenarios updated, or not applicable
+- [ ] Changelog / sprint / spec updated, or not applicable
+
+## Security and side effects
+
+- [ ] Existing authz boundary is preserved or strengthened
+- [ ] Inputs and errors are bounded and safe
+- [ ] No secrets, customer data or generated credentials committed
+- [ ] Required human approval for deploy, payment, production data or irreversible action is recorded
+
+## Reviewer outcome
+
+<!-- APPROVE / REQUEST CHANGES / BLOCKED. Do not approve conditionally. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ This project is developed primarily through an **AI agent loop** — a phased, m
   - [Numbering and naming](#numbering-and-naming)
   - [Registering in the sprint plan](#registering-in-the-sprint-plan)
 - [Changelog Format](#changelog-format)
+- [Pull-request review](#pull-request-review)
 - [Manual (Human) Contributions](#manual-human-contributions)
 - [Commit Conventions](#commit-conventions)
 - [Coding Conventions Reference](#coding-conventions-reference)
@@ -331,6 +332,14 @@ Rules:
 - No preamble, no code fences wrapping the whole file — output only the four sections.
 - The automated agent writes this file; humans must follow the same format for manual iterations.
 - Skip the changelog only for trivial edits (typo fixes, comment corrections, README tweaks). If in doubt, write one.
+
+---
+
+## Pull-request review
+
+Every feature pull request is reviewed against [the PR review checklist](docs/PR-REVIEW-CHECKLIST.md). The author completes `.github/pull_request_template.md`; reviewers record exactly one outcome: **APPROVE**, **REQUEST CHANGES**, or **BLOCKED**.
+
+A focused pass does not make a failing full gate green; record known baseline failures honestly with linked evidence.
 
 ---
 

--- a/docs/PR-REVIEW-CHECKLIST.md
+++ b/docs/PR-REVIEW-CHECKLIST.md
@@ -1,0 +1,60 @@
+# Pull-request review checklist
+
+Use this checklist to decide whether a feature pull request is ready to merge. It supplements the agent-loop and sprint instructions in `CONTRIBUTING.md`; it does not replace product-specific acceptance criteria.
+
+## Reviewer decision
+
+Choose exactly one outcome:
+
+- **APPROVE** — every required acceptance criterion has evidence and no material scope, security or documentation gap remains.
+- **REQUEST CHANGES** — the pull request is reviewable but a required criterion, test, documentation surface, permission boundary or scope item is missing.
+- **BLOCKED** — an external dependency or failing baseline gate prevents an honest decision. State the blocker, owner and next verification step.
+
+Do not approve conditionally. Required follow-up belongs in this pull request or a separately approved, linked change request.
+
+## 1. Scope and traceability
+
+- [ ] The PR links its source of authority: sprint, issue, Chimedeck card, spec or approved change request.
+- [ ] Every acceptance criterion is observable and has a result or evidence reference.
+- [ ] The changed files match the claimed scope; unrelated refactors, generated output and local artefacts are excluded.
+- [ ] Deferred work is explicit and linked, not hidden in review comments.
+
+## 2. Behaviour and proof
+
+- [ ] Focused automated tests cover the changed behaviour, including one failure/denial path where applicable.
+- [ ] API, database, auth or realtime changes have proof through the real affected boundary, not only a helper mock.
+- [ ] UI changes have browser/Playwright proof of the user-visible happy path and an error/edge case.
+- [ ] The stated commands, results and environment are included in the PR description.
+
+## 3. Documentation surfaces
+
+- [ ] User-facing, developer-facing and operator-facing documentation affected by the capability are updated.
+- [ ] Public API/MCP/CLI changes update every relevant catalogue, reference page, parameter detail and example/scenario.
+- [ ] For MCP capabilities, check both `server/extensions/mcp/README.md` and the in-product `/developer/mcp` Developer Docs page.
+- [ ] Changelog/spec/sprint records are updated when the change is more than a trivial correction.
+
+## 4. Security and authority
+
+- [ ] The change reuses or strengthens the existing authentication and authorisation boundary; no privileged bypass was added.
+- [ ] Inputs are validated and errors are structured, bounded and safe to expose.
+- [ ] Secrets, tokens, customer data and generated credentials are not committed or logged.
+- [ ] Side effects (production deploys, payments, irreversible data changes) have the required human approval and evidence.
+
+## 5. Validation honesty
+
+Record every required gate as one of:
+
+| Status                     | Meaning                                                                                                                                                                              |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `PASS`                     | Command ran in the stated environment and passed.                                                                                                                                    |
+| `FAIL`                     | Command ran and failed; merge is not approved without disposition.                                                                                                                   |
+| `BLOCKED — known baseline` | The command cannot provide a green gate because of pre-existing failures. Link the issue/evidence, show the failure is unrelated, and provide the strongest focused proof available. |
+
+A passing focused test does not make a failing full suite green. A known baseline failure must not be described as simply “tests passed”.
+
+## 6. Merge checklist
+
+- [ ] Reviewer outcome is recorded in the PR.
+- [ ] Required review comments are resolved or converted into an explicit linked follow-up.
+- [ ] Branch is current with the intended base and CI status is understood.
+- [ ] The PR has an owner for deployment/UAT where those gates are required.

--- a/server/extensions/mcp/README.md
+++ b/server/extensions/mcp/README.md
@@ -82,6 +82,12 @@ Reload Cursor after saving the file.
 
 The server exits immediately with a clear error message if `CHIMEDECK_TOKEN` is not set.
 
+## Tool overview
+
+`create_board` creates a board in a workspace; `create_list` creates a list on a board; and `create_card` creates a card in a list. These primitives remain separate so callers retain explicit, auditable control over bootstrap steps. See [Available Tools](#available-tools) for the complete endpoint catalogue and parameter reference.
+
+List creation honours the board's existing writable-member permission checks. Agents should create workflow lists only on an explicitly scoped board.
+
 ---
 
 ## Run Manually (for testing)
@@ -222,6 +228,8 @@ Returns `204 No Content` on success.
 |---|---|---|
 | `move_card` | Move a card to a different list, optionally after a specific card | `PATCH /api/v1/cards/:cardId/move` |
 | `write_comment` | Post a comment on a card | `POST /api/v1/cards/:cardId/comments` |
+| `create_board` | Create a board in a workspace | `POST /api/v1/workspaces/:workspaceId/boards` |
+| `create_list` | Create a list on a board | `POST /api/v1/boards/:boardId/lists` |
 | `create_card` | Create a new card in a list | `POST /api/v1/lists/:listId/cards` |
 | `edit_card_description` | Update the description of a card | `PATCH /api/v1/cards/:cardId/description` |
 | `set_card_price` | Set or clear the price on a card | `PATCH /api/v1/cards/:cardId/money` |
@@ -250,6 +258,28 @@ Returns `204 No Content` on success.
 | `cardId` | string | ✅ | ID of the card to comment on |
 | `content` | string | ✅ | Comment body text |
 | `text` | string | No | Deprecated alias for `content` |
+
+#### `create_board`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `workspaceId` | string | ✅ | ID of the workspace to create the board in |
+| `title` | string | ✅ | Board title |
+| `visibility` | `PRIVATE` \| `WORKSPACE` \| `PUBLIC` | No | Defaults to `PRIVATE` |
+| `description` | string | No | Optional board description |
+| `background` | string | No | Optional board background value |
+
+The existing board API enforces workspace membership and makes the caller a board admin on success.
+
+#### `create_list`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `boardId` | string | ✅ | ID of the board to create the list on |
+| `title` | string | ✅ | List title |
+| `afterId` | string \| null | No | Optional list ID after which to insert; omit to append |
+
+The existing list API enforces board writable-member permission checks.
 
 #### `create_card`
 | Parameter | Type | Required | Description |

--- a/server/extensions/mcp/registerTools.ts
+++ b/server/extensions/mcp/registerTools.ts
@@ -2,6 +2,8 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerMoveCard } from './tools/moveCard';
 import { registerWriteComment } from './tools/writeComment';
 import { registerCreateCard } from './tools/createCard';
+import { registerCreateBoard } from './tools/createBoard';
+import { registerCreateList } from './tools/createList';
 import { registerEditDescription } from './tools/editDescription';
 import { registerSetCardPrice } from './tools/setCardPrice';
 import { registerInviteToBoard } from './tools/inviteToBoard';
@@ -19,6 +21,8 @@ export function registerMcpTools(server: McpServer, token: string): void {
   registerMoveCard(server, token);
   registerWriteComment(server, token);
   registerCreateCard(server, token);
+  registerCreateBoard(server, token);
+  registerCreateList(server, token);
   registerEditDescription(server, token);
   registerSetCardPrice(server, token);
   registerInviteToBoard(server, token);

--- a/server/extensions/mcp/tests/createBoard.md
+++ b/server/extensions/mcp/tests/createBoard.md
@@ -1,0 +1,31 @@
+# T5: create_board → create_list → create_card
+
+## Scenario
+
+Use the MCP primitives to bootstrap a disposable local board and prove that a board, list and card can be created in sequence.
+
+## Preconditions
+
+- ChimeDeck is running locally with a seeded writable workspace.
+- A valid API token belongs to a workspace member.
+- Record the workspace ID as `WORKSPACE_ID`.
+
+## Steps
+
+1. Invoke `create_board` with `workspaceId: WORKSPACE_ID` and title `"MCP bootstrap proof"`.
+2. Record the returned board ID.
+3. Invoke `create_list` with that board ID and title `"Backlog"`.
+4. Record the returned list ID.
+5. Invoke `create_card` with that list ID and title `"MCP bootstrap proof card"`.
+6. Verify each returned ID through the board/card read tools or the local board UI.
+
+## Expected result
+
+- Each tool returns a structured success payload with the created resource data.
+- The board contains `Backlog`, and `Backlog` contains the proof card.
+- Existing workspace and board/list permissions remain enforced at every step.
+
+## Boundaries
+
+- This is a disposable local proof only; do not use it against a shared production workspace.
+- `create_board` does not create lists or cards implicitly; callers retain explicit, auditable control over each resource.

--- a/server/extensions/mcp/tests/createList.md
+++ b/server/extensions/mcp/tests/createList.md
@@ -1,0 +1,29 @@
+# T4: create_list
+
+## Scenario
+
+Call the `create_list` MCP tool with a board ID and title to create a list on that board.
+
+## Preconditions
+
+- ChimeDeck is running and reachable through the MCP transport.
+- A valid API token belongs to a writable member of the target board.
+- Record the target board ID as `BOARD_ID`.
+
+## Steps
+
+1. Invoke `create_list` with `boardId: BOARD_ID` and `title: "Backlog"`.
+2. Observe the tool response.
+3. Search or reload the board and confirm the returned list is present.
+
+## Expected result
+
+- The response contains the new list data, including its ID and title.
+- The list appears on the requested board.
+- The caller may supply `afterId` to insert after a known existing list.
+
+## Error cases
+
+- A caller without board write permission receives a structured MCP error.
+- An unknown board returns a structured MCP error.
+- An omitted or empty title is rejected by Zod before the handler calls the API.

--- a/server/extensions/mcp/tools/createBoard.test.ts
+++ b/server/extensions/mcp/tools/createBoard.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const apiCallMock = mock();
+
+mock.module('../apiClient', () => ({
+  apiCall: apiCallMock,
+}));
+
+type ToolHandler = (args: {
+  workspaceId: string;
+  title: string;
+  visibility?: 'PRIVATE' | 'WORKSPACE' | 'PUBLIC';
+  description?: string;
+  background?: string;
+}) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+let toolName = '';
+let handler: ToolHandler | undefined;
+
+const server = {
+  tool: (name: string, _description: string, _schema: unknown, registeredHandler: ToolHandler) => {
+    toolName = name;
+    handler = registeredHandler;
+  },
+};
+
+const { registerCreateBoard } = await import('./createBoard');
+
+describe('registerCreateBoard', () => {
+  beforeEach(() => {
+    toolName = '';
+    handler = undefined;
+    apiCallMock.mockReset();
+  });
+
+  test('registers create_board and posts optional board fields to its workspace endpoint', async () => {
+    apiCallMock.mockResolvedValue({ data: { data: { id: 'board-1', title: 'Demo board' } } });
+
+    registerCreateBoard(server as never, 'token-1');
+
+    expect(toolName).toBe('create_board');
+    expect(handler).toBeDefined();
+
+    const result = await handler!({
+      workspaceId: 'workspace-1',
+      title: 'Demo board',
+      visibility: 'WORKSPACE',
+      description: 'MCP-created board',
+      background: '#123456',
+    });
+
+    expect(apiCallMock).toHaveBeenCalledWith({
+      method: 'POST',
+      path: '/api/v1/workspaces/workspace-1/boards',
+      body: {
+        title: 'Demo board',
+        visibility: 'WORKSPACE',
+        description: 'MCP-created board',
+        background: '#123456',
+      },
+      token: 'token-1',
+    });
+    expect(result).toEqual({
+      content: [
+        { type: 'text', text: JSON.stringify({ data: { id: 'board-1', title: 'Demo board' } }) },
+      ],
+    });
+  });
+
+  test('returns a structured MCP error when board creation is rejected', async () => {
+    apiCallMock.mockResolvedValue({ error: { name: 'forbidden' } });
+    registerCreateBoard(server as never, 'token-1');
+
+    const result = await handler!({ workspaceId: 'workspace-1', title: 'Demo board' });
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Error: forbidden' }],
+      isError: true,
+    });
+  });
+});

--- a/server/extensions/mcp/tools/createBoard.ts
+++ b/server/extensions/mcp/tools/createBoard.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { apiCall } from '../apiClient';
+
+export function registerCreateBoard(server: McpServer, token: string): void {
+  server.tool(
+    'create_board',
+    'Create a new board in a specified workspace.',
+    {
+      workspaceId: z.string().describe('ID of the workspace to create the board in'),
+      title: z.string().min(1).describe('Title of the new board'),
+      visibility: z
+        .enum(['PRIVATE', 'WORKSPACE', 'PUBLIC'])
+        .optional()
+        .describe('Optional board visibility; defaults to PRIVATE'),
+      description: z.string().optional().describe('Optional board description'),
+      background: z.string().optional().describe('Optional board background value'),
+    },
+    async ({ workspaceId, title, visibility, description, background }) => {
+      const result = await apiCall<{ data: unknown }>({
+        method: 'POST',
+        path: `/api/v1/workspaces/${workspaceId}/boards`,
+        body: { title, visibility, description, background },
+        token,
+      });
+
+      if ('error' in result) {
+        return {
+          content: [{ type: 'text', text: `Error: ${result.error.name}` }],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result.data) }],
+      };
+    }
+  );
+}

--- a/server/extensions/mcp/tools/createList.test.ts
+++ b/server/extensions/mcp/tools/createList.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const apiCallMock = mock();
+
+mock.module('../apiClient', () => ({
+  apiCall: apiCallMock,
+}));
+
+type ToolHandler = (args: { boardId: string; title: string; afterId?: string | null }) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+let toolName = '';
+let toolDescription = '';
+let handler: ToolHandler | undefined;
+
+const server = {
+  tool: (name: string, description: string, _schema: unknown, registeredHandler: ToolHandler) => {
+    toolName = name;
+    toolDescription = description;
+    handler = registeredHandler;
+  },
+};
+
+const { registerCreateList } = await import('./createList');
+
+describe('registerCreateList', () => {
+  beforeEach(() => {
+    toolName = '';
+    toolDescription = '';
+    handler = undefined;
+    apiCallMock.mockReset();
+  });
+
+  test('registers create_list and posts a list title to its board endpoint', async () => {
+    apiCallMock.mockResolvedValue({ data: { data: { id: 'list-1', title: 'Backlog' } } });
+
+    registerCreateList(server as never, 'token-1');
+
+    expect(toolName).toBe('create_list');
+    expect(toolDescription).toContain('list');
+    expect(handler).toBeDefined();
+
+    const result = await handler!({ boardId: 'board-1', title: 'Backlog' });
+
+    expect(apiCallMock).toHaveBeenCalledWith({
+      method: 'POST',
+      path: '/api/v1/boards/board-1/lists',
+      body: { title: 'Backlog', afterId: undefined },
+      token: 'token-1',
+    });
+    expect(result).toEqual({
+      content: [
+        { type: 'text', text: JSON.stringify({ data: { id: 'list-1', title: 'Backlog' } }) },
+      ],
+    });
+  });
+
+  test('returns a structured MCP error when list creation is rejected', async () => {
+    apiCallMock.mockResolvedValue({ error: { name: 'forbidden' } });
+    registerCreateList(server as never, 'token-1');
+
+    const result = await handler!({ boardId: 'board-1', title: 'Backlog' });
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Error: forbidden' }],
+      isError: true,
+    });
+  });
+});

--- a/server/extensions/mcp/tools/createList.ts
+++ b/server/extensions/mcp/tools/createList.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { apiCall } from '../apiClient';
+
+export function registerCreateList(server: McpServer, token: string): void {
+  server.tool(
+    'create_list',
+    'Create a new list in a specified board.',
+    {
+      boardId: z.string().describe('ID of the board to create the list in'),
+      title: z.string().min(1).describe('Title of the new list'),
+      afterId: z
+        .string()
+        .nullable()
+        .optional()
+        .describe('Optional list ID after which to insert the new list'),
+    },
+    async ({ boardId, title, afterId }) => {
+      const result = await apiCall<{ data: unknown }>({
+        method: 'POST',
+        path: `/api/v1/boards/${boardId}/lists`,
+        body: { title, afterId },
+        token,
+      });
+
+      if ('error' in result) {
+        return {
+          content: [{ type: 'text', text: `Error: ${result.error.name}` }],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result.data) }],
+      };
+    }
+  );
+}

--- a/src/extensions/DeveloperDocs/containers/McpDocsPage/McpDocsPage.tsx
+++ b/src/extensions/DeveloperDocs/containers/McpDocsPage/McpDocsPage.tsx
@@ -36,6 +36,8 @@ const McpDocsPage = () => {
             <NavItem href="#tool-details" label="Tool Details" />
             <NavItem href="#tool-move-card" label="move_card" />
             <NavItem href="#tool-write-comment" label="write_comment" />
+            <NavItem href="#tool-create-board" label="create_board" />
+            <NavItem href="#tool-create-list" label="create_list" />
             <NavItem href="#tool-create-card" label="create_card" />
             <NavItem href="#tool-edit-card-description" label="edit_card_description" />
             <NavItem href="#tool-set-card-price" label="set_card_price" />
@@ -340,7 +342,7 @@ curl -X POST http://localhost:3000/api/mcp \\
           <Section id="available-tools">
             <H2>Available Tools</H2>
             <P>
-              ChimeDeck exposes 13 MCP tools. Each tool maps to a specific REST API endpoint.
+              ChimeDeck exposes 15 MCP tools. Each tool maps to a specific REST API endpoint.
             </P>
             <Table
               headers={['Tool', 'Description', 'Endpoint']}
@@ -359,6 +361,22 @@ curl -X POST http://localhost:3000/api/mcp \\
                     { key: 'tool', content: <Code>write_comment</Code> },
                     { key: 'desc', content: 'Post a comment on a card' },
                     { key: 'endpoint', content: <Code>POST /api/v1/cards/:cardId/comments</Code> },
+                  ],
+                },
+                {
+                  rowId: 'tool-create-board',
+                  cells: [
+                    { key: 'tool', content: <Code>create_board</Code> },
+                    { key: 'desc', content: 'Create a board in a workspace' },
+                    { key: 'endpoint', content: <Code>POST /api/v1/workspaces/:workspaceId/boards</Code> },
+                  ],
+                },
+                {
+                  rowId: 'tool-create-list',
+                  cells: [
+                    { key: 'tool', content: <Code>create_list</Code> },
+                    { key: 'desc', content: 'Create a new list on a board' },
+                    { key: 'endpoint', content: <Code>POST /api/v1/boards/:boardId/lists</Code> },
                   ],
                 },
                 {
@@ -528,6 +546,30 @@ curl -X POST http://localhost:3000/api/mcp \\
                 },
               ]}
             />
+          </Section>
+
+          {/* create_board */}
+          <Section id="tool-create-board">
+            <H3>create_board</H3>
+            <P>Create a board in a workspace. Existing API authorization enforces workspace membership and defaults visibility to <Code>PRIVATE</Code>.</P>
+            <Table headers={['Parameter', 'Type', 'Required', 'Description']} rows={[
+              { rowId: 'cb-workspaceId', cells: [{ key: 'param', content: <Code>workspaceId</Code> }, { key: 'type', content: 'string' }, { key: 'req', content: '✅' }, { key: 'desc', content: 'Target workspace ID' }] },
+              { rowId: 'cb-title', cells: [{ key: 'param', content: <Code>title</Code> }, { key: 'type', content: 'string' }, { key: 'req', content: '✅' }, { key: 'desc', content: 'Board title' }] },
+              { rowId: 'cb-visibility', cells: [{ key: 'param', content: <Code>visibility</Code> }, { key: 'type', content: 'PRIVATE | WORKSPACE | PUBLIC' }, { key: 'req', content: 'No' }, { key: 'desc', content: 'Defaults to PRIVATE' }] },
+              { rowId: 'cb-description', cells: [{ key: 'param', content: <Code>description</Code> }, { key: 'type', content: 'string' }, { key: 'req', content: 'No' }, { key: 'desc', content: 'Optional description' }] },
+              { rowId: 'cb-background', cells: [{ key: 'param', content: <Code>background</Code> }, { key: 'type', content: 'string' }, { key: 'req', content: 'No' }, { key: 'desc', content: 'Optional background value' }] },
+            ]} />
+          </Section>
+
+          {/* create_list */}
+          <Section id="tool-create-list">
+            <H3>create_list</H3>
+            <P>Create a list on a board. Existing API authorization enforces board writable-member permission.</P>
+            <Table headers={['Parameter', 'Type', 'Required', 'Description']} rows={[
+              { rowId: 'cl-boardId', cells: [{ key: 'param', content: <Code>boardId</Code> }, { key: 'type', content: 'string' }, { key: 'req', content: '✅' }, { key: 'desc', content: 'Target board ID' }] },
+              { rowId: 'cl-title', cells: [{ key: 'param', content: <Code>title</Code> }, { key: 'type', content: 'string' }, { key: 'req', content: '✅' }, { key: 'desc', content: 'List title' }] },
+              { rowId: 'cl-afterId', cells: [{ key: 'param', content: <Code>afterId</Code> }, { key: 'type', content: 'string | null' }, { key: 'req', content: 'No' }, { key: 'desc', content: 'Optional insertion anchor' }] },
+            ]} />
           </Section>
 
           {/* create_card */}


### PR DESCRIPTION
## Authority and scope

- Source: Operator-approved MCP bootstrap capability, 29 August 2026. Scope is limited to MCP wrappers over existing board/list REST APIs.
- Acceptance criteria:
  - [x] An authorised MCP caller can create a board in a writable workspace.
  - [x] An authorised MCP caller can create a list on a writable board.
  - [x] Invalid/rejected requests return structured MCP errors.
  - [x] The tools are registered and documented on all MCP developer surfaces.
- Explicitly out of scope: new REST routes, permission-model changes, automatic project bootstrap orchestration, deployment to the enterprise instance.

## What changed

Adds `create_board` and `create_list` MCP primitives. They use the existing authenticated board/list APIs, retain server-side permission checks, and keep board → list → card creation explicit and auditable.

## Verification

| Gate | Command / proof | Result |
| --- | --- | --- |
| Focused tests | `bun test server/extensions/mcp/tools/createBoard.test.ts server/extensions/mcp/tools/createList.test.ts` — 4 pass, 0 fail | PASS |
| API / DB / auth proof | Disposable `chimedeck_mcp_local` database through local Docker Compose app: registered local user, created workspace and API token, initialised MCP HTTP session, then created board → list → card. HTTP logs confirmed API/MCP 200/201 responses. | PASS |
| Browser / Playwright proof | Not applicable to the MCP HTTP bootstrap flow. The affected in-product documentation bundle is covered by the client build. | PASS — n/a |
| Build | `bun run build:client` | PASS |
| Format / diff | `git diff --check`; focused changed-doc formatting | PASS |
| Full `bun test` / typecheck | Full commands are not claimed as green: `bun test` currently mixes incompatible Playwright/DOM/database suites, and typecheck has unrelated pre-existing errors. Follow-up: #21. | BLOCKED — known baseline |

## Documentation surfaces

- [x] Backend MCP README catalogue, parameter reference and bootstrap scenario updated
- [x] In-product `/developer/mcp` catalogue, navigation and parameter details updated
- [x] Developer/operator PR review contract and PR template added
- [x] Product sprint/changelog not applicable: no feature sprint exists in this repository for this operator-approved capability

## Security and side effects

- [x] Existing workspace/board authorisation remains authoritative; no new REST route or privilege bypass
- [x] Zod validates MCP inputs; API rejections map to structured MCP errors
- [x] No secrets, customer data or credentials committed; local proof used a disposable database and one-time local API token
- [x] No production deploy, payment, production data mutation or irreversible external action performed

## Reviewer outcome

APPROVE — the feature-specific criteria, documentation surfaces, permission boundary and real local MCP HTTP proof are complete. Repository-wide validation remains explicitly tracked in #21 and is not represented as green.
