### PR TITLE
fix(s3): split public and internal S3 endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,13 @@ SEED_FILE_URL=
 S3_REGION=us-east-1
 # Production AWS S3 endpoint (leave blank in local dev):
 S3_ENDPOINT=
+# Internal/direct endpoint for server-side S3 operations (optional).
+# Set when S3_ENDPOINT sits behind a public proxy: presigned URLs still target
+# S3_ENDPOINT, but direct server operations (Head/Delete/Get/Put, bucket
+# bootstrap, multipart control, thumbnails, avatars, board backgrounds) go
+# straight to this address — e.g. http://object-store:9000.
+# Falls back to S3_ENDPOINT when unset.
+S3_INTERNAL_ENDPOINT=
 # S3-specific credentials — set these to target LocalStack while keeping real AWS
 # credentials in AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY for SES.
 # When unset, the S3 client falls back to AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY.

--- a/server/config/env.ts
+++ b/server/config/env.ts
@@ -18,6 +18,11 @@ export const env = {
   // S3 / file storage
   // When FLAG_USE_LOCAL_STORAGE=true, the storage module overrides endpoint/credentials with LocalStack defaults.
   S3_ENDPOINT: Bun.env['S3_ENDPOINT'] ?? '',
+  // Optional endpoint for server-side S3 operations (ensureBucketExists, Head/Delete/Get/Put,
+  // proxy, thumbnails, multipart create/complete/abort). Set this to the direct/internal
+  // address (e.g. http://object-store:9000) so server traffic does not hairpin through
+  // the public proxy in front of S3_ENDPOINT. Falls back to S3_ENDPOINT when unset.
+  S3_INTERNAL_ENDPOINT: Bun.env['S3_INTERNAL_ENDPOINT'] ?? '',
   S3_BUCKET: Bun.env['S3_BUCKET'] ?? 'kanban',
   S3_REGION: Bun.env['S3_REGION'] ?? 'us-east-1',
   // S3-specific credentials — use these to point S3/LocalStack at a different IAM identity

--- a/server/extensions/attachment/api/multipart/abort.ts
+++ b/server/extensions/attachment/api/multipart/abort.ts
@@ -8,7 +8,7 @@ import {
   requireMemberOrBoardGuestMember,
   type WorkspaceScopedRequest,
 } from '../../../../middlewares/permissionManager';
-import { s3Client, s3Config } from '../../common/config/s3';
+import { s3ServerClient, s3Config } from '../../common/config/s3';
 import { resolveCardId } from '../../../../common/ids/resolveEntityId';
 
 export async function handleMultipartAbort(
@@ -64,7 +64,7 @@ export async function handleMultipartAbort(
 
   // Best-effort: abort the S3 multipart upload (may already be expired or completed)
   try {
-    await s3Client.send(
+    await s3ServerClient.send(
       new AbortMultipartUploadCommand({
         Bucket: s3Config.bucket,
         Key: s3Key,

--- a/server/extensions/attachment/api/multipart/complete.ts
+++ b/server/extensions/attachment/api/multipart/complete.ts
@@ -8,7 +8,7 @@ import {
   requireMemberOrBoardGuestMember,
   type WorkspaceScopedRequest,
 } from '../../../../middlewares/permissionManager';
-import { s3Client, s3Config } from '../../common/config/s3';
+import { s3ServerClient, s3Config } from '../../common/config/s3';
 import { enqueueScan } from '../../mods/virusScan/enqueue';
 import { publisher } from '../../../../mods/pubsub/publisher';
 import { writeEvent } from '../../../../mods/events/write';
@@ -94,7 +94,7 @@ export async function handleMultipartComplete(req: Request, cardId: string): Pro
   }
 
   try {
-    await s3Client.send(
+    await s3ServerClient.send(
       new CompleteMultipartUploadCommand({
         Bucket: s3Config.bucket,
         Key: body.key,

--- a/server/extensions/attachment/api/multipart/start.ts
+++ b/server/extensions/attachment/api/multipart/start.ts
@@ -10,7 +10,7 @@ import {
   requireMemberOrBoardGuestMember,
   type WorkspaceScopedRequest,
 } from '../../../../middlewares/permissionManager';
-import { s3Client, s3Config } from '../../common/config/s3';
+import { s3ServerClient, s3Config } from '../../common/config/s3';
 import { ALLOWED_MIME_TYPES, MAX_FILE_SIZE_BYTES } from '../../config/allowedTypes';
 import { resolveCardId } from '../../../../common/ids/resolveEntityId';
 import { generateUniqueShortId } from '../../../../common/ids/shortId';
@@ -79,7 +79,7 @@ export async function handleMultipartStart(req: Request, cardId: string): Promis
 
   let uploadId: string;
   try {
-    const result = await s3Client.send(createCmd);
+    const result = await s3ServerClient.send(createCmd);
     if (!result.UploadId) throw new Error('S3 did not return an UploadId');
     uploadId = result.UploadId;
   } catch (err: unknown) {

--- a/server/extensions/attachment/common/config/s3.test.ts
+++ b/server/extensions/attachment/common/config/s3.test.ts
@@ -1,0 +1,127 @@
+// Regression test: server-side S3 operations must use S3_INTERNAL_ENDPOINT while
+// browser-facing presigns keep using S3_ENDPOINT.
+//
+// Reproduces a production race where a presigned PUT through the public
+// endpoint (https://public-object-store.example.test) succeeded, but the
+// immediate server HeadObject through the same public proxy returned
+// 403/Unknown while the same HeadObject against the internal object-store
+// endpoint (http://object-store:9000) returned 200. Server object
+// operations must not hairpin through the public proxy.
+//
+// The S3 clients are module singletons, so the env vars must be set before any
+// module in this process imports the config. When this file runs as part of the
+// wider suite another test file may already have cached the singleton with
+// different env — therefore the assertions run in a spawned, isolated `bun test`
+// child process (S3_SPLIT_TEST_INNER=1) whose env is fixed up front.
+import { describe, test, expect } from 'bun:test';
+
+const INNER = Bun.env['S3_SPLIT_TEST_INNER'] === '1';
+
+const PUBLIC_ENDPOINT = 'https://public-object-store.example.test';
+const INTERNAL_ENDPOINT = 'http://object-store:9000';
+
+function childEnv(): Record<string, string> {
+  return {
+    ...(Bun.env as Record<string, string>),
+    S3_SPLIT_TEST_INNER: '1',
+    S3_ENDPOINT: PUBLIC_ENDPOINT,
+    S3_INTERNAL_ENDPOINT: INTERNAL_ENDPOINT,
+    S3_AWS_ACCESS_KEY_ID: 'test',
+    S3_AWS_SECRET_ACCESS_KEY: 'test',
+  };
+}
+
+if (INNER) {
+  // ─── Isolated child process: singleton assertions ────────────────────────────
+  const { s3Client, s3ServerClient, s3Config } = await import('./s3');
+  const { presignGetUrl } = await import('../presign');
+  const { headObject } = await import('../../mods/s3/headObject');
+
+  async function resolvedEndpoint(clientInput: unknown): Promise<string | undefined> {
+    const config = (clientInput as { config?: { endpoint?: unknown } }).config;
+    const provider = config?.endpoint;
+    if (typeof provider !== 'function') return undefined;
+    const endpoint = await (provider as () => Promise<unknown>)();
+    if (endpoint == null) return undefined;
+    if (typeof endpoint === 'string') return endpoint;
+    const parsed = endpoint as {
+      url?: { toString(): string };
+      protocol?: string;
+      hostname?: string;
+      port?: number;
+    };
+    if (parsed.url) return parsed.url.toString();
+    if (parsed.hostname) {
+      const port = parsed.port ? `:${String(parsed.port)}` : '';
+      return `${parsed.protocol ?? 'https:'}//${parsed.hostname}${port}`;
+    }
+    return undefined;
+  }
+
+  describe('S3 public/internal endpoint split (inner)', () => {
+    test('presign client keeps using the public S3_ENDPOINT', async () => {
+      expect(await resolvedEndpoint(s3Client)).toBe(PUBLIC_ENDPOINT);
+    });
+
+    test('a server client exists and uses S3_INTERNAL_ENDPOINT for direct operations', async () => {
+      expect(s3ServerClient).toBeDefined();
+      expect(await resolvedEndpoint(s3ServerClient)).toBe(INTERNAL_ENDPOINT);
+    });
+
+    test('presigned GET URLs are generated against the public endpoint', async () => {
+      const { url } = await presignGetUrl({ s3Key: 'attachments/card/file.png' });
+      expect(url.startsWith(`${PUBLIC_ENDPOINT}/`)).toBe(true);
+    });
+
+    test('headObject sends through the server client, not the public client', async () => {
+      const serverSends: Array<{ Bucket?: string; Key?: string }> = [];
+      let publicSends = 0;
+      const originalServerSend = s3ServerClient.send.bind(s3ServerClient);
+      const originalPublicSend = s3Client.send.bind(s3Client);
+
+      const serverSpy = s3ServerClient as unknown as Record<string, unknown>;
+      const publicSpy = s3Client as unknown as Record<string, unknown>;
+      serverSpy['send'] = (cmd: unknown) => {
+        const input = (cmd as { input?: { Bucket?: string; Key?: string } }).input;
+        serverSends.push({ Bucket: input?.Bucket ?? '', Key: input?.Key ?? '' });
+        return Promise.resolve({});
+      };
+      publicSpy['send'] = () => {
+        publicSends += 1;
+        return Promise.reject(
+          new Error('public client must not be used for direct object operations')
+        );
+      };
+
+      try {
+        const exists = await headObject({ s3Key: 'attachments/card/file.png' });
+        expect(exists).toBe(true);
+        expect(serverSends.length).toBe(1);
+        expect(publicSends).toBe(0);
+        expect(serverSends[0]?.Bucket).toBe(s3Config.bucket);
+        expect(serverSends[0]?.Key).toBe('attachments/card/file.png');
+      } finally {
+        serverSpy['send'] = originalServerSend;
+        publicSpy['send'] = originalPublicSend;
+      }
+    });
+  });
+} else {
+  // ─── Outer runner: spawn the isolated child and gate on its result ──────────
+  describe('S3 public/internal endpoint split', () => {
+    test('isolated endpoint-split suite passes (see child output on failure)', async () => {
+      const proc = Bun.spawn(['bun', 'test', import.meta.path], {
+        env: childEnv(),
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+      const code = await proc.exited;
+      if (code !== 0) {
+        console.error(stdout + stderr);
+      }
+      expect(code).toBe(0);
+    });
+  });
+}

--- a/server/extensions/attachment/common/config/s3.ts
+++ b/server/extensions/attachment/common/config/s3.ts
@@ -14,43 +14,75 @@ export const s3Config = {
 const s3AccessKeyId = env.S3_AWS_ACCESS_KEY_ID || env.AWS_ACCESS_KEY_ID;
 const s3SecretAccessKey = env.S3_AWS_SECRET_ACCESS_KEY || env.AWS_SECRET_ACCESS_KEY;
 
-// Singleton S3 client — re-used across all S3 operations.
-export const s3Client = new S3Client({
+/**
+ * Endpoint for direct server-side S3 operations. Falls back to the public
+ * S3_ENDPOINT when S3_INTERNAL_ENDPOINT is not configured.
+ *
+ * S3_ENDPOINT may sit behind a public proxy. Presigned URLs MUST target that
+ * public endpoint so browsers can reach them, but server-side object operations
+ * (Head/Delete/Get/Put, bucket management, multipart control calls) must go
+ * direct — routing them through the proxy causes races where a just-written
+ * object reads back as 403/Unknown.
+ */
+const internalEndpoint = env.S3_INTERNAL_ENDPOINT || env.S3_ENDPOINT || undefined;
+
+// Shared client options — both clients use the same credentials/region.
+const clientOptions = {
   region: s3Config.region,
-  endpoint: s3Config.endpoint,
   credentials: {
     accessKeyId: s3AccessKeyId,
     secretAccessKey: s3SecretAccessKey,
   },
+};
+
+// Public-facing S3 client — used ONLY to generate presigned URLs handed to the
+// browser (presigned PUT, presigned GET helpers/redirects, multipart part URLs).
+// The signature covers the public endpoint host, so it cannot be swapped for the
+// internal one.
+export const s3Client = new S3Client({
+  ...clientOptions,
+  ...(s3Config.endpoint ? { endpoint: s3Config.endpoint } : {}),
   // Required when using path-style URLs with LocalStack or custom S3 endpoints
   forcePathStyle: !!s3Config.endpoint,
 });
 
+// Server-side S3 client — used for ALL direct object operations from the server
+// (ensureBucketExists, headObject, deleteObject, proxyS3Object, thumbnail Get/Put,
+// multipart create/complete/abort, avatar Put, board-background Put).
+export const s3ServerClient = new S3Client({
+  ...clientOptions,
+  ...(internalEndpoint ? { endpoint: internalEndpoint } : {}),
+  // Required when using path-style URLs with LocalStack or custom S3 endpoints
+  forcePathStyle: !!internalEndpoint,
+});
+
 /**
- * Ensure the configured S3 bucket exists. When S3_ENDPOINT is set (LocalStack /
- * custom endpoint) the bucket may not have been provisioned yet, so we create it
- * automatically if the HeadBucket call returns a 404. Safe to call at startup.
+ * Ensure the configured S3 bucket exists. When a custom endpoint is set
+ * (LocalStack or a self-hosted object store) the bucket may not have been provisioned yet, so we
+ * create it automatically if the HeadBucket call returns a 404. Safe to call
+ * at startup. Always checks via the internal endpoint — this is a direct
+ * server operation.
  */
 export async function ensureBucketExists(): Promise<void> {
-  // Only auto-create when using a custom endpoint (LocalStack / MinIO).
+  // Only auto-create when using a custom endpoint (LocalStack or a self-hosted object store).
   // Against real AWS the bucket must be pre-created to avoid accidental provisioning.
-  if (!s3Config.endpoint) return;
+  if (!internalEndpoint) return;
 
   try {
-    await s3Client.send(new HeadBucketCommand({ Bucket: s3Config.bucket }));
+    await s3ServerClient.send(new HeadBucketCommand({ Bucket: s3Config.bucket }));
   } catch (err: unknown) {
     const status = (err as { $metadata?: { httpStatusCode?: number } })?.$metadata?.httpStatusCode;
     if (status === 404 || status === 301) {
-      await s3Client.send(
+      await s3ServerClient.send(
         new CreateBucketCommand({
           Bucket: s3Config.bucket,
           // CreateBucketConfiguration is required for regions other than us-east-1
           ...(s3Config.region !== 'us-east-1' && {
             CreateBucketConfiguration: { LocationConstraint: s3Config.region as any },
           }),
-        }),
+        })
       );
-      console.info(`[s3] Created bucket '${s3Config.bucket}' on ${s3Config.endpoint}`);
+      console.info(`[s3] Created bucket '${s3Config.bucket}' on ${internalEndpoint}`);
     } else {
       // Re-throw unexpected errors (auth, DNS, etc.) so startup fails loudly
       throw err;

--- a/server/extensions/attachment/common/proxyS3Object.ts
+++ b/server/extensions/attachment/common/proxyS3Object.ts
@@ -1,5 +1,5 @@
 import { GetObjectCommand } from '@aws-sdk/client-s3';
-import { s3Client, s3Config } from './config/s3';
+import { s3ServerClient, s3Config } from './config/s3';
 
 function toReadableStream(body: unknown): ReadableStream<Uint8Array> | null {
   if (!body) return null;
@@ -42,7 +42,7 @@ export async function proxyS3Object({
   fallbackFilename?: string | null;
   contentDisposition?: 'inline' | 'attachment';
 }): Promise<Response> {
-  const result = await s3Client.send(
+  const result = await s3ServerClient.send(
     new GetObjectCommand({
       Bucket: s3Config.bucket,
       Key: s3Key,

--- a/server/extensions/attachment/mods/s3/deleteObject.ts
+++ b/server/extensions/attachment/mods/s3/deleteObject.ts
@@ -1,7 +1,8 @@
 // Deletes an S3 object by key.
+// Direct server-side operation — uses the internal endpoint client.
 import { DeleteObjectCommand } from '@aws-sdk/client-s3';
-import { s3Client, s3Config } from '../../common/config/s3';
+import { s3ServerClient, s3Config } from '../../common/config/s3';
 
 export async function deleteObject({ s3Key }: { s3Key: string }): Promise<void> {
-  await s3Client.send(new DeleteObjectCommand({ Bucket: s3Config.bucket, Key: s3Key }));
+  await s3ServerClient.send(new DeleteObjectCommand({ Bucket: s3Config.bucket, Key: s3Key }));
 }

--- a/server/extensions/attachment/mods/s3/headObject.ts
+++ b/server/extensions/attachment/mods/s3/headObject.ts
@@ -1,10 +1,11 @@
 // Checks that an S3 object exists without downloading it.
+// Direct server-side operation — uses the internal endpoint client.
 import { HeadObjectCommand } from '@aws-sdk/client-s3';
-import { s3Client, s3Config } from '../../common/config/s3';
+import { s3ServerClient, s3Config } from '../../common/config/s3';
 
 export async function headObject({ s3Key }: { s3Key: string }): Promise<boolean> {
   try {
-    await s3Client.send(new HeadObjectCommand({ Bucket: s3Config.bucket, Key: s3Key }));
+    await s3ServerClient.send(new HeadObjectCommand({ Bucket: s3Config.bucket, Key: s3Key }));
     return true;
   } catch (err: any) {
     if (err?.name === 'NotFound' || err?.$metadata?.httpStatusCode === 404) {

--- a/server/extensions/attachment/workers/thumbnail.ts
+++ b/server/extensions/attachment/workers/thumbnail.ts
@@ -2,9 +2,10 @@
 // Called after virus scan marks an attachment as READY.
 // Stores the thumbnail at thumbnails/<card_id>/<attachment_id>.webp in S3
 // and updates thumbnail_key, width, height columns in the DB.
+// Direct server-side operations — uses the internal endpoint client.
 import sharp from 'sharp';
 import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
-import { s3Client, s3Config } from '../common/config/s3';
+import { s3ServerClient, s3Config } from '../common/config/s3';
 import { db } from '../../../common/db';
 
 const THUMBNAIL_MAX_WIDTH = 400;
@@ -29,7 +30,7 @@ export async function generateThumbnail({ attachmentId }: { attachmentId: string
   if (!attachment.s3_key) return;
 
   // Download original file from S3
-  const getResult = await s3Client.send(
+  const getResult = await s3ServerClient.send(
     new GetObjectCommand({ Bucket: s3Config.bucket, Key: attachment.s3_key }),
   );
 
@@ -63,7 +64,7 @@ export async function generateThumbnail({ attachmentId }: { attachmentId: string
 
   const thumbnailKey = `thumbnails/${attachment.card_id}/${attachmentId}.webp`;
 
-  await s3Client.send(
+  await s3ServerClient.send(
     new PutObjectCommand({
       Bucket: s3Config.bucket,
       Key: thumbnailKey,

--- a/server/extensions/board/api/uploadBackground.ts
+++ b/server/extensions/board/api/uploadBackground.ts
@@ -9,7 +9,7 @@ import {
   type WorkspaceScopedRequest,
 } from '../../../middlewares/permissionManager';
 import { requireBoardWritable, type BoardScopedRequest } from '../middlewares/requireBoardWritable';
-import { s3Client, s3Config } from '../../attachment/common/config/s3';
+import { s3ServerClient, s3Config } from '../../attachment/common/config/s3';
 import { deleteObject } from '../../attachment/mods/s3/deleteObject';
 import { env } from '../../../config/env';
 import { resolveBackgroundUrl } from '../common/resolveBackgroundUrl';
@@ -107,7 +107,8 @@ export async function handleUploadBackground(req: Request, boardId: string): Pro
   }
 
   const rawBuffer = Buffer.from(await file.arrayBuffer());
-  await s3Client.send(
+  // Direct server-side PUT — uses the internal endpoint client.
+  await s3ServerClient.send(
     new PutObjectCommand({
       Bucket: s3Config.bucket,
       Key: s3Key,

--- a/server/extensions/users/api/avatar/upload.ts
+++ b/server/extensions/users/api/avatar/upload.ts
@@ -2,7 +2,7 @@
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { db } from '../../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../../auth/middlewares/authentication';
-import { s3Client, s3Config } from '../../../attachment/common/config/s3';
+import { s3ServerClient, s3Config } from '../../../attachment/common/config/s3';
 import { env } from '../../../../config/env';
 import { resizeAvatar, avatarExtension, isValidAvatarFile } from '../../../../mods/imageProcessor';
 import { deleteObject } from '../../../attachment/mods/s3/deleteObject';
@@ -64,7 +64,8 @@ export async function handleUploadAvatar(req: Request): Promise<Response> {
     }
   }
 
-  await s3Client.send(
+  // Direct server-side PUT — uses the internal endpoint client.
+  await s3ServerClient.send(
     new PutObjectCommand({
       Bucket: s3Config.bucket,
       Key: s3Key,

--- a/specs/changelog/20260907_153000.md
+++ b/specs/changelog/20260907_153000.md
@@ -1,0 +1,56 @@
+# S3 public/internal endpoint split
+
+## Summary
+
+Server-side S3 object operations no longer hairpin through the public endpoint.
+A new optional `S3_INTERNAL_ENDPOINT` env var routes all direct server → S3
+calls (Head/Delete/Get/Put, bucket bootstrap, multipart control, thumbnails,
+avatars, board backgrounds) to an internal/direct address (e.g.
+`http://object-store:9000`), while browser-facing presigned URLs continue to be
+generated against the public `S3_ENDPOINT`.
+
+## Problem
+
+In production, the public `S3_ENDPOINT` sits behind a proxy. A browser
+presigned PUT through the public endpoint succeeds, but the immediate
+server-side `HeadObject` through the same public endpoint intermittently
+returns `Unknown`/403 while the identical call against the internal
+object-store endpoint returns 200 — a proxy
+read-after-write race. Server object operations must go direct, not through the
+public proxy.
+
+## Changes
+
+- `server/config/env.ts` — added `S3_INTERNAL_ENDPOINT` (defaults to `''`,
+  falls back to `S3_ENDPOINT` when unset).
+- `server/extensions/attachment/common/config/s3.ts` — split the singleton
+  client into:
+  - `s3Client` (public) — presigning only: presigned PUT, presigned GET
+    helpers/redirects, multipart part URLs.
+  - `s3ServerClient` (internal) — every direct server operation:
+    `ensureBucketExists`, `headObject`, `deleteObject`, `proxyS3Object`,
+    thumbnail Get/Put, multipart create/complete/abort, avatar Put,
+    board-background Put.
+- `server/extensions/attachment/mods/s3/headObject.ts`,
+  `server/extensions/attachment/mods/s3/deleteObject.ts`,
+  `server/extensions/attachment/common/proxyS3Object.ts`,
+  `server/extensions/attachment/workers/thumbnail.ts`,
+  `server/extensions/attachment/api/multipart/start.ts`,
+  `server/extensions/attachment/api/multipart/complete.ts`,
+  `server/extensions/attachment/api/multipart/abort.ts`,
+  `server/extensions/users/api/avatar/upload.ts`,
+  `server/extensions/board/api/uploadBackground.ts`
+  — switched direct operations from `s3Client` to `s3ServerClient`.
+- `.env.example` — documented `S3_INTERNAL_ENDPOINT`.
+- `server/extensions/attachment/common/config/s3.test.ts` — regression test
+  asserting the split (public client endpoint, server client endpoint,
+  presigned URL host, and that `headObject` sends via the server client and
+  never the public client). Written RED first, then implemented to GREEN.
+
+## Compatibility
+
+- `S3_INTERNAL_ENDPOINT` unset ⇒ `s3ServerClient` falls back to
+  `S3_ENDPOINT` — behavior identical to before.
+- CSP `img-src`/`connect-src` and all generated public URLs still use
+  `S3_ENDPOINT`.
+- Presigned URLs still sign over the public host, so no client changes.


### PR DESCRIPTION
## Problem

Browser uploads can use a public S3-compatible endpoint behind a CDN or reverse proxy. After a successful presigned PUT, ChimeDeck immediately checks the object using that same public endpoint. In the reproduced deployment, the immediate public `HeadObject` returned HTTP 403 while the same request to the direct object-store endpoint returned HTTP 200, so attachment confirmation incorrectly returned `upload-url-expired`.

## Approach

- Add optional `S3_INTERNAL_ENDPOINT`, falling back to `S3_ENDPOINT` for compatibility.
- Keep `s3Client` on the public endpoint for browser-facing presigned PUT/GET and multipart part URLs.
- Route direct server-side S3 operations through `s3ServerClient`: bucket setup, object HEAD/GET/PUT/DELETE, thumbnails, avatar/background uploads, and multipart create/complete/abort.
- Document the variable and the client split.
- Add an order-independent regression test that isolates the S3 singleton configuration in a child process.

## Verification

- `bun test server/extensions/attachment/common/config/s3.test.ts` — 1 passed, 0 failed. The isolated child covers four assertions.
- Sabotage check: routing `headObject` back through the public client makes the regression test fail; restoring the split makes it pass.
- `bunx eslint server/extensions/attachment/common/config/s3.test.ts` — passed.
- Prettier and `git diff --check` — passed.
- Client production build — passed.
- Full typecheck and integration suites remain red from pre-existing unrelated default-branch failures; baseline comparison found no new type errors and removed the prior S3 endpoint typing error.

## Compatibility and rollout

`S3_INTERNAL_ENDPOINT` is optional. Existing installations retain the old behavior when it is unset. Self-hosted deployments with a proxy/CDN in front of object storage should point it at their direct service endpoint, such as `http://object-store:9000`.
