### PR TITLE
fix(mcp): migrate set-card-price tool registration

### DIFF
--- a/server/extensions/mcp/tools/setCardPrice.test.ts
+++ b/server/extensions/mcp/tools/setCardPrice.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+let toolName = '';
+let toolDescription = '';
+let handlerRegistered = false;
+
+const server = {
+  registerTool: (
+    name: string,
+    config: { description: string; inputSchema: unknown },
+    _handler: unknown,
+  ) => {
+    toolName = name;
+    toolDescription = config.description;
+    handlerRegistered = true;
+  },
+};
+
+const { registerSetCardPrice } = await import('./setCardPrice');
+
+describe('registerSetCardPrice', () => {
+  beforeEach(() => {
+    toolName = '';
+    toolDescription = '';
+    handlerRegistered = false;
+  });
+
+  test('registers the stable set_card_price tool contract', () => {
+    registerSetCardPrice(server as never, 'token-1');
+
+    expect(toolName).toBe('set_card_price');
+    expect(toolDescription).toBe("Set or clear the price on a card. Pass amount=null to remove the price.");
+    expect(handlerRegistered).toBeTrue();
+  });
+});

--- a/server/extensions/mcp/tools/setCardPrice.ts
+++ b/server/extensions/mcp/tools/setCardPrice.ts
@@ -3,15 +3,17 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiCall } from '../apiClient';
 
 export function registerSetCardPrice(server: McpServer, token: string): void {
-  server.tool(
+  server.registerTool(
     'set_card_price',
-    'Set or clear the price on a card. Pass amount=null to remove the price.',
     {
+      description: 'Set or clear the price on a card. Pass amount=null to remove the price.',
+      inputSchema: {
       cardId: z.string().describe('ID of the card to update'),
       // nullable() allows amount: null to explicitly clear the price
       amount: z.number().nullable().describe('Price amount (pass null to clear the price)'),
       currency: z.string().optional().describe('ISO 4217 currency code, e.g. "USD"'),
       label: z.string().optional().describe('Optional display label for the price'),
+      },
     },
     async ({ cardId, amount, currency, label }) => {
       const result = await apiCall<{ data: unknown }>({


### PR DESCRIPTION
Migrates set_card_price from deprecated server.tool to server.registerTool. Adds a focused registration-contract regression test; the existing input schema and handler remain unchanged.