### PR TITLE
fix(mcp): migrate invite-to-board tool registration

### DIFF
--- a/server/extensions/mcp/tools/inviteToBoard.test.ts
+++ b/server/extensions/mcp/tools/inviteToBoard.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { z } from 'zod';
+
+let toolName = '';
+let toolDescription = '';
+let inputSchema: Record<string, z.ZodType> | undefined;
+let handlerRegistered = false;
+
+const server = {
+  registerTool: (
+    name: string,
+    config: { description: string; inputSchema: Record<string, z.ZodType> },
+    _handler: unknown,
+  ) => {
+    toolName = name;
+    toolDescription = config.description;
+    inputSchema = config.inputSchema;
+    handlerRegistered = true;
+  },
+};
+
+const { registerInviteToBoard } = await import('./inviteToBoard');
+
+describe('registerInviteToBoard', () => {
+  beforeEach(() => {
+    toolName = '';
+    toolDescription = '';
+    inputSchema = undefined;
+    handlerRegistered = false;
+  });
+
+  test('registers the stable invite_to_board tool contract', () => {
+    registerInviteToBoard(server as never, 'token-1');
+
+    expect(toolName).toBe('invite_to_board');
+    expect(toolDescription).toBe("Invite a user to a board by email. Requires the token holder to be a board admin.");
+    expect(handlerRegistered).toBeTrue();
+  });
+
+  test('uses the non-deprecated email schema', () => {
+    registerInviteToBoard(server as never, 'token-1');
+
+    const emailSchema = inputSchema?.email;
+    if (!emailSchema) throw new Error('invite_to_board email schema was not registered');
+    expect(emailSchema.safeParse('not-an-email').success).toBeFalse();
+  });
+});

--- a/server/extensions/mcp/tools/inviteToBoard.ts
+++ b/server/extensions/mcp/tools/inviteToBoard.ts
@@ -3,16 +3,18 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiCall } from '../apiClient';
 
 export function registerInviteToBoard(server: McpServer, token: string): void {
-  server.tool(
+  server.registerTool(
     'invite_to_board',
-    'Invite a user to a board by email. Requires the token holder to be a board admin.',
     {
-      boardId: z.string().describe('ID of the board to invite the user to'),
-      email: z.string().email().describe('Email address of the user to invite'),
-      role: z
-        .enum(['member', 'observer'])
-        .optional()
-        .describe('Role to assign; defaults to "member"'),
+      description: 'Invite a user to a board by email. Requires the token holder to be a board admin.',
+      inputSchema: {
+        boardId: z.string().describe('ID of the board to invite the user to'),
+        email: z.email().describe('Email address of the user to invite'),
+        role: z
+          .enum(['member', 'observer'])
+          .optional()
+          .describe('Role to assign; defaults to "member"'),
+      },
     },
     async ({ boardId, email, role }) => {
       const result = await apiCall<{ data: unknown }>({


### PR DESCRIPTION
Migrates invite_to_board to registerTool, adds registration/schema coverage, and replaces deprecated z.string().email() with z.email().