### PR TITLE
fix(mcp): migrate create-list tool registration

### DIFF
--- a/server/extensions/mcp/tools/createList.test.ts
+++ b/server/extensions/mcp/tools/createList.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
 const apiCallMock = mock();
 
-mock.module('../apiClient', () => ({
+void mock.module('../apiClient', () => ({
   apiCall: apiCallMock,
 }));
 
@@ -16,9 +16,13 @@ let toolDescription = '';
 let handler: ToolHandler | undefined;
 
 const server = {
-  tool: (name: string, description: string, _schema: unknown, registeredHandler: ToolHandler) => {
+  registerTool: (
+    name: string,
+    config: { description: string; inputSchema: unknown },
+    registeredHandler: ToolHandler
+  ) => {
     toolName = name;
-    toolDescription = description;
+    toolDescription = config.description;
     handler = registeredHandler;
   },
 };
@@ -42,7 +46,10 @@ describe('registerCreateList', () => {
     expect(toolDescription).toContain('list');
     expect(handler).toBeDefined();
 
-    const result = await handler!({ boardId: 'board-1', title: 'Backlog' });
+    const registeredHandler = handler;
+    if (!registeredHandler) throw new Error('create_list handler was not registered');
+
+    const result = await registeredHandler({ boardId: 'board-1', title: 'Backlog' });
 
     expect(apiCallMock).toHaveBeenCalledWith({
       method: 'POST',
@@ -61,7 +68,10 @@ describe('registerCreateList', () => {
     apiCallMock.mockResolvedValue({ error: { name: 'forbidden' } });
     registerCreateList(server as never, 'token-1');
 
-    const result = await handler!({ boardId: 'board-1', title: 'Backlog' });
+    const registeredHandler = handler;
+    if (!registeredHandler) throw new Error('create_list handler was not registered');
+
+    const result = await registeredHandler({ boardId: 'board-1', title: 'Backlog' });
 
     expect(result).toEqual({
       content: [{ type: 'text', text: 'Error: forbidden' }],

--- a/server/extensions/mcp/tools/createList.ts
+++ b/server/extensions/mcp/tools/createList.ts
@@ -3,17 +3,19 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiCall } from '../apiClient';
 
 export function registerCreateList(server: McpServer, token: string): void {
-  server.tool(
+  server.registerTool(
     'create_list',
-    'Create a new list in a specified board.',
     {
-      boardId: z.string().describe('ID of the board to create the list in'),
-      title: z.string().min(1).describe('Title of the new list'),
-      afterId: z
-        .string()
-        .nullable()
-        .optional()
-        .describe('Optional list ID after which to insert the new list'),
+      description: 'Create a new list in a specified board.',
+      inputSchema: {
+        boardId: z.string().describe('ID of the board to create the list in'),
+        title: z.string().min(1).describe('Title of the new list'),
+        afterId: z
+          .string()
+          .nullable()
+          .optional()
+          .describe('Optional list ID after which to insert the new list'),
+      },
     },
     async ({ boardId, title, afterId }) => {
       const result = await apiCall<{ data: unknown }>({


### PR DESCRIPTION
## Scope
Migrates the `create_list` MCP tool from the deprecated `server.tool` API to `server.registerTool`.

The tool name, description, input schema, handler and API payload are preserved. The test now captures the supported registration config and fails explicitly when a handler is not registered.

## TDD evidence
- RED: test mock exposed only `registerTool`; the old `server.tool` implementation failed with `TypeError`
- GREEN: migrated implementation passes the same endpoint, payload and structured-error assertions

## Validation
- `bun test server/extensions/mcp/tools/createList.test.ts` — 2 passed
- focused ESLint — passed
- `git diff --check` — passed