### PR TITLE
fix(mcp): migrate search-board tool registration

### DIFF
--- a/server/extensions/mcp/tools/searchBoard.test.ts
+++ b/server/extensions/mcp/tools/searchBoard.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+let toolName = '';
+let toolDescription = '';
+let handlerRegistered = false;
+
+const server = {
+  registerTool: (
+    name: string,
+    config: { description: string; inputSchema: unknown },
+    _handler: unknown,
+  ) => {
+    toolName = name;
+    toolDescription = config.description;
+    handlerRegistered = true;
+  },
+};
+
+const { registerSearchBoard } = await import('./searchBoard');
+
+describe('registerSearchBoard', () => {
+  beforeEach(() => {
+    toolName = '';
+    toolDescription = '';
+    handlerRegistered = false;
+  });
+
+  test('registers the stable search_board tool contract', () => {
+    registerSearchBoard(server as never, 'token-1');
+
+    expect(toolName).toBe('search_board');
+    expect(toolDescription).toBe("Full-text search over cards and lists scoped to a single board.");
+    expect(handlerRegistered).toBeTrue();
+  });
+});

--- a/server/extensions/mcp/tools/searchBoard.ts
+++ b/server/extensions/mcp/tools/searchBoard.ts
@@ -3,14 +3,16 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiCall } from '../apiClient';
 
 export function registerSearchBoard(server: McpServer, token: string): void {
-  server.tool(
+  server.registerTool(
     'search_board',
-    'Full-text search over cards and lists scoped to a single board.',
     {
+      description: 'Full-text search over cards and lists scoped to a single board.',
+      inputSchema: {
       boardId: z.string().describe('ID of the board to search within'),
       query: z.string().optional().describe('Full-text search query'),
       q: z.string().optional().describe('Deprecated alias for full-text search query'),
       limit: z.number().optional().describe('Maximum number of results to return'),
+      },
     },
     async ({ boardId, query, q, limit }) => {
       const resolvedQuery = query ?? q;


### PR DESCRIPTION
## Scope
Migrates `search_board` from deprecated `server.tool` to `server.registerTool`. Adds a focused registration-contract regression test; the existing input schema and handler remain unchanged.

## TDD evidence
- RED: registration-only fixture failed on `server.tool`
- GREEN: stable tool name, description and handler registration are preserved

## Validation
- `bun test server/extensions/mcp/tools/searchBoard.test.ts` — passed
- focused ESLint — passed
- `git diff --check` — passed