### PR TITLE
fix(mcp): migrate write-comment tool registration

### DIFF
--- a/server/extensions/mcp/tools/writeComment.test.ts
+++ b/server/extensions/mcp/tools/writeComment.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+let toolName = '';
+let toolDescription = '';
+let handlerRegistered = false;
+
+const server = {
+  registerTool: (
+    name: string,
+    config: { description: string; inputSchema: unknown },
+    _handler: unknown,
+  ) => {
+    toolName = name;
+    toolDescription = config.description;
+    handlerRegistered = true;
+  },
+};
+
+const { registerWriteComment } = await import('./writeComment');
+
+describe('registerWriteComment', () => {
+  beforeEach(() => {
+    toolName = '';
+    toolDescription = '';
+    handlerRegistered = false;
+  });
+
+  test('registers the stable write_comment tool contract', () => {
+    registerWriteComment(server as never, 'token-1');
+
+    expect(toolName).toBe('write_comment');
+    expect(toolDescription).toBe("Post a comment on a card.");
+    expect(handlerRegistered).toBeTrue();
+  });
+});

--- a/server/extensions/mcp/tools/writeComment.ts
+++ b/server/extensions/mcp/tools/writeComment.ts
@@ -3,13 +3,15 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiCall } from '../apiClient';
 
 export function registerWriteComment(server: McpServer, token: string): void {
-  server.tool(
+  server.registerTool(
     'write_comment',
-    'Post a comment on a card.',
     {
+      description: 'Post a comment on a card.',
+      inputSchema: {
       cardId: z.string().describe('ID of the card to comment on'),
       content: z.string().optional().describe('Comment body text'),
       text: z.string().optional().describe('Deprecated alias for comment body text'),
+      },
     },
     async ({ cardId, content, text }) => {
       const commentContent = content ?? text;


### PR DESCRIPTION
Migrates write_comment from deprecated server.tool to server.registerTool. Adds a focused stable registration-contract regression test; the existing input schema and handler remain unchanged.