### PR TITLE
fix(attachments): encode Unicode content disposition

### DIFF
--- a/server/extensions/attachment/common/contentDisposition.test.ts
+++ b/server/extensions/attachment/common/contentDisposition.test.ts
@@ -1,0 +1,137 @@
+// Unit tests for Unicode-safe Content-Disposition header building.
+// Covers: diacritics, emoji, apostrophes/parentheses, quote/backslash
+// stripping, CRLF/control stripping, inline vs attachment, ASCII-only
+// output, RFC 5987 `filename*=UTF-8''...` encoding (including `'()*`),
+// and construction of a real Headers/Response without throwing.
+import { describe, expect, it } from 'bun:test';
+
+import { buildContentDisposition } from './contentDisposition';
+
+const PRINTABLE_ASCII = /^[\x20-\x7E]*$/;
+const HEADER_SHAPE = /^(inline|attachment); filename="[^"]*"; filename\*=UTF-8''[!-~]+$/;
+
+describe('buildContentDisposition', () => {
+  it('returns null when no usable filename is provided', () => {
+    expect(buildContentDisposition(null)).toBeNull();
+    expect(buildContentDisposition(undefined)).toBeNull();
+    expect(buildContentDisposition('')).toBeNull();
+    expect(buildContentDisposition('   ')).toBeNull();
+    expect(buildContentDisposition('"\r\n"')).toBeNull();
+  });
+
+  it('defaults to attachment and keeps plain ASCII names unchanged', () => {
+    expect(buildContentDisposition('report.pdf')).toBe(
+      'attachment; filename="report.pdf"; filename*=UTF-8\'\'report.pdf'
+    );
+  });
+
+  it('supports the inline disposition', () => {
+    expect(buildContentDisposition('preview.png', 'inline')).toBe(
+      'inline; filename="preview.png"; filename*=UTF-8\'\'preview.png'
+    );
+  });
+
+  it('folds diacritics to a deterministic ASCII fallback', () => {
+    expect(buildContentDisposition('café.pdf')).toBe(
+      'attachment; filename="cafe.pdf"; filename*=UTF-8\'\'caf%C3%A9.pdf'
+    );
+    expect(buildContentDisposition('João.jpg')).toBe(
+      'attachment; filename="Joao.jpg"; filename*=UTF-8\'\'Jo%C3%A3o.jpg'
+    );
+  });
+
+  it('replaces non-Latin characters with underscores in the fallback', () => {
+    expect(buildContentDisposition('文档.pdf')).toBe(
+      'attachment; filename="__.pdf"; filename*=UTF-8\'\'%E6%96%87%E6%A1%A3.pdf'
+    );
+  });
+
+  it('replaces emoji with an underscore in the fallback and encodes them for filename*', () => {
+    expect(buildContentDisposition('📊 report.xlsx')).toBe(
+      'attachment; filename="_ report.xlsx"; filename*=UTF-8\'\'%F0%9F%93%8A%20report.xlsx'
+    );
+  });
+
+  it('keeps apostrophes and parentheses in the quoted fallback but encodes them for filename*', () => {
+    expect(buildContentDisposition("John's (final).txt")).toBe(
+      "attachment; filename=\"John's (final).txt\"; filename*=UTF-8''John%27s%20%28final%29.txt"
+    );
+  });
+
+  it("encodes the RFC 5987 reserved characters '()* and %", () => {
+    expect(buildContentDisposition('star*100%.pdf')).toBe(
+      'attachment; filename="star*100%.pdf"; filename*=UTF-8\'\'star%2A100%25.pdf'
+    );
+  });
+
+  it('strips double quotes and backslashes from both variants', () => {
+    expect(buildContentDisposition('a"b\\c.pdf')).toBe(
+      'attachment; filename="abc.pdf"; filename*=UTF-8\'\'abc.pdf'
+    );
+  });
+
+  it('strips CRLF and other control characters', () => {
+    expect(buildContentDisposition('bad\r\nname.pdf')).toBe(
+      'attachment; filename="badname.pdf"; filename*=UTF-8\'\'badname.pdf'
+    );
+    expect(buildContentDisposition('\u0000\u001Fx.pdf\u007F')).toBe(
+      'attachment; filename="x.pdf"; filename*=UTF-8\'\'x.pdf'
+    );
+  });
+
+  it('strips path separators and C1 controls', () => {
+    expect(buildContentDisposition('folder/report\u0085.pdf')).toBe(
+      'attachment; filename="folderreport.pdf"; filename*=UTF-8\'\'folderreport.pdf'
+    );
+  });
+
+  it('handles degenerate and malformed names deterministically', () => {
+    for (const name of ['/', '\\', '.', '..', ' /..\\ ']) {
+      expect(buildContentDisposition(name)).toBeNull();
+    }
+    expect(buildContentDisposition('\u0301')).toBe(
+      'attachment; filename="download"; filename*=UTF-8\'\'%CC%81'
+    );
+    expect(buildContentDisposition('bad\uD800.txt')).toBe(
+      'attachment; filename="bad_.txt"; filename*=UTF-8\'\'bad%EF%BF%BD.txt'
+    );
+  });
+
+  it('always produces printable-ASCII-only header values', () => {
+    const gnarly = [
+      'café.pdf',
+      '📊 report.xlsx',
+      "John's (final).txt",
+      'a"b\\c.pdf',
+      'bad\r\nname.pdf',
+      '文档.pdf',
+      'Ünïcödé (tüfe).txt',
+      "emoji 🎉 'quote' (paren) *star*.bin",
+    ];
+    for (const name of gnarly) {
+      const header = buildContentDisposition(name);
+      expect(header).not.toBeNull();
+      expect(header).toMatch(PRINTABLE_ASCII);
+      expect(header).toMatch(HEADER_SHAPE);
+    }
+  });
+
+  it('builds a real Headers object and Response without throwing', () => {
+    const header = buildContentDisposition('📊 résumé (final) "v2"\r\n.pdf');
+    expect(header).not.toBeNull();
+
+    const headers = new Headers();
+    expect(() => {
+      headers.set('Content-Disposition', header as string);
+    }).not.toThrow();
+    expect(headers.get('Content-Disposition')).toBe(header);
+    expect(() => new Response(null, { headers })).not.toThrow();
+  });
+
+  it('percent-encoded filename* decodes back to the sanitized original', () => {
+    const header = buildContentDisposition('📊 résumé (final) "v2"\r\n.pdf');
+    const encoded = (header as string).match(/filename\*=UTF-8''(.+)$/)?.[1];
+    expect(encoded).toBeDefined();
+    expect(decodeURIComponent(encoded as string)).toBe('📊 résumé (final) v2.pdf');
+  });
+});

--- a/server/extensions/attachment/common/contentDisposition.ts
+++ b/server/extensions/attachment/common/contentDisposition.ts
@@ -1,0 +1,38 @@
+// RFC 6266/5987: a quoted ASCII fallback plus the sanitized UTF-8 filename.
+// Strip controls and path/quoted-string delimiters before building either value.
+// eslint-disable-next-line no-control-regex
+const UNSAFE_FILENAME_CHARACTERS = /[\u0000-\u001F\u007F-\u009F"\\/]/g;
+const COMBINING_MARKS = /[\u0300-\u036F]/g;
+const RFC5987_EXTRA = /['()*]/g;
+
+export type ContentDispositionType = 'inline' | 'attachment';
+
+function toAsciiFallback(sanitized: string): string {
+  const folded = sanitized.normalize('NFD').replace(COMBINING_MARKS, '');
+  let fallback = '';
+  for (const ch of folded) {
+    fallback += ch >= '\u0020' && ch <= '\u007E' ? ch : '_';
+  }
+  return fallback || 'download';
+}
+
+function toRfc5987Value(sanitized: string): string {
+  return encodeURIComponent(sanitized).replace(
+    RFC5987_EXTRA,
+    (ch) => `%${ch.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0')}`
+  );
+}
+
+export function buildContentDisposition(
+  filename: string | null | undefined,
+  disposition: ContentDispositionType = 'attachment'
+): string | null {
+  const sanitized = (filename ?? '')
+    .replace(UNSAFE_FILENAME_CHARACTERS, '')
+    // In Unicode mode this matches lone surrogates, preserving valid pairs.
+    .replace(/[\uD800-\uDFFF]/gu, '\uFFFD')
+    .trim();
+  if (!sanitized || /^\.+$/.test(sanitized)) return null;
+
+  return `${disposition}; filename="${toAsciiFallback(sanitized)}"; filename*=UTF-8''${toRfc5987Value(sanitized)}`;
+}

--- a/server/extensions/attachment/common/proxyS3Object.ts
+++ b/server/extensions/attachment/common/proxyS3Object.ts
@@ -1,4 +1,5 @@
 import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { buildContentDisposition } from './contentDisposition';
 import { s3ServerClient, s3Config } from './config/s3';
 
 function toReadableStream(body: unknown): ReadableStream<Uint8Array> | null {
@@ -62,10 +63,9 @@ export async function proxyS3Object({
   // Private resources: avoid browser/proxy caching across users.
   headers.set('Cache-Control', 'private, no-store');
 
-  const rawFilename = fallbackFilename?.trim();
-  if (rawFilename) {
-    const escapedFilename = rawFilename.replaceAll('"', '');
-    headers.set('Content-Disposition', `${contentDisposition}; filename="${escapedFilename}"`);
+  const contentDispositionHeader = buildContentDisposition(fallbackFilename, contentDisposition);
+  if (contentDispositionHeader) {
+    headers.set('Content-Disposition', contentDispositionHeader);
   }
 
   return new Response(stream, { status: 200, headers });

--- a/server/extensions/attachment/common/proxyS3Object.ts
+++ b/server/extensions/attachment/common/proxyS3Object.ts
@@ -12,7 +12,7 @@ function toReadableStream(body: unknown): ReadableStream<Uint8Array> | null {
   if (body instanceof ReadableStream) return body as ReadableStream<Uint8Array>;
 
   const asyncIterable = body as AsyncIterable<Uint8Array>;
-  if (typeof asyncIterable?.[Symbol.asyncIterator] !== 'function') return null;
+  if (typeof asyncIterable[Symbol.asyncIterator] !== 'function') return null;
 
   const iterator = asyncIterable[Symbol.asyncIterator]();
   return new ReadableStream<Uint8Array>({


### PR DESCRIPTION
## Problem

Attachment proxy responses placed the stored filename directly in the quoted `filename=` parameter. Runtime header validation rejects non-ASCII values, so otherwise valid files with Unicode names returned HTTP 500 when viewed or downloaded.

## Approach

- Add a pure RFC 6266/5987 `Content-Disposition` builder.
- Emit an ASCII-safe quoted `filename=` fallback.
- Emit `filename*=UTF-8''...` with the sanitized original filename percent-encoded for Unicode-capable clients.
- Strip control characters and path/quoted-string delimiters before constructing either value.
- Use the helper for both inline views and downloads.

## Verification

- Focused unit suite: 15 passed, 0 failed, 54 assertions.
- The test suite constructs real `Headers` and `Response` instances with Unicode filenames.
- RED verified before implementation because the helper was absent; the old raw-header behavior is covered by the real-header assertion.
- ESLint and Prettier passed for the new helper and test.
- Production client build and `git diff --check` passed.
- Deployment-identifier scan across the commit passed.

## Compatibility

ASCII filenames retain a readable quoted fallback. Unicode-aware browsers recover the sanitized original from `filename*`. Empty or unsafe-only names omit the optional header rather than constructing an invalid response.
