### PR TITLE
fix(attachments): type attachment list rows

### DIFF
--- a/server/extensions/attachment/api/list.test.ts
+++ b/server/extensions/attachment/api/list.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import { serializeAttachment } from './serializeAttachment';
+
+describe('serializeAttachment', () => {
+  test('uses proxy URLs for files and preserves referenced card details', () => {
+    const result = serializeAttachment(
+      {
+        id: 'attachment-1',
+        card_id: 'card-1',
+        name: 'brief.pdf',
+        alias: null,
+        type: 'FILE',
+        url: null,
+        external_url: null,
+        mime_type: 'application/pdf',
+        size_bytes: 42,
+        status: 'READY',
+        thumbnail_key: 'thumbs/brief.png',
+        width: null,
+        height: null,
+        created_at: '2026-09-07T00:00:00.000Z',
+        updated_at: '2026-09-07T00:00:00.000Z',
+        referenced_card_id: 'card-2',
+      },
+      {
+        'card-2': {
+          id: 'card-2',
+          title: 'Referenced card',
+          board_id: 'board-1',
+          board_name: 'Board',
+          list_id: 'list-1',
+          list_name: 'List',
+          labels: [{ id: 'label-1', name: 'Urgent', color: 'red' }],
+        },
+      },
+    );
+
+    expect(result.view_url).toBe('/api/v1/attachments/attachment-1/view');
+    expect(result.thumbnail_url).toBe('/api/v1/attachments/attachment-1/thumbnail');
+    expect(result.referenced_card?.labels).toEqual([{ id: 'label-1', name: 'Urgent', color: 'red' }]);
+  });
+
+  test('returns an external URL directly only for URL attachments', () => {
+    const result = serializeAttachment(
+      {
+        id: 'attachment-2', card_id: 'card-1', name: 'Link', alias: null, type: 'URL',
+        url: 'https://example.com', external_url: null, mime_type: null, size_bytes: null,
+        status: 'READY', thumbnail_key: null, width: null, height: null,
+        created_at: '2026-09-07T00:00:00.000Z', updated_at: '2026-09-07T00:00:00.000Z',
+        referenced_card_id: null,
+      },
+      {},
+    );
+
+    expect(result.view_url).toBe('https://example.com');
+    expect(result.thumbnail_url).toBeNull();
+  });
+});

--- a/server/extensions/attachment/api/list.ts
+++ b/server/extensions/attachment/api/list.ts
@@ -9,6 +9,12 @@ import {
   type WorkspaceScopedRequest,
 } from '../../../middlewares/permissionManager';
 import { resolveCardId } from '../../../common/ids/resolveEntityId';
+import { serializeAttachment, type AttachmentRow, type ReferencedCard } from './serializeAttachment';
+
+type CardRow = { id: string; list_id: string; title: string };
+type ListRow = { id: string; board_id: string; title: string };
+type BoardRow = { id: string; workspace_id: string; title: string };
+type CardLabelRow = { card_id: string; label_id: string; name: string; color: string };
 
 export async function handleListAttachments(req: Request, cardId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
@@ -19,13 +25,13 @@ export async function handleListAttachments(req: Request, cardId: string): Promi
     return Response.json({ name: 'card-not-found', data: { message: 'Card not found' } }, { status: 404 });
   }
 
-  const card = await db('cards').where({ id: resolvedCardId }).first();
+  const card = await db<CardRow>('cards').where({ id: resolvedCardId }).first();
   if (!card) {
     return Response.json({ name: 'card-not-found', data: { message: 'Card not found' } }, { status: 404 });
   }
 
-  const list = await db('lists').where({ id: card.list_id }).first();
-  const board = list ? await db('boards').where({ id: list.board_id }).first() : null;
+  const list = await db<ListRow>('lists').where({ id: card.list_id }).first();
+  const board = list ? await db<BoardRow>('boards').where({ id: list.board_id }).first() : null;
   if (!board) {
     return Response.json({ name: 'board-not-found', data: { message: 'Board not found' } }, { status: 404 });
   }
@@ -34,37 +40,26 @@ export async function handleListAttachments(req: Request, cardId: string): Promi
   const membershipError = await requireWorkspaceMembership(scopedReq, board.workspace_id);
   if (membershipError) return membershipError;
 
-  const attachments = await db('attachments')
+  const attachments = await db<AttachmentRow>('attachments')
     .where({ card_id: resolvedCardId })
     .orderBy('created_at', 'desc');
 
   // Resolve referenced card data for internal card-link attachments.
   const referencedCardIds = attachments
-    .map((a) => a.referenced_card_id as string | null)
+    .map((a) => a.referenced_card_id)
     .filter((id): id is string => Boolean(id));
 
-  let refCardMap: Record<
-    string,
-    {
-      id: string;
-      title: string;
-      board_id: string | null;
-      board_name: string | null;
-      list_id: string | null;
-      list_name: string | null;
-      labels: Array<{ id: string; name: string; color: string }>;
-    }
-  > = {};
+  const refCardMap: Record<string, ReferencedCard> = {};
 
   if (referencedCardIds.length > 0) {
-    const refCards = await db('cards').whereIn('id', referencedCardIds);
-    const refLists = await db('lists').whereIn('id', refCards.map((c) => c.list_id));
-    const refBoards = await db('boards').whereIn('id', refLists.map((l) => l.board_id));
+    const refCards = await db<CardRow>('cards').whereIn('id', referencedCardIds);
+    const refLists = await db<ListRow>('lists').whereIn('id', refCards.map((c) => c.list_id));
+    const refBoards = await db<BoardRow>('boards').whereIn('id', refLists.map((l) => l.board_id));
 
-    const cardLabelRows = await db('card_labels')
+    const cardLabelRows = await db<CardLabelRow>('card_labels')
       .join('labels', 'card_labels.label_id', 'labels.id')
       .whereIn('card_labels.card_id', referencedCardIds)
-      .select('card_labels.card_id', 'labels.id as label_id', 'labels.name', 'labels.color');
+      .select<CardLabelRow[]>('card_labels.card_id', 'labels.id as label_id', 'labels.name', 'labels.color');
 
     const listMap = Object.fromEntries(refLists.map((l) => [l.id, l]));
     const boardMap = Object.fromEntries(refBoards.map((b) => [b.id, b]));
@@ -81,45 +76,12 @@ export async function handleListAttachments(req: Request, cardId: string): Promi
         list_name: refList?.title ?? null,
         labels: cardLabelRows
           .filter((cl) => cl.card_id === rc.id)
-          .map((cl) => ({ id: cl.label_id as string, name: cl.name as string, color: cl.color as string })),
+          .map((cl) => ({ id: cl.label_id, name: cl.name, color: cl.color })),
       };
     }
   }
 
-  const data = attachments.map((attachment) => {
-    // URL-type attachments expose their external URL directly (user-supplied, not S3).
-    // FILE-type attachments use the authenticated proxy paths; never raw presigned URLs.
-    const view_url =
-      attachment.type === 'URL'
-        ? (attachment.url ?? attachment.external_url ?? null)
-        : `/api/v1/attachments/${attachment.id}/view`;
-
-    const thumbnail_url = attachment.thumbnail_key
-      ? `/api/v1/attachments/${attachment.id}/thumbnail`
-      : null;
-
-    return {
-      id: attachment.id,
-      card_id: attachment.card_id,
-      name: attachment.name,
-      alias: attachment.alias ?? null,
-      type: attachment.type,
-      content_type: attachment.mime_type ?? null,
-      size_bytes: attachment.size_bytes ?? null,
-      status: attachment.status,
-      view_url,
-      thumbnail_url,
-      external_url: attachment.external_url ?? null,
-      width: attachment.width ?? null,
-      height: attachment.height ?? null,
-      created_at: attachment.created_at,
-      updated_at: attachment.updated_at,
-      referenced_card_id: attachment.referenced_card_id ?? null,
-      referenced_card: attachment.referenced_card_id
-        ? (refCardMap[attachment.referenced_card_id as string] ?? null)
-        : null,
-    };
-  });
+  const data = attachments.map((attachment) => serializeAttachment(attachment, refCardMap));
 
   return Response.json({ data });
 }

--- a/server/extensions/attachment/api/serializeAttachment.ts
+++ b/server/extensions/attachment/api/serializeAttachment.ts
@@ -1,0 +1,33 @@
+export type AttachmentRow = {
+  id: string; card_id: string; name: string; alias: string | null; type: 'FILE' | 'URL';
+  url: string | null; external_url: string | null; mime_type: string | null; size_bytes: number | null;
+  status: string; thumbnail_key: string | null; width: number | null; height: number | null;
+  created_at: string; updated_at: string; referenced_card_id: string | null;
+};
+
+export type ReferencedCard = {
+  id: string; title: string; board_id: string | null; board_name: string | null;
+  list_id: string | null; list_name: string | null;
+  labels: Array<{ id: string; name: string; color: string }>;
+};
+
+export function serializeAttachment(
+  attachment: AttachmentRow,
+  refCardMap: Record<string, ReferencedCard>,
+) {
+  const view_url = attachment.type === 'URL'
+    ? (attachment.url ?? attachment.external_url ?? null)
+    : `/api/v1/attachments/${attachment.id}/view`;
+  const thumbnail_url = attachment.thumbnail_key
+    ? `/api/v1/attachments/${attachment.id}/thumbnail`
+    : null;
+
+  return {
+    id: attachment.id, card_id: attachment.card_id, name: attachment.name, alias: attachment.alias ?? null,
+    type: attachment.type, content_type: attachment.mime_type ?? null, size_bytes: attachment.size_bytes ?? null,
+    status: attachment.status, view_url, thumbnail_url, external_url: attachment.external_url ?? null,
+    width: attachment.width ?? null, height: attachment.height ?? null, created_at: attachment.created_at,
+    updated_at: attachment.updated_at, referenced_card_id: attachment.referenced_card_id ?? null,
+    referenced_card: attachment.referenced_card_id ? (refCardMap[attachment.referenced_card_id] ?? null) : null,
+  };
+}


### PR DESCRIPTION
## Scope
Types the attachment-list database boundaries and extracts its pure response mapper. This removes the focused lint debt without changing the public attachment response contract.

## Validation
- focused mapper tests: 2 passed
- focused ESLint: passed
- client build: passed
- full Bun suite: 801 passed, 3 skipped, 118 failed, 93 errors; new mapper tests pass. Remaining failures are existing baseline debt.
- typecheck remains baseline-red outside this slice; no list.ts error is reported.
- git diff --check: passed