### PR TITLE
fix(attachments): type multipart upload start

### DIFF
--- a/server/extensions/attachment/api/multipart/start.ts
+++ b/server/extensions/attachment/api/multipart/start.ts
@@ -14,6 +14,43 @@ import { s3Client, s3Config } from '../../common/config/s3';
 import { ALLOWED_MIME_TYPES, MAX_FILE_SIZE_BYTES } from '../../config/allowedTypes';
 import { resolveCardId } from '../../../../common/ids/resolveEntityId';
 import { generateUniqueShortId } from '../../../../common/ids/shortId';
+import { buildUploadS3Key } from '../uploadKey';
+
+interface MultipartStartBody {
+  filename?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+}
+
+interface CardRow {
+  id: string;
+  list_id: string;
+}
+
+interface ListRow {
+  id: string;
+  board_id: string;
+}
+
+interface BoardRow {
+  id: string;
+  workspace_id: string;
+}
+
+interface PendingAttachmentRow {
+  id: string;
+  short_id: string;
+  card_id: string;
+  uploaded_by: string;
+  name: string;
+  type: 'FILE';
+  s3_key: string;
+  s3_bucket: string;
+  mime_type: string;
+  size_bytes: number;
+  status: 'PENDING';
+  created_at: string;
+}
 
 export async function handleMultipartStart(req: Request, cardId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
@@ -24,9 +61,9 @@ export async function handleMultipartStart(req: Request, cardId: string): Promis
     return Response.json({ name: 'card-not-found', data: { cardId } }, { status: 404 });
   }
 
-  let body: { filename?: string; mimeType?: string; sizeBytes?: number };
+  let body: MultipartStartBody;
   try {
-    body = (await req.json()) as typeof body;
+    body = (await req.json()) as MultipartStartBody;
   } catch {
     return Response.json({ name: 'bad-request', data: { message: 'Invalid JSON body' } }, { status: 400 });
   }
@@ -49,13 +86,13 @@ export async function handleMultipartStart(req: Request, cardId: string): Promis
     );
   }
 
-  const card = await db('cards').where({ id: resolvedCardId }).first();
+  const card = await db<CardRow>('cards').where({ id: resolvedCardId }).first();
   if (!card) {
     return Response.json({ name: 'card-not-found', data: { cardId } }, { status: 404 });
   }
 
-  const list = await db('lists').where({ id: card.list_id }).first();
-  const board = list ? await db('boards').where({ id: list.board_id }).first() : null;
+  const list = await db<ListRow>('lists').where({ id: card.list_id }).first();
+  const board = list ? await db<BoardRow>('boards').where({ id: list.board_id }).first() : null;
   if (!board) {
     return Response.json({ name: 'board-not-found', data: {} }, { status: 404 });
   }
@@ -66,10 +103,15 @@ export async function handleMultipartStart(req: Request, cardId: string): Promis
   const roleError = await requireMemberOrBoardGuestMember(scopedReq, board.id);
   if (roleError) return roleError;
 
-  const actorId = (req as AuthenticatedRequest).currentUser!.id;
+  const actor = (req as AuthenticatedRequest).currentUser;
+  if (!actor) {
+    return Response.json({ name: 'unauthorized', data: { message: 'Authentication required' } }, { status: 401 });
+  }
+
+  const actorId = actor.id;
   const attachmentId = randomUUID();
   const shortId = await generateUniqueShortId('attachments');
-  const s3Key = `attachments/${resolvedCardId}/${attachmentId}/${body.filename}`;
+  const s3Key = buildUploadS3Key(resolvedCardId, attachmentId, body.filename);
 
   const createCmd = new CreateMultipartUploadCommand({
     Bucket: s3Config.bucket,
@@ -87,7 +129,7 @@ export async function handleMultipartStart(req: Request, cardId: string): Promis
     return Response.json({ name: 's3-error', data: { message: 'Failed to initiate multipart upload' } }, { status: 502 });
   }
 
-  await db('attachments').insert({
+  await db<PendingAttachmentRow>('attachments').insert({
     id: attachmentId,
     short_id: shortId,
     card_id: resolvedCardId,


### PR DESCRIPTION
## Summary
- type multipart-start database boundaries
- reuse the tested upload object-key contract
- replace unsafe authenticated-user assertion with a safe guard

## Validation
- existing upload-key regression test
- focused ESLint
- multipart integration fixture remains baseline-red from invalid JWT test setup, outside this slice
- `bun run typecheck` (baseline-red; no multipart-start diagnostics)
- `bun run build:client`
- `git diff --check`
- full `bun test` reporting: 805 pass, 3 skip, 118 fail, 93 errors (baseline suite debt)