### PR TITLE
fix(attachments): clarify link preview timeout callback

### DIFF
--- a/server/extensions/attachment/api/linkPreview.ts
+++ b/server/extensions/attachment/api/linkPreview.ts
@@ -40,7 +40,9 @@ export async function handleLinkPreview(req: Request): Promise<Response> {
 /** Fetch up to HTML_LIMIT bytes from the URL and extract the page title. Returns null on failure. */
 async function fetchPageTitle(rawUrl: string): Promise<string | null> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  const timer = setTimeout(() => {
+    controller.abort();
+  }, FETCH_TIMEOUT_MS);
   try {
     const resp = await fetch(rawUrl, {
       signal: controller.signal,


### PR DESCRIPTION
## Summary
- make the link-preview timeout callback explicit to satisfy strict ESLint
- preserve timeout and abort behaviour

## Validation
- focused ESLint: passed
- client build: passed
- git diff --check: passed
- typecheck: baseline-red; no linkPreview.ts diagnostics
- full Bun suite: baseline unchanged (805 passed, 3 skipped, 118 failed, 93 errors)