### PR TITLE
fix(attachments): type upload confirmation

### DIFF
--- a/server/extensions/attachment/__tests__/uploadConfirmation.test.ts
+++ b/server/extensions/attachment/__tests__/uploadConfirmation.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'bun:test';
+import { hasUploadedS3Key } from '../api/uploadConfirmation';
+
+describe('hasUploadedS3Key', () => {
+  test('requires a non-empty S3 key before confirming an upload', () => {
+    expect(hasUploadedS3Key('attachments/card/file.pdf')).toBe(true);
+    expect(hasUploadedS3Key('')).toBe(false);
+    expect(hasUploadedS3Key(null)).toBe(false);
+  });
+});

--- a/server/extensions/attachment/api/confirmUpload.ts
+++ b/server/extensions/attachment/api/confirmUpload.ts
@@ -13,6 +13,35 @@ import { publisher } from '../../../mods/pubsub/publisher';
 import { dispatchEvent } from '../../../mods/events/dispatch';
 import { writeActivity } from '../../activity/mods/write';
 import { resolveCardId } from '../../../common/ids/resolveEntityId';
+import { hasUploadedS3Key } from './uploadConfirmation';
+
+interface ConfirmUploadBody {
+  attachmentId?: string;
+}
+
+interface CardRow {
+  id: string;
+  list_id: string;
+  title: string | null;
+}
+
+interface ListRow {
+  id: string;
+  board_id: string;
+}
+
+interface BoardRow {
+  id: string;
+  workspace_id: string;
+}
+
+interface FileAttachmentRow {
+  id: string;
+  card_id: string;
+  type: 'FILE';
+  s3_key: string | null;
+  name: string;
+}
 
 export async function handleConfirmUpload(req: Request, cardId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
@@ -23,13 +52,13 @@ export async function handleConfirmUpload(req: Request, cardId: string): Promise
     return Response.json({ error: { code: 'card-not-found', message: 'Card not found' } }, { status: 404 });
   }
 
-  const card = await db('cards').where({ id: resolvedCardId }).first();
+  const card = await db<CardRow>('cards').where({ id: resolvedCardId }).first();
   if (!card) {
     return Response.json({ error: { code: 'card-not-found', message: 'Card not found' } }, { status: 404 });
   }
 
-  const list = await db('lists').where({ id: card.list_id }).first();
-  const board = list ? await db('boards').where({ id: list.board_id }).first() : null;
+  const list = await db<ListRow>('lists').where({ id: card.list_id }).first();
+  const board = list ? await db<BoardRow>('boards').where({ id: list.board_id }).first() : null;
   if (!board) {
     return Response.json({ error: { code: 'board-not-found', message: 'Board not found' } }, { status: 404 });
   }
@@ -40,9 +69,9 @@ export async function handleConfirmUpload(req: Request, cardId: string): Promise
   const roleError = await requireMemberOrBoardGuestMember(scopedReq, board.id);
   if (roleError) return roleError;
 
-  let body: { attachmentId?: string };
+  let body: ConfirmUploadBody;
   try {
-    body = (await req.json()) as typeof body;
+    body = (await req.json()) as ConfirmUploadBody;
   } catch {
     return Response.json({ error: { code: 'bad-request', message: 'Invalid JSON body' } }, { status: 400 });
   }
@@ -51,7 +80,7 @@ export async function handleConfirmUpload(req: Request, cardId: string): Promise
     return Response.json({ error: { code: 'bad-request', message: 'attachmentId is required' } }, { status: 400 });
   }
 
-  const attachment = await db('attachments')
+  const attachment = await db<FileAttachmentRow>('attachments')
     .where({ id: body.attachmentId, card_id: resolvedCardId, type: 'FILE' })
     .first();
 
@@ -63,7 +92,7 @@ export async function handleConfirmUpload(req: Request, cardId: string): Promise
   }
 
   // Verify the client actually PUT the file to S3
-  if (!attachment.s3_key) {
+  if (!hasUploadedS3Key(attachment.s3_key)) {
     return Response.json(
       { error: { code: 'upload-url-expired', message: 'Upload was not completed' } },
       { status: 400 },
@@ -78,7 +107,12 @@ export async function handleConfirmUpload(req: Request, cardId: string): Promise
     );
   }
 
-  const actorId = (req as AuthenticatedRequest).currentUser!.id;
+  const actor = (req as AuthenticatedRequest).currentUser;
+  if (!actor) {
+    return Response.json({ error: { code: 'unauthorized', message: 'Authentication required' } }, { status: 401 });
+  }
+
+  const actorId = actor.id;
 
   // Enqueue virus scan (no-op when VIRUS_SCAN_ENABLED=false)
   await enqueueScan({ attachmentId: attachment.id });
@@ -107,6 +141,6 @@ export async function handleConfirmUpload(req: Request, cardId: string): Promise
     )
     .catch(() => {});
 
-  const updated = await db('attachments').where({ id: attachment.id }).first();
+  const updated = await db<FileAttachmentRow>('attachments').where({ id: attachment.id }).first();
   return Response.json({ data: updated }, { status: 200 });
 }

--- a/server/extensions/attachment/api/uploadConfirmation.ts
+++ b/server/extensions/attachment/api/uploadConfirmation.ts
@@ -1,0 +1,3 @@
+export function hasUploadedS3Key(s3Key: string | null): s3Key is string {
+  return typeof s3Key === 'string' && s3Key.length > 0;
+}


### PR DESCRIPTION
## Summary
- type upload confirmation database boundaries
- preserve S3 upload precondition through a pure helper and regression test
- replace unsafe authenticated-user assertion with a safe guard

## Validation
- focused upload-confirmation test
- focused ESLint
- `bun run typecheck` (baseline-red; no confirmation-slice diagnostics)
- `bun run build:client`
- `git diff --check`
- full `bun test` reporting: 805 pass, 3 skip, 118 fail, 93 errors (baseline suite debt; new test green)