### PR TITLE
fix(mcp): migrate set-state-transitions tool registration

### DIFF
--- a/server/extensions/mcp/tools/setStateTransitions.test.ts
+++ b/server/extensions/mcp/tools/setStateTransitions.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+let toolName = '';
+let toolDescription = '';
+let handlerRegistered = false;
+
+const server = {
+  registerTool: (
+    name: string,
+    config: { description: string; inputSchema: unknown },
+    _handler: unknown,
+  ) => {
+    toolName = name;
+    toolDescription = config.description;
+    handlerRegistered = true;
+  },
+};
+
+const { registerSetStateTransitions } = await import('./setStateTransitions');
+
+describe('registerSetStateTransitions', () => {
+  beforeEach(() => {
+    toolName = '';
+    toolDescription = '';
+    handlerRegistered = false;
+  });
+
+  test('registers the stable set_state_transitions tool contract', () => {
+    registerSetStateTransitions(server as never, 'token-1');
+
+    expect(toolName).toBe('set_state_transitions');
+    expect(toolDescription).toBe("Update state transition graph and/or enabled flag for a board.");
+    expect(handlerRegistered).toBeTrue();
+  });
+});

--- a/server/extensions/mcp/tools/setStateTransitions.ts
+++ b/server/extensions/mcp/tools/setStateTransitions.ts
@@ -3,13 +3,15 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiCall } from '../apiClient';
 
 export function registerSetStateTransitions(server: McpServer, token: string): void {
-  server.tool(
+  server.registerTool(
     'set_state_transitions',
-    'Update state transition graph and/or enabled flag for a board.',
     {
+      description: 'Update state transition graph and/or enabled flag for a board.',
+      inputSchema: {
       boardId: z.string().describe('ID of the board'),
       enabled: z.boolean().optional().describe('Enable or disable state transition enforcement'),
       graph: z.unknown().optional().describe('State transition graph payload'),
+      },
     },
     async ({ boardId, enabled, graph }) => {
       if (enabled === undefined && graph === undefined) {


### PR DESCRIPTION
## Scope
Migrates `set_state_transitions` from deprecated `server.tool` to `server.registerTool`. Adds a focused registration-contract regression test; the existing input schema and handler remain unchanged.

## TDD evidence
- RED: registration-only fixture failed on `server.tool`
- GREEN: stable tool name, description and handler registration are preserved

## Validation
- `bun test server/extensions/mcp/tools/setStateTransitions.test.ts` — passed
- focused ESLint — passed
- `git diff --check` — passed