### PR TITLE
feat(webhooks): enrich mention notification context

### DIFF
--- a/server/extensions/notifications/mods/__tests__/mentionWebhookContext.test.ts
+++ b/server/extensions/notifications/mods/__tests__/mentionWebhookContext.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Pure helpers that build the enriched `mention` webhook payload context.
+// These tests intentionally avoid DB/network mocks — inputs are plain strings.
+// ---------------------------------------------------------------------------
+const { buildSourcePreview, buildActorDisplayName, buildMentionWebhookPayload } =
+  await import('../mentionWebhookContext');
+
+describe('buildSourcePreview — plain-text, bounded source summary', () => {
+  test('strips HTML markup and decodes entities to plain text', () => {
+    expect(buildSourcePreview({ sourceText: '<p>Hi <b>@alice</b>, please review</p>' })).toBe(
+      'Hi @alice, please review'
+    );
+  });
+
+  test('preserves readable spacing across rich-text block elements', () => {
+    expect(
+      buildSourcePreview({
+        sourceText: '<p>First point</p><p>Second point</p><ul><li>Third point</li></ul>',
+      })
+    ).toBe('First point Second point Third point');
+  });
+
+  test('collapses newlines, tabs, and control characters into single spaces', () => {
+    expect(buildSourcePreview({ sourceText: 'line1\nline2\ttabbed\u0000ctrl  spaced' })).toBe(
+      'line1 line2 tabbed ctrl spaced'
+    );
+  });
+
+  test('caps preview at a total of 200 characters including the ellipsis when truncated', () => {
+    const out = buildSourcePreview({ sourceText: 'x'.repeat(500) });
+    expect(out.length).toBe(200);
+    expect(out.startsWith('x'.repeat(199))).toBe(true);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  test('does not append ellipsis when the text fits exactly within the cap', () => {
+    expect(buildSourcePreview({ sourceText: 'y'.repeat(200) })).toBe('y'.repeat(200));
+  });
+
+  test('returns empty string for empty or whitespace-only input', () => {
+    expect(buildSourcePreview({ sourceText: '' })).toBe('');
+    expect(buildSourcePreview({ sourceText: '   \n\t  ' })).toBe('');
+    expect(buildSourcePreview({ sourceText: undefined })).toBe('');
+  });
+});
+
+describe('buildActorDisplayName — nickname preferred, never an email', () => {
+  test('returns the nickname when present', () => {
+    expect(buildActorDisplayName({ nickname: 'alice', name: 'Alice Smith' })).toBe('alice');
+  });
+
+  test('trims surrounding whitespace from the nickname', () => {
+    expect(buildActorDisplayName({ nickname: '  alice  ', name: 'Alice Smith' })).toBe('alice');
+  });
+
+  test('falls back to a non-email display name when nickname is empty', () => {
+    expect(buildActorDisplayName({ nickname: '', name: 'Alice Smith' })).toBe('Alice Smith');
+    expect(buildActorDisplayName({ nickname: null, name: 'Alice Smith' })).toBe('Alice Smith');
+    expect(buildActorDisplayName({ nickname: undefined, name: 'Alice Smith' })).toBe('Alice Smith');
+  });
+
+  test('returns null when the only available name looks like an email address', () => {
+    expect(buildActorDisplayName({ nickname: '', name: 'alice@example.com' })).toBe(null);
+    expect(buildActorDisplayName({ nickname: '', name: 'Alice <alice@example.com>' })).toBe(null);
+    expect(buildActorDisplayName({ nickname: null, name: null })).toBe(null);
+    expect(buildActorDisplayName({ nickname: undefined, name: undefined })).toBe(null);
+  });
+
+  test('skips an email-like nickname and falls back to the non-email name', () => {
+    expect(buildActorDisplayName({ nickname: 'alice@example.com', name: 'Alice Smith' })).toBe(
+      'Alice Smith'
+    );
+  });
+});
+
+describe('buildMentionWebhookPayload — stable enriched contract', () => {
+  test('preserves legacy identifiers and adds safe display context', () => {
+    expect(
+      buildMentionWebhookPayload({
+        boardId: 'board-1',
+        cardId: 'card-1',
+        sourceType: 'comment',
+        sourceId: 'comment-1',
+        actorId: 'actor-1',
+        recipients: ['user-1'],
+        cardTitle: 'Fix login flow',
+        boardName: 'Phoenix Ops',
+        sourceText: '<p>Please review\nthis before Friday.</p>',
+        actor: { nickname: 'maria', name: 'Maria Silva' },
+      })
+    ).toEqual({
+      boardId: 'board-1',
+      cardId: 'card-1',
+      sourceType: 'comment',
+      sourceId: 'comment-1',
+      actorId: 'actor-1',
+      mentionedUserIds: ['user-1'],
+      cardTitle: 'Fix login flow',
+      boardTitle: 'Phoenix Ops',
+      sourcePreview: 'Please review this before Friday.',
+      actorName: 'maria',
+    });
+  });
+});

--- a/server/extensions/notifications/mods/createNotifications.ts
+++ b/server/extensions/notifications/mods/createNotifications.ts
@@ -14,31 +14,18 @@ import { dispatchNotificationEmail } from './emailDispatch';
 import { env } from '../../../config/env';
 import { getActiveWebhooksForEvent } from '../../webhooks/mods/registry';
 import { dispatchWebhook } from '../../webhooks/mods/dispatch';
+import { buildMentionWebhookPayload, type MentionWebhookPayload } from './mentionWebhookContext';
 import type { Knex } from 'knex';
 
 // [why] extracted to keep createNotificationsForMentions within the cognitive complexity limit.
-async function fireMentionWebhooks({
-  boardId,
-  cardId,
-  sourceType,
-  sourceId,
-  actorId,
-  recipients,
-}: {
-  boardId: string;
-  cardId: string | null;
-  sourceType: string;
-  sourceId: string;
-  actorId: string;
-  recipients: string[];
-}): Promise<void> {
+async function fireMentionWebhooks({ payload }: { payload: MentionWebhookPayload }): Promise<void> {
   const webhooks = await getActiveWebhooksForEvent({ knex: db, eventType: 'mention' });
   for (const wh of webhooks) {
     dispatchWebhook({
       endpoint: wh.endpoint_url,
       signingSecret: wh.signing_secret,
       eventType: 'mention',
-      payload: { boardId, cardId, sourceType, sourceId, actorId, mentionedUserIds: recipients },
+      payload,
       webhookId: wh.id,
       knex: db,
     });
@@ -205,7 +192,23 @@ export async function createNotificationsForMentions({
   // Fire-and-forget mention webhook — dispatched once per mention event (not per recipient).
   // [why] webhook subscribers receive the full mention context rather than a per-user notification.
   if (env.WEBHOOKS_ENABLED) {
-    fireMentionWebhooks({ boardId, cardId, sourceType, sourceId, actorId, recipients }).catch(() => {
+    // [why] enrich the mention webhook with stable, backward-compatible context
+    //       built from data already fetched above — no extra DB round-trips.
+    const payload = buildMentionWebhookPayload({
+      boardId,
+      cardId,
+      sourceType,
+      sourceId,
+      actorId,
+      recipients,
+      cardTitle,
+      boardName,
+      sourceText,
+      actor: actorPayload as Record<string, unknown>,
+    });
+    fireMentionWebhooks({
+      payload,
+    }).catch(() => {
       // Webhook errors must never propagate to the caller.
     });
   }

--- a/server/extensions/notifications/mods/mentionWebhookContext.ts
+++ b/server/extensions/notifications/mods/mentionWebhookContext.ts
@@ -1,0 +1,128 @@
+// server/extensions/notifications/mods/mentionWebhookContext.ts
+// Pure helpers that enrich the outgoing `mention` webhook payload with
+// stable, backward-compatible context (titles, actor display name, and a
+// safely bounded plain-text source preview).
+// [why] pure and side-effect-free so payload shaping is unit-testable
+//       without DB/network mocks, and identical across all dispatch sites.
+// [why] no email addresses ever leave the server in webhook payloads —
+//       actor names are checked and dropped when they look like emails.
+
+import { sanitizeText } from '../../../common/sanitize';
+
+const PREVIEW_MAX_LENGTH = 200;
+const EMAIL_LIKE = /[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+/;
+const RICH_TEXT_BREAK_TAGS =
+  /<\/?(?:address|article|aside|blockquote|br|div|figcaption|figure|footer|h[1-6]|header|hr|li|main|nav|ol|p|pre|section|table|tbody|td|tfoot|th|thead|tr|ul)\b[^>]*>/gi;
+
+/**
+ * Convert rich source text (card description / comment content) into a
+ * plain-text preview safe for external webhook consumers:
+ * - strips all HTML markup (sanitizes to text, decodes entities)
+ * - replaces newlines, tabs, and control characters with single spaces
+ * - collapses runs of whitespace into one space and trims
+ * - caps the result at PREVIEW_MAX_LENGTH characters, appending an
+ *   ellipsis character only when truncation actually happened
+ */
+export function buildSourcePreview({
+  sourceText,
+}: {
+  sourceText?: string | null | undefined;
+}): string {
+  if (!sourceText) return '';
+
+  // [why] sanitizeText strips ALL tags and decodes HTML entities to plain text.
+  // [why] if sanitization throws, return an empty preview rather than leaking
+  //       unsanitized source text to external consumers.
+  let text: string;
+  try {
+    text = sanitizeText(sourceText.replace(RICH_TEXT_BREAK_TAGS, ' '));
+  } catch {
+    return '';
+  }
+
+  // [why] replace control chars (incl. \r\n\t) with spaces, then collapse runs.
+  const collapsed = text
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (collapsed.length === 0) return '';
+  if (collapsed.length <= PREVIEW_MAX_LENGTH) return collapsed;
+  // [why] PREVIEW_MAX_LENGTH is a TOTAL cap: 199 chars + 1-char ellipsis keeps
+  //       the ellipsis inside the cap for receivers that hard-truncate at 200.
+  return `${collapsed.slice(0, PREVIEW_MAX_LENGTH - 1)}…`;
+}
+
+/**
+ * Pick the safest actor display name for an external payload.
+ * Preference order: a non-email nickname, then a non-email display name.
+ * Returns null when neither is available without leaking an email address.
+ */
+export function buildActorDisplayName({
+  nickname,
+  name,
+}: {
+  nickname?: string | null | undefined;
+  name?: string | null | undefined;
+}): string | null {
+  const nick = (nickname ?? '').trim();
+  if (nick.length > 0 && !EMAIL_LIKE.test(nick)) return nick;
+
+  const display = (name ?? '').trim();
+  if (display.length > 0 && !EMAIL_LIKE.test(display)) return display;
+
+  return null;
+}
+
+export interface MentionWebhookPayload extends Record<string, unknown> {
+  boardId: string;
+  cardId: string | null;
+  sourceType: 'card_description' | 'comment';
+  sourceId: string;
+  actorId: string;
+  mentionedUserIds: string[];
+  cardTitle: string;
+  boardTitle: string;
+  sourcePreview: string;
+  actorName: string | null;
+}
+
+export function buildMentionWebhookPayload({
+  boardId,
+  cardId,
+  sourceType,
+  sourceId,
+  actorId,
+  recipients,
+  cardTitle,
+  boardName,
+  sourceText,
+  actor,
+}: {
+  boardId: string;
+  cardId: string | null;
+  sourceType: 'card_description' | 'comment';
+  sourceId: string;
+  actorId: string;
+  recipients: string[];
+  cardTitle?: string | undefined;
+  boardName?: string | undefined;
+  sourceText?: string | undefined;
+  actor: Record<string, unknown>;
+}): MentionWebhookPayload {
+  const actorNickname = typeof actor['nickname'] === 'string' ? actor['nickname'] : null;
+  const actorName = typeof actor['name'] === 'string' ? actor['name'] : null;
+  return {
+    boardId,
+    cardId,
+    sourceType,
+    sourceId,
+    actorId,
+    mentionedUserIds: [...recipients],
+    cardTitle: cardTitle ?? '',
+    boardTitle: boardName ?? '',
+    sourcePreview: buildSourcePreview({ sourceText }),
+    actorName: buildActorDisplayName({ nickname: actorNickname, name: actorName }),
+  };
+}


### PR DESCRIPTION
## Summary

- enrich outgoing `mention` webhook payloads with card, board, actor, and source context
- include a sanitized one-line source preview capped at 200 characters
- retain every existing identifier field for backward compatibility
- omit actor display names when the only available value contains an email address

## Problem

Webhook consumers received only IDs for comment/description mentions. They could route the event but could not produce a useful notification such as who mentioned the user, on which card, or what the comment was about.

## Payload additions

`mention.data` now also includes:

- `cardTitle`
- `boardTitle`
- `actorName` (nickname preferred; email-like values omitted)
- `sourcePreview` (plain text, whitespace-collapsed, maximum 200 characters)

## Verification

- strict RED/GREEN coverage for the pure payload builder and sanitizers
- `12 passed` — mention-context tests
- `17 passed` — existing webhook signing and dispatch tests
- Prettier passes for both new files
- full typecheck retains the repository's existing 175 baseline errors; zero errors reference changed files
- independent reviewer verdict: **ship**

## Related bridge change

The KingKong receiver formats these optional fields into detailed Discord DMs while remaining compatible with sparse legacy payloads:
https://gitlab.duplanet.ovh/duplanet/phoenix-discord-reporter/-/merge_requests/1

Refs #19
