### PR TITLE
fix(mcp): migrate create-board tool registration

### DIFF
--- a/server/extensions/mcp/tools/createBoard.test.ts
+++ b/server/extensions/mcp/tools/createBoard.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
 const apiCallMock = mock();
 
-mock.module('../apiClient', () => ({
+void mock.module('../apiClient', () => ({
   apiCall: apiCallMock,
 }));
 
@@ -21,7 +21,11 @@ let toolName = '';
 let handler: ToolHandler | undefined;
 
 const server = {
-  tool: (name: string, _description: string, _schema: unknown, registeredHandler: ToolHandler) => {
+  registerTool: (
+    name: string,
+    _config: { description: string; inputSchema: unknown },
+    registeredHandler: ToolHandler
+  ) => {
     toolName = name;
     handler = registeredHandler;
   },
@@ -44,7 +48,10 @@ describe('registerCreateBoard', () => {
     expect(toolName).toBe('create_board');
     expect(handler).toBeDefined();
 
-    const result = await handler!({
+    const registeredHandler = handler;
+    if (!registeredHandler) throw new Error('create_board handler was not registered');
+
+    const result = await registeredHandler({
       workspaceId: 'workspace-1',
       title: 'Demo board',
       visibility: 'WORKSPACE',
@@ -74,7 +81,10 @@ describe('registerCreateBoard', () => {
     apiCallMock.mockResolvedValue({ error: { name: 'forbidden' } });
     registerCreateBoard(server as never, 'token-1');
 
-    const result = await handler!({ workspaceId: 'workspace-1', title: 'Demo board' });
+    const registeredHandler = handler;
+    if (!registeredHandler) throw new Error('create_board handler was not registered');
+
+    const result = await registeredHandler({ workspaceId: 'workspace-1', title: 'Demo board' });
 
     expect(result).toEqual({
       content: [{ type: 'text', text: 'Error: forbidden' }],

--- a/server/extensions/mcp/tools/createBoard.ts
+++ b/server/extensions/mcp/tools/createBoard.ts
@@ -3,18 +3,20 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiCall } from '../apiClient';
 
 export function registerCreateBoard(server: McpServer, token: string): void {
-  server.tool(
+  server.registerTool(
     'create_board',
-    'Create a new board in a specified workspace.',
     {
-      workspaceId: z.string().describe('ID of the workspace to create the board in'),
-      title: z.string().min(1).describe('Title of the new board'),
-      visibility: z
-        .enum(['PRIVATE', 'WORKSPACE', 'PUBLIC'])
-        .optional()
-        .describe('Optional board visibility; defaults to PRIVATE'),
-      description: z.string().optional().describe('Optional board description'),
-      background: z.string().optional().describe('Optional board background value'),
+      description: 'Create a new board in a specified workspace.',
+      inputSchema: {
+        workspaceId: z.string().describe('ID of the workspace to create the board in'),
+        title: z.string().min(1).describe('Title of the new board'),
+        visibility: z
+          .enum(['PRIVATE', 'WORKSPACE', 'PUBLIC'])
+          .optional()
+          .describe('Optional board visibility; defaults to PRIVATE'),
+        description: z.string().optional().describe('Optional board description'),
+        background: z.string().optional().describe('Optional board background value'),
+      },
     },
     async ({ workspaceId, title, visibility, description, background }) => {
       const result = await apiCall<{ data: unknown }>({


### PR DESCRIPTION
## Scope
Migrates the `create_board` MCP tool from the deprecated `server.tool` API to `server.registerTool`.

The registered name, description, input schema, handler and API payload are unchanged. The tool test now asserts the new registration seam and fails explicitly if registration is absent.

## TDD evidence
- RED: test mock exposed only `registerTool`; existing `server.tool` implementation failed with `TypeError`
- GREEN: migrated implementation passes the same behaviour assertions

## Validation
- `bun test server/extensions/mcp/tools/createBoard.test.ts` — 2 passed
- focused ESLint — passed
- `git diff --check` — passed

Stacked on #35, the lint bootstrap PR.