### PR TITLE
fix(attachments): type multipart upload abort

### DIFF
--- a/server/extensions/attachment/api/multipart/abort.ts
+++ b/server/extensions/attachment/api/multipart/abort.ts
@@ -11,6 +11,28 @@ import {
 import { s3Client, s3Config } from '../../common/config/s3';
 import { resolveCardId } from '../../../../common/ids/resolveEntityId';
 
+interface CardRow {
+  id: string;
+  list_id: string;
+}
+
+interface ListRow {
+  id: string;
+  board_id: string;
+}
+
+interface BoardRow {
+  id: string;
+  workspace_id: string;
+}
+
+interface PendingAttachmentRow {
+  id: string;
+  card_id: string;
+  s3_key: string;
+  status: 'PENDING';
+}
+
 export async function handleMultipartAbort(
   req: Request,
   cardId: string,
@@ -34,13 +56,13 @@ export async function handleMultipartAbort(
     );
   }
 
-  const card = await db('cards').where({ id: resolvedCardId }).first();
+  const card = await db<CardRow>('cards').where({ id: resolvedCardId }).first();
   if (!card) {
     return Response.json({ name: 'card-not-found', data: { cardId } }, { status: 404 });
   }
 
-  const list = await db('lists').where({ id: card.list_id }).first();
-  const board = list ? await db('boards').where({ id: list.board_id }).first() : null;
+  const list = await db<ListRow>('lists').where({ id: card.list_id }).first();
+  const board = list ? await db<BoardRow>('boards').where({ id: list.board_id }).first() : null;
   if (!board) {
     return Response.json({ name: 'board-not-found', data: {} }, { status: 404 });
   }
@@ -52,7 +74,7 @@ export async function handleMultipartAbort(
   if (roleError) return roleError;
 
   // Verify the S3 key belongs to a pending attachment on this card
-  const attachment = await db('attachments')
+  const attachment = await db<PendingAttachmentRow>('attachments')
     .where({ card_id: resolvedCardId, s3_key: s3Key, status: 'PENDING' })
     .first();
   if (!attachment) {
@@ -77,7 +99,7 @@ export async function handleMultipartAbort(
   }
 
   // Remove the PENDING attachment row so it does not accumulate as an orphan
-  await db('attachments').where({ id: attachment.id }).delete();
+  await db<PendingAttachmentRow>('attachments').where({ id: attachment.id }).delete();
 
   return new Response(null, { status: 204 });
 }


### PR DESCRIPTION
## Summary
- type multipart-abort database boundaries
- preserve card-scoped pending-attachment validation and best-effort S3 cleanup

## Validation
- focused ESLint
- multipart integration fixture remains baseline-red from invalid JWT setup, outside this slice
- `bun run typecheck` (baseline-red; no multipart-abort diagnostics)
- `bun run build:client`
- `git diff --check`
- full `bun test` reporting: 805 pass, 3 skip, 118 fail, 93 errors (baseline suite debt)