### PR TITLE
ci: verify pull requests targeting stable

### DIFF
--- a/.github/workflows/stable-pr-verification.yml
+++ b/.github/workflows/stable-pr-verification.yml
@@ -1,0 +1,36 @@
+name: Stable PR verification
+
+on:
+  pull_request:
+    branches:
+      - stable
+
+permissions:
+  contents: read
+
+concurrency:
+  group: stable-pr-verification-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.14'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build client
+        run: bun run build:client
+
+      - name: Check pull-request diff
+        run: git diff --check "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"


### PR DESCRIPTION
## Authority and scope

- Source: protect the production-triggering `stable` branch without creating a second deployment path.
- Acceptance criteria:
  - [x] A verification-only GitHub workflow runs only for pull requests targeting `stable`.
  - [x] It performs a frozen Bun install, client production build, and pull-request diff whitespace check.
  - [x] It has no deployment, AWS access, cache, artefact upload, service container, or push trigger.
  - [x] Superseded PR runs are cancelled and each run times out after 10 minutes.
- Explicitly out of scope: fixing the repository-wide Vitest/Prettier baselines; changing TurtleCI deployment.

## What changed

Adds `.github/workflows/stable-pr-verification.yml`. After this PR's `verify` job succeeds, that status will be required by `stable` branch protection alongside a human review. TurtleCI remains the post-merge deployment system.

## Verification

| Gate | Command / proof | Result |
| --- | --- | --- |
| Workflow YAML | Ruby YAML parse | PASS |
| Workflow formatting | `bunx prettier --check .github/workflows/stable-pr-verification.yml` | PASS |
| Client build | `bun run build:client` | PASS |
| Diff check | `git diff --check` | PASS |
| Full Vitest | `bun test` | BLOCKED — baseline: 1,137 pass / 384 fail / 141 errors; also mutates `specs/sprints/sprint-plan.md` |
| Full Prettier | `bun run format:check` | BLOCKED — baseline: 1,327 files reported |

## Security and side effects

- [x] Workflow permissions are read-only (`contents: read`).
- [x] No secret access, deployment command, AWS credential, artefact, or cache is configured.
- [x] TurtleCI remains the only stable deployment path.

## Reviewer outcome

<!-- APPROVE / REQUEST CHANGES / BLOCKED. Do not approve conditionally. -->
