### PR TITLE
fix(mcp): migrate move-card tool registration

### DIFF
--- a/server/extensions/mcp/tools/moveCard.test.ts
+++ b/server/extensions/mcp/tools/moveCard.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const apiCallMock = mock();
+
+void mock.module('../apiClient', () => ({
+  apiCall: apiCallMock,
+}));
+
+type MoveCardArgs = {
+  cardId: string;
+  targetListId: string;
+  afterCardId?: string | null;
+  position?: number;
+};
+
+type ToolHandler = (args: MoveCardArgs) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+let toolName = '';
+let toolDescription = '';
+let handler: ToolHandler | undefined;
+
+const server = {
+  registerTool: (
+    name: string,
+    config: { description: string; inputSchema: unknown },
+    registeredHandler: ToolHandler,
+  ) => {
+    toolName = name;
+    toolDescription = config.description;
+    handler = registeredHandler;
+  },
+};
+
+const { registerMoveCard } = await import('./moveCard');
+
+function registeredHandler(): ToolHandler {
+  if (!handler) throw new Error('move_card handler was not registered');
+  return handler;
+}
+
+describe('registerMoveCard', () => {
+  beforeEach(() => {
+    toolName = '';
+    toolDescription = '';
+    handler = undefined;
+    apiCallMock.mockReset();
+  });
+
+  test('registers move_card and sends the destination and insertion card', async () => {
+    apiCallMock.mockResolvedValue({ data: { data: { id: 'card-1' } } });
+    registerMoveCard(server as never, 'token-1');
+
+    expect(toolName).toBe('move_card');
+    expect(toolDescription).toContain('Move a card');
+
+    const result = await registeredHandler()({
+      cardId: 'card-1',
+      targetListId: 'list-2',
+      afterCardId: 'card-0',
+    });
+
+    expect(apiCallMock).toHaveBeenCalledWith({
+      method: 'PATCH',
+      path: '/api/v1/cards/card-1/move',
+      body: { targetListId: 'list-2', afterCardId: 'card-0' },
+      token: 'token-1',
+    });
+    expect(result).toEqual({ content: [{ type: 'text', text: JSON.stringify({ data: { id: 'card-1' } }) }] });
+  });
+
+  test('maps the supported legacy top position to a null insertion card', async () => {
+    apiCallMock.mockResolvedValue({ data: { data: { id: 'card-1' } } });
+    registerMoveCard(server as never, 'token-1');
+
+    await registeredHandler()({ cardId: 'card-1', targetListId: 'list-2', position: 0 });
+
+    expect(apiCallMock).toHaveBeenCalledWith({
+      method: 'PATCH',
+      path: '/api/v1/cards/card-1/move',
+      body: { targetListId: 'list-2', afterCardId: null },
+      token: 'token-1',
+    });
+  });
+
+  test('rejects unsupported legacy positions without calling the API', async () => {
+    registerMoveCard(server as never, 'token-1');
+
+    const result = await registeredHandler()({ cardId: 'card-1', targetListId: 'list-2', position: 2 });
+
+    expect(apiCallMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Error: bad-request (position is deprecated; use afterCardId)' }],
+      isError: true,
+    });
+  });
+});

--- a/server/extensions/mcp/tools/moveCard.ts
+++ b/server/extensions/mcp/tools/moveCard.ts
@@ -3,14 +3,16 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiCall } from '../apiClient';
 
 export function registerMoveCard(server: McpServer, token: string): void {
-  server.tool(
+  server.registerTool(
     'move_card',
-    'Move a card to a different list, optionally after a specific card.',
     {
-      cardId: z.string().describe('ID of the card to move'),
-      targetListId: z.string().describe('ID of the destination list'),
-      afterCardId: z.string().nullable().optional().describe('Insert after this card ID (null places at top)'),
-      position: z.number().optional().describe('Deprecated alias. Only 0 is supported and maps to top'),
+      description: 'Move a card to a different list, optionally after a specific card.',
+      inputSchema: {
+        cardId: z.string().describe('ID of the card to move'),
+        targetListId: z.string().describe('ID of the destination list'),
+        afterCardId: z.string().nullable().optional().describe('Insert after this card ID (null places at top)'),
+        position: z.number().optional().describe('Deprecated alias. Only 0 is supported and maps to top'),
+      },
     },
     async ({ cardId, targetListId, afterCardId, position }) => {
       if (afterCardId === undefined && position !== undefined && position !== 0) {


### PR DESCRIPTION
## Scope
Migrates the `move_card` MCP tool from deprecated `server.tool` to `server.registerTool`.

Adds focused coverage for registration, the move request, supported legacy `position: 0` handling, and unsupported legacy position rejection. The tool schema and existing compatibility behaviour are preserved.

## TDD evidence
- RED: new `registerTool`-only fixture failed on the old `server.tool` call
- GREEN: migrated implementation passes request and legacy-compatibility coverage

## Validation
- `bun test server/extensions/mcp/tools/moveCard.test.ts` — 3 passed
- focused ESLint — passed
- `git diff --check` — passed