### PR TITLE
fix(attachments): type thumbnail retrieval

### DIFF
--- a/server/extensions/attachment/api/thumbnail.ts
+++ b/server/extensions/attachment/api/thumbnail.ts
@@ -9,18 +9,42 @@ import {
 } from '../../../middlewares/permissionManager';
 import { proxyS3Object } from '../common/proxyS3Object';
 
+interface ThumbnailAttachmentRow {
+  id: string;
+  card_id: string;
+  thumbnail_key: string | null;
+  status: 'PENDING' | 'REJECTED' | 'READY';
+  alias: string | null;
+  name: string | null;
+}
+
+interface CardRow {
+  id: string;
+  list_id: string;
+}
+
+interface ListRow {
+  id: string;
+  board_id: string;
+}
+
+interface BoardRow {
+  id: string;
+  workspace_id: string;
+}
+
 export async function handleThumbnailAttachment(req: Request, attachmentId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const attachment = await db('attachments').where({ id: attachmentId }).first();
+  const attachment = await db<ThumbnailAttachmentRow>('attachments').where({ id: attachmentId }).first();
   if (!attachment) {
     return Response.json({ name: 'attachment-not-found', data: { message: 'Attachment not found' } }, { status: 404 });
   }
 
-  const card = await db('cards').where({ id: attachment.card_id }).first();
-  const list = card ? await db('lists').where({ id: card.list_id }).first() : null;
-  const board = list ? await db('boards').where({ id: list.board_id }).first() : null;
+  const card = await db<CardRow>('cards').where({ id: attachment.card_id }).first();
+  const list = card ? await db<ListRow>('lists').where({ id: card.list_id }).first() : null;
+  const board = list ? await db<BoardRow>('boards').where({ id: list.board_id }).first() : null;
   if (!board) {
     return Response.json({ name: 'board-not-found', data: { message: 'Board not found' } }, { status: 404 });
   }


### PR DESCRIPTION
## Summary
- type attachment, card, list and board query boundaries in thumbnail retrieval
- preserve membership checks and pending/rejected/missing thumbnail responses

## Validation
- focused ESLint: passed
- client build: passed
- git diff --check: passed
- typecheck: baseline-red; no thumbnail.ts diagnostics
- full Bun suite: baseline report (821 passed, 3 skipped, 118 failed, 93 errors)