### PR TITLE
ci: verify pull requests targeting main

### DIFF
--- a/.github/workflows/main-pr-verification.yml
+++ b/.github/workflows/main-pr-verification.yml
@@ -1,0 +1,36 @@
+name: Main PR verification
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: main-pr-verification-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.14'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build client
+        run: bun run build:client
+
+      - name: Check pull-request diff
+        run: git diff --check "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"


### PR DESCRIPTION
## Authority and scope

- Source: apply the established protected-merge flow to public default branch `main`.
- Acceptance criteria:
  - [x] A verification-only GitHub workflow runs only for pull requests targeting `main`.
  - [x] It performs a frozen Bun install, client production build, and pull-request diff whitespace check.
  - [x] It has no deployment, AWS access, cache, artefact upload, service container, or push trigger.
  - [x] Superseded PR runs are cancelled and each run times out after 10 minutes.
- Explicitly out of scope: fixing repository-wide Vitest/Prettier baselines; changing `stable` or TurtleCI deployment.

## What changed

Adds `.github/workflows/main-pr-verification.yml`. Once merged, `main` branch protection will require its `verify` check and an independent approval. This does not trigger TurtleCI or any deployment.

## Verification

| Gate | Command / proof | Result |
| --- | --- | --- |
| Workflow YAML | Ruby YAML parse | PASS |
| Workflow formatting | `bunx prettier --check .github/workflows/main-pr-verification.yml` | PASS |
| Frozen install | `bun install --frozen-lockfile` | PASS |
| Client build | `bun run build:client` | PASS |
| Diff check | `git diff --check` | PASS |
| Full Vitest | `bun test` | BLOCKED — known baseline failures |
| Full Prettier | `bun run format:check` | BLOCKED — known baseline formatting failures |

## Security and side effects

- [x] Workflow permissions are read-only (`contents: read`).
- [x] No secret access, deployment command, AWS credential, artefact, or cache is configured.
- [x] No TurtleCI config is modified or invoked.

## Reviewer outcome

<!-- APPROVE / REQUEST CHANGES / BLOCKED. Do not approve conditionally. -->
