### PR TITLE
fix(mcp): migrate copy-state-transitions tool registration

### DIFF
--- a/server/extensions/mcp/tools/copyStateTransitions.test.ts
+++ b/server/extensions/mcp/tools/copyStateTransitions.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+let toolName = '';
+let toolDescription = '';
+let handlerRegistered = false;
+
+const server = {
+  registerTool: (
+    name: string,
+    config: { description: string; inputSchema: unknown },
+    _handler: unknown,
+  ) => {
+    toolName = name;
+    toolDescription = config.description;
+    handlerRegistered = true;
+  },
+};
+
+const { registerCopyStateTransitions } = await import('./copyStateTransitions');
+
+describe('registerCopyStateTransitions', () => {
+  beforeEach(() => {
+    toolName = '';
+    toolDescription = '';
+    handlerRegistered = false;
+  });
+
+  test('registers the stable copy_state_transitions tool contract', () => {
+    registerCopyStateTransitions(server as never, 'token-1');
+
+    expect(toolName).toBe('copy_state_transitions');
+    expect(toolDescription).toBe("Copy state transition graph from one board to another.");
+    expect(handlerRegistered).toBeTrue();
+  });
+});

--- a/server/extensions/mcp/tools/copyStateTransitions.ts
+++ b/server/extensions/mcp/tools/copyStateTransitions.ts
@@ -3,13 +3,15 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiCall } from '../apiClient';
 
 export function registerCopyStateTransitions(server: McpServer, token: string): void {
-  server.tool(
+  server.registerTool(
     'copy_state_transitions',
-    'Copy state transition graph from one board to another.',
     {
+      description: 'Copy state transition graph from one board to another.',
+      inputSchema: {
       boardId: z.string().describe('ID of the source board'),
       targetBoardId: z.string().describe('ID of the target board'),
       copyEnabled: z.boolean().optional().describe('Copy enabled flag from source board when true'),
+      },
     },
     async ({ boardId, targetBoardId, copyEnabled }) => {
       const body: Record<string, unknown> = { targetBoardId };


### PR DESCRIPTION
## Scope
Migrates `copy_state_transitions` from deprecated `server.tool` to `server.registerTool`. Adds a focused registration-contract regression test; the existing input schema and handler remain unchanged.

## TDD evidence
- RED: registration-only fixture failed on `server.tool`
- GREEN: stable tool name, description and handler registration are preserved

## Validation
- `bun test server/extensions/mcp/tools/copyStateTransitions.test.ts` — passed
- focused ESLint — passed
- `git diff --check` — passed