### PR TITLE
fix(mcp): migrate get-state-transition-rules tool registration

### DIFF
--- a/server/extensions/mcp/tools/getStateTransitionRules.test.ts
+++ b/server/extensions/mcp/tools/getStateTransitionRules.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+let toolName = '';
+let toolDescription = '';
+let handlerRegistered = false;
+
+const server = {
+  registerTool: (
+    name: string,
+    config: { description: string; inputSchema: unknown },
+    _handler: unknown,
+  ) => {
+    toolName = name;
+    toolDescription = config.description;
+    handlerRegistered = true;
+  },
+};
+
+const { registerGetStateTransitionRules } = await import('./getStateTransitionRules');
+
+describe('registerGetStateTransitionRules', () => {
+  beforeEach(() => {
+    toolName = '';
+    toolDescription = '';
+    handlerRegistered = false;
+  });
+
+  test('registers the stable get_state_transition_rules tool contract', () => {
+    registerGetStateTransitionRules(server as never, 'token-1');
+
+    expect(toolName).toBe('get_state_transition_rules');
+    expect(toolDescription).toBe("Get enforceable state-transition rules for a board.");
+    expect(handlerRegistered).toBeTrue();
+  });
+});

--- a/server/extensions/mcp/tools/getStateTransitionRules.ts
+++ b/server/extensions/mcp/tools/getStateTransitionRules.ts
@@ -3,11 +3,13 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiCall } from '../apiClient';
 
 export function registerGetStateTransitionRules(server: McpServer, token: string): void {
-  server.tool(
+  server.registerTool(
     'get_state_transition_rules',
-    'Get enforceable state-transition rules for a board.',
     {
+      description: 'Get enforceable state-transition rules for a board.',
+      inputSchema: {
       boardId: z.string().describe('ID of the board'),
+      },
     },
     async ({ boardId }) => {
       const result = await apiCall<{ data: unknown }>({


### PR DESCRIPTION
## Scope
Migrates `get_state_transition_rules` from deprecated `server.tool` to `server.registerTool`. Adds a focused registration-contract regression test; the existing input schema and handler remain unchanged.

## TDD evidence
- RED: registration-only fixture failed on `server.tool`
- GREEN: stable tool name, description and handler registration are preserved

## Validation
- `bun test server/extensions/mcp/tools/getStateTransitionRules.test.ts` — passed
- focused ESLint — passed
- `git diff --check` — passed