### PR TITLE
fix(deploy): harden managed-service EC2 rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,23 @@ docker compose -f docker-compose.prod.yml --profile redis up -d
 docker compose -f docker-compose.prod.yml --profile local-db --profile local-s3 --profile redis up -d
 ```
 
+### Managed-service EC2 rollout
+
+For an EC2 fleet behind a load balancer, run `scripts/deploy-on-instance.sh` **one host at a time** through a controlled remote-execution channel such as SSM. It uses managed services by default; it does not start local Postgres, LocalStack or Redis.
+
+```bash
+IMAGE_URL=<account>.dkr.ecr.<region>.amazonaws.com/chimedeck-app:<immutable-tag> \
+AWS_REGION=<region> \
+COMPOSE_FILE=docker-compose.prod.yml \
+RUN_MIGRATIONS=false \
+bash scripts/deploy-on-instance.sh
+```
+
+- The script logs in to the registry host derived from `IMAGE_URL`, pulls and force-recreates only the app container, then requires consecutive local `/health` successes.
+- `RUN_MIGRATIONS=true` runs `bun run db:migrate:safe` before rollout. Run that phase once, not once per host.
+- Trello seeding is rejected by the deployment script. Run `bun run db:seed:trello` only as an explicitly approved one-off operation.
+- If the new image fails health checks, the script restores the prior image and exits non-zero. Verify load-balancer target health before moving to the next host.
+
 > The app connects to **AWS RDS** via `DATABASE_URL` and to **AWS S3** via `S3_BUCKET` / `AWS_*` credentials — no database or S3 container runs on the host.
 
 ### Environment

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test:unit": "bun test tests/integration",
     "test:e2e": "playwright test --project=e2e",
     "test:mcp": "bash run-all-tests-full.sh",
+    "test:deploy": "bash scripts/test-deploy-on-instance.sh",
     "test:load": "k6 run tests/load/board-load.js && k6 run tests/load/drag-latency.js && k6 run tests/load/ws-broadcast.js",
     "clean": "rm -rf dist .vite node_modules/.cache"
   },

--- a/scripts/deploy-on-instance.sh
+++ b/scripts/deploy-on-instance.sh
@@ -1,92 +1,83 @@
 #!/usr/bin/env bash
-# Deploy script for chimedeck — runs on the host machine alongside docker-compose.chimedeck.prod.yml
-# Required env vars:
-#   IMAGE_URL        — full image URI, e.g. 123456789.dkr.ecr.ap-southeast-1.amazonaws.com/chimedeck-app:abc1234
-#   AWS_REGION       — AWS region for ECR login (default: ap-southeast-1)
-# Optional env vars:
-#   COMPOSE_PROFILES — comma-separated list of profiles to activate (default: local-db,local-s3,redis)
-#                      local-db  → start internal Postgres instead of AWS RDS
-#                      local-s3  → start LocalStack instead of AWS S3
-#                      redis     → start Redis sidecar
-#                      e.g. COMPOSE_PROFILES="" to use all external AWS services
+# Managed-service EC2 rollout. Run one host at a time behind a load balancer.
+set -euo pipefail
 
-COMPOSE_FILE=docker-compose.chimedeck.prod.yml
-AWS_REGION=${AWS_REGION:-ap-southeast-1}
-export COMPOSE_PROFILES=${COMPOSE_PROFILES:-local-db}
+COMPOSE_FILE=${COMPOSE_FILE:-docker-compose.prod.yml}
+AWS_REGION=${AWS_REGION:-us-east-1}
+MAIN_CONTAINER_NAME=${MAIN_CONTAINER_NAME:-chimedeck-prod}
+MAIN_APP_PORT=${MAIN_APP_PORT:-3000}
+HEALTH_ATTEMPTS=${HEALTH_ATTEMPTS:-60}
+HEALTH_CONSECUTIVE_SUCCESSES=${HEALTH_CONSECUTIVE_SUCCESSES:-5}
+RUN_MIGRATIONS=${RUN_MIGRATIONS:-false}
 
-# Main deployment config
-MAIN_CONTAINER_NAME=chimedeck-prod
-MAIN_APP_PORT=6402
-
-# Fallback deployment config
-FALLBACK_CONTAINER_NAME=chimedeck-prod-fallback
-FALLBACK_APP_PORT=6412
-
-echo "Begin deploy process"
-set -e
-SECONDS=0
-
-if [[ -z "${IMAGE_URL}" ]]; then
-  echo "ERROR: IMAGE_URL is not set" >&2
+if [[ -z "${IMAGE_URL:-}" || "$IMAGE_URL" != */* ]]; then
+  echo "ERROR: IMAGE_URL must be a fully qualified image URI" >&2
+  exit 1
+fi
+if [[ "$RUN_MIGRATIONS" != "true" && "$RUN_MIGRATIONS" != "false" ]]; then
+  echo "ERROR: RUN_MIGRATIONS must be true or false" >&2
+  exit 1
+fi
+if [[ "${SEED_TRELLO:-false}" != "false" ]]; then
+  echo "ERROR: deployment never runs Trello seeding; run the one-off seed separately" >&2
   exit 1
 fi
 
-echo "Authenticating with ECR"
-# Extract registry host (everything before the first /)
-ECR_REGISTRY=$(echo "${IMAGE_URL}" | cut -d'/' -f1)
-aws ecr get-login-password --region "${AWS_REGION}" \
-  | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+ECR_REGISTRY=${IMAGE_URL%%/*}
+PREVIOUS_IMAGE=$(docker inspect --format '{{.Config.Image}}' "$MAIN_CONTAINER_NAME" 2>/dev/null || true)
 
-echo "Pulling new image: ${IMAGE_URL}"
-CONTAINER_NAME=${MAIN_CONTAINER_NAME} APP_PORT=${MAIN_APP_PORT} IMAGE_URL="${IMAGE_URL}" \
-  docker compose -f "${COMPOSE_FILE}" pull app
+compose() {
+  CONTAINER_NAME="$MAIN_CONTAINER_NAME" APP_PORT="$MAIN_APP_PORT" \
+    SEED_TRELLO=false IMAGE_URL="$1" \
+    docker compose -f "$COMPOSE_FILE" "${@:2}"
+}
 
-echo "Ensuring infra services (postgres, localstack or redis) are running"
-# Only starts services whose profile is active in COMPOSE_PROFILES.
-# If COMPOSE_PROFILES is unset (using AWS RDS/S3), no infra containers are started.
-if [[ -n "${COMPOSE_PROFILES}" ]]; then
-  CONTAINER_NAME=${MAIN_CONTAINER_NAME} APP_PORT=${MAIN_APP_PORT} IMAGE_URL="${IMAGE_URL}" \
-  POSTGRES_USER=chimedeck POSTGRES_PASSWORD=chimedeck POSTGRES_DB=chimedeck_dev \
-    docker compose -f "${COMPOSE_FILE}" up -d --no-recreate --no-deps
-else
-  echo "No local infra profiles active — using external AWS services"
+wait_for_health() {
+  local attempt=0 consecutive=0 status
+  while (( attempt < HEALTH_ATTEMPTS )); do
+    attempt=$((attempt + 1))
+    status=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${MAIN_APP_PORT}/health" 2>/dev/null || true)
+    if [[ "$status" == "200" ]]; then
+      consecutive=$((consecutive + 1))
+      if (( consecutive >= HEALTH_CONSECUTIVE_SUCCESSES )); then
+        echo "Health check passed after ${attempt} attempt(s)"
+        return 0
+      fi
+    else
+      consecutive=0
+    fi
+    sleep 2
+  done
+  echo "ERROR: health check did not stabilise" >&2
+  return 1
+}
+
+rollback() {
+  if [[ -z "$PREVIOUS_IMAGE" || "$PREVIOUS_IMAGE" == "$IMAGE_URL" ]]; then
+    echo "No distinct previous image is available for rollback" >&2
+    return 0
+  fi
+  echo "Rolling back to ${PREVIOUS_IMAGE}" >&2
+  compose "$PREVIOUS_IMAGE" up -d --no-deps --force-recreate app
+  wait_for_health || echo "ERROR: rollback image did not become healthy" >&2
+}
+
+printf 'Deploying image: %s\n' "$IMAGE_URL"
+printf 'Authenticating with ECR registry: %s\n' "$ECR_REGISTRY"
+aws ecr get-login-password --region "$AWS_REGION" \
+  | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+
+if [[ "$RUN_MIGRATIONS" == "true" ]]; then
+  echo "Running explicit migration phase"
+  compose "$IMAGE_URL" run --rm app bun run db:migrate:safe
 fi
 
-echo "Raising fallback container"
-docker container rm ${FALLBACK_CONTAINER_NAME} -f || echo "No fallback container found"
-CONTAINER_NAME=${FALLBACK_CONTAINER_NAME} APP_PORT=${FALLBACK_APP_PORT} SEED_TRELLO=false IMAGE_URL="${IMAGE_URL}" \
-  docker compose -f "${COMPOSE_FILE}" up -d --no-deps app
+compose "$IMAGE_URL" pull app
+compose "$IMAGE_URL" up -d --no-deps --force-recreate app
 
-echo "Waiting for fallback container to set up itself"
-sleep 5
+if ! wait_for_health; then
+  rollback
+  exit 1
+fi
 
-echo "____________________"
-echo "Working on NGINX to use fallback server"
-sudo rm -f /etc/nginx/conf.d/main-chimedeck.conf
-sudo cp ./fallback-chimedeck.conf /etc/nginx/conf.d/
-sudo systemctl restart nginx
-echo "____________________"
-
-echo "Starting main containers with new image"
-CONTAINER_NAME=${MAIN_CONTAINER_NAME} APP_PORT=${MAIN_APP_PORT} SEED_TRELLO=true IMAGE_URL="${IMAGE_URL}" \
-  docker compose -f "${COMPOSE_FILE}" up -d --no-deps --remove-orphans app
-
-echo "Deployed successfully!"
-duration=$SECONDS
-echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds deploy time."
-
-echo "Waiting for main container to set up itself"
-sleep 5
-
-echo "____________________"
-echo "Switch NGINX to use main server"
-sudo rm -f /etc/nginx/conf.d/fallback-chimedeck.conf
-sudo cp ./main-chimedeck.conf /etc/nginx/conf.d/
-sudo systemctl restart nginx
-echo "____________________"
-
-echo "Closing fallback container"
-docker container rm "${FALLBACK_CONTAINER_NAME}" -f || echo "No fallback container to remove"
-
-echo "Pruning dangling images"
-docker image prune -f
+echo "Deployment completed successfully"

--- a/scripts/test-deploy-on-instance.sh
+++ b/scripts/test-deploy-on-instance.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$ROOT/scripts/deploy-on-instance.sh"
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+assert_contains() { grep -Fqx "$2" "$1" || fail "missing log line: $2"; }
+assert_not_contains() { ! grep -Fq "$2" "$1" || fail "unexpected log line: $2"; }
+
+run_case() {
+  local name=$1
+  shift
+  local tmp
+  tmp=$(mktemp -d)
+  mkdir -p "$tmp/bin"
+  : >"$tmp/calls"
+
+  cat >"$tmp/bin/aws" <<'EOF'
+#!/usr/bin/env bash
+printf 'aws %s\n' "$*" >>"$CALLS"
+printf 'token'
+EOF
+  cat >"$tmp/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+printf 'docker %s\n' "$*" >>"$CALLS"
+if [[ "$1" == login ]]; then cat >/dev/null; fi
+if [[ "$1" == inspect ]]; then printf '%s\n' "$PREVIOUS_IMAGE"; fi
+EOF
+  cat >"$tmp/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf 'curl %s\n' "$*" >>"$CALLS"
+printf '%s' "$MOCK_HTTP_STATUS"
+EOF
+  cat >"$tmp/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+:
+EOF
+  cat >"$tmp/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+printf 'sudo %s\n' "$*" >>"$CALLS"
+exit 0
+EOF
+  chmod +x "$tmp/bin"/*
+
+  local status=0
+  env PATH="$tmp/bin:$PATH" CALLS="$tmp/calls" PREVIOUS_IMAGE="registry.example/old:stable" \
+    IMAGE_URL="123456789012.dkr.ecr.us-east-1.amazonaws.com/chimedeck:test" \
+    AWS_REGION=us-east-1 COMPOSE_FILE=compose.yml MAIN_APP_PORT=3000 \
+    HEALTH_ATTEMPTS=1 HEALTH_CONSECUTIVE_SUCCESSES=1 "$@" \
+    bash "$SCRIPT" >"$tmp/output" 2>&1 || status=$?
+  CASE_TMP="$tmp"
+  return "$status"
+}
+
+run_case success MOCK_HTTP_STATUS=200 RUN_MIGRATIONS=true
+assert_contains "$CASE_TMP/calls" 'docker login --username AWS --password-stdin 123456789012.dkr.ecr.us-east-1.amazonaws.com'
+assert_contains "$CASE_TMP/calls" 'docker compose -f compose.yml run --rm app bun run db:migrate:safe'
+assert_contains "$CASE_TMP/calls" 'docker compose -f compose.yml up -d --no-deps --force-recreate app'
+assert_not_contains "$CASE_TMP/calls" 'SEED_TRELLO=true'
+
+if run_case failed-health MOCK_HTTP_STATUS=500 RUN_MIGRATIONS=false; then
+  fail 'health failure unexpectedly succeeded'
+fi
+assert_contains "$CASE_TMP/calls" 'docker compose -f compose.yml up -d --no-deps --force-recreate app'
+assert_contains "$CASE_TMP/calls" 'docker compose -f compose.yml up -d --no-deps --force-recreate app'
+
+echo 'PASS: deploy-on-instance contract'


### PR DESCRIPTION
## Authority and scope

- Source: production host-layout inspection after MCP PR #20 merge.
- Acceptance criteria:
  - [x] Deployment authenticates Docker to the registry host, not the full image URI.
  - [x] Managed-service rollout does not start local infrastructure or automatically seed Trello.
  - [x] Migrations run only when explicitly requested.
  - [x] The replacement container must pass consecutive `/health` checks; failure restores the prior image and returns non-zero.
  - [x] The process is documented for a one-host-at-a-time load-balanced EC2 rollout.
- Explicitly out of scope: JourneyHorizon account IDs, hostnames, ECR URIs, secrets, SSM instance IDs and production host files.

## What changed

Replaces the host-specific fallback/Nginx deployment script with a portable managed-service EC2 rollout:

- ECR registry is derived from `IMAGE_URL`.
- `RUN_MIGRATIONS=true` is an explicit one-off migration phase.
- Trello seeding is rejected during ordinary deployment.
- A failed health check restores the prior image.
- Adds a mocked shell contract test and `bun run test:deploy`.

## Verification

| Gate | Command / proof | Result |
| --- | --- | --- |
| Deployment contract | `bun run test:deploy` | PASS |
| Shell syntax | `bash -n scripts/deploy-on-instance.sh scripts/test-deploy-on-instance.sh` | PASS |
| Client build | `bun run build:client` | PASS |
| Diff | `git diff --check origin/main...HEAD` | PASS |
| Full `bun test` / typecheck | Existing aggregate runner/typecheck issues remain tracked in #21; not represented as green. | BLOCKED — known baseline |

## Documentation surfaces

- [x] README managed-service rollout section added
- [x] `test:deploy` command added
- [x] No public API, MCP or UI capability changed

## Security and side effects

- [x] No AWS identifiers, secrets, host paths or deployment configuration were committed
- [x] Script does not inspect or print environment variables
- [x] Trello import is no longer an implicit deployment side effect
- [x] Production rollout remains a human-approved operation

## Reviewer outcome

REQUEST CHANGES until an independent reviewer accepts the deployment semantics. This PR must merge before the production MCP rollout.
