### PR TITLE
fix(mcp): migrate create-card tool registration

### DIFF
--- a/server/extensions/mcp/tools/createCard.test.ts
+++ b/server/extensions/mcp/tools/createCard.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const apiCallMock = mock();
+
+void mock.module('../apiClient', () => ({
+  apiCall: apiCallMock,
+}));
+
+type ToolHandler = (args: { listId: string; title: string; description?: string }) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+let toolName = '';
+let toolDescription = '';
+let handler: ToolHandler | undefined;
+
+const server = {
+  registerTool: (
+    name: string,
+    config: { description: string; inputSchema: unknown },
+    registeredHandler: ToolHandler
+  ) => {
+    toolName = name;
+    toolDescription = config.description;
+    handler = registeredHandler;
+  },
+};
+
+const { registerCreateCard } = await import('./createCard');
+
+describe('registerCreateCard', () => {
+  beforeEach(() => {
+    toolName = '';
+    toolDescription = '';
+    handler = undefined;
+    apiCallMock.mockReset();
+  });
+
+  test('registers create_card and posts the card fields to its list endpoint', async () => {
+    apiCallMock.mockResolvedValue({ data: { data: { id: 'card-1', title: 'Demo card' } } });
+
+    registerCreateCard(server as never, 'token-1');
+
+    expect(toolName).toBe('create_card');
+    expect(toolDescription).toContain('card');
+
+    const registeredHandler = handler;
+    if (!registeredHandler) throw new Error('create_card handler was not registered');
+
+    const result = await registeredHandler({
+      listId: 'list-1',
+      title: 'Demo card',
+      description: 'Created through MCP',
+    });
+
+    expect(apiCallMock).toHaveBeenCalledWith({
+      method: 'POST',
+      path: '/api/v1/lists/list-1/cards',
+      body: { title: 'Demo card', description: 'Created through MCP' },
+      token: 'token-1',
+    });
+    expect(result).toEqual({
+      content: [{ type: 'text', text: JSON.stringify({ data: { id: 'card-1', title: 'Demo card' } }) }],
+    });
+  });
+
+  test('returns a structured MCP error when card creation is rejected', async () => {
+    apiCallMock.mockResolvedValue({ error: { name: 'forbidden' } });
+    registerCreateCard(server as never, 'token-1');
+
+    const registeredHandler = handler;
+    if (!registeredHandler) throw new Error('create_card handler was not registered');
+
+    const result = await registeredHandler({ listId: 'list-1', title: 'Demo card' });
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Error: forbidden' }],
+      isError: true,
+    });
+  });
+});

--- a/server/extensions/mcp/tools/createCard.ts
+++ b/server/extensions/mcp/tools/createCard.ts
@@ -3,13 +3,15 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiCall } from '../apiClient';
 
 export function registerCreateCard(server: McpServer, token: string): void {
-  server.tool(
+  server.registerTool(
     'create_card',
-    'Create a new card in a specified list.',
     {
-      listId: z.string().describe('ID of the list to create the card in'),
-      title: z.string().describe('Title of the new card'),
-      description: z.string().optional().describe('Optional description for the new card'),
+      description: 'Create a new card in a specified list.',
+      inputSchema: {
+        listId: z.string().describe('ID of the list to create the card in'),
+        title: z.string().describe('Title of the new card'),
+        description: z.string().optional().describe('Optional description for the new card'),
+      },
     },
     async ({ listId, title, description }) => {
       const result = await apiCall<{ data: unknown }>({


### PR DESCRIPTION
## Scope
Migrates the `create_card` MCP tool from deprecated `server.tool` to `server.registerTool`.

Adds focused registration, endpoint/payload, success-response and structured-error coverage. The tool name, description, Zod input schema and API handler contract remain unchanged.

## TDD evidence
- RED: new `registerTool`-only fixture failed on the old `server.tool` call
- GREEN: migrated implementation passes both success and rejection cases

## Validation
- `bun test server/extensions/mcp/tools/createCard.test.ts` — 2 passed
- focused ESLint — passed
- `git diff --check` — passed