### PR TITLE
fix(mcp): migrate edit-card-description tool registration

### DIFF
--- a/server/extensions/mcp/tools/editDescription.test.ts
+++ b/server/extensions/mcp/tools/editDescription.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+let toolName = '';
+let toolDescription = '';
+let handlerRegistered = false;
+
+const server = {
+  registerTool: (
+    name: string,
+    config: { description: string; inputSchema: unknown },
+    _handler: unknown,
+  ) => {
+    toolName = name;
+    toolDescription = config.description;
+    handlerRegistered = true;
+  },
+};
+
+const { registerEditDescription } = await import('./editDescription');
+
+describe('registerEditDescription', () => {
+  beforeEach(() => {
+    toolName = '';
+    toolDescription = '';
+    handlerRegistered = false;
+  });
+
+  test('registers the stable edit_card_description tool contract', () => {
+    registerEditDescription(server as never, 'token-1');
+
+    expect(toolName).toBe('edit_card_description');
+    expect(toolDescription).toBe("Update the description of an existing card.");
+    expect(handlerRegistered).toBeTrue();
+  });
+});

--- a/server/extensions/mcp/tools/editDescription.ts
+++ b/server/extensions/mcp/tools/editDescription.ts
@@ -3,12 +3,14 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiCall } from '../apiClient';
 
 export function registerEditDescription(server: McpServer, token: string): void {
-  server.tool(
+  server.registerTool(
     'edit_card_description',
-    'Update the description of an existing card.',
     {
+      description: 'Update the description of an existing card.',
+      inputSchema: {
       cardId: z.string().describe('ID of the card to update'),
       description: z.string().describe('New description text for the card'),
+      },
     },
     async ({ cardId, description }) => {
       const result = await apiCall<{ data: unknown }>({


### PR DESCRIPTION
## Scope
Migrates `edit_card_description` from deprecated `server.tool` to `server.registerTool`. Adds a focused registration-contract regression test; the existing input schema and handler remain unchanged.

## TDD evidence
- RED: registration-only fixture failed on `server.tool`
- GREEN: stable tool name, description and handler registration are preserved

## Validation
- `bun test server/extensions/mcp/tools/editDescription.test.ts` — passed
- focused ESLint — passed
- `git diff --check` — passed