### PR TITLE
fix(cards): type list card retrieval

### DIFF
--- a/server/extensions/card/api/list.ts
+++ b/server/extensions/card/api/list.ts
@@ -8,11 +8,27 @@ import {
 import { buildAvatarProxyUrlsInCollection } from '../../../common/avatar/resolveAvatarUrl';
 import { resolveCoverImageUrls } from '../../../common/cards/cover';
 
+interface ListRow {
+  id: string;
+  board_id: string;
+}
+
+interface BoardRow {
+  id: string;
+  workspace_id: string;
+}
+
+interface CardListRow extends Record<string, unknown> {
+  id: string;
+  cover_attachment_id: string | null;
+  members: Array<{ avatar_url?: string | null } & Record<string, unknown>>;
+}
+
 export async function handleListCards(req: Request, listId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const list = await db('lists').where({ id: listId }).first();
+  const list = await db<ListRow>('lists').where({ id: listId }).first();
   if (!list) {
     return Response.json(
       { error: { code: 'list-not-found', message: 'List not found' } },
@@ -20,7 +36,7 @@ export async function handleListCards(req: Request, listId: string): Promise<Res
     );
   }
 
-  const board = await db('boards').where({ id: list.board_id }).first();
+  const board = await db<BoardRow>('boards').where({ id: list.board_id }).first();
   if (!board) {
     return Response.json(
       { error: { code: 'board-not-found', message: 'Board not found' } },
@@ -47,7 +63,7 @@ export async function handleListCards(req: Request, listId: string): Promise<Res
 
   // WHY: aggregate labels and members in a single query so card tiles have
   // all data needed for Sprint 27 (label chips) and Sprint 28 (member avatars).
-  const cardsBaseQuery = db('cards as c')
+  const cardsBaseQuery = db<CardListRow>('cards as c')
     .where({ 'c.list_id': listId, 'c.archived': false })
     .orderBy('c.position', 'asc')
     .select(
@@ -93,18 +109,12 @@ export async function handleListCards(req: Request, listId: string): Promise<Res
     cardsBaseQuery.limit(limit).offset(offset);
   }
 
-  const rows = await cardsBaseQuery;
+  const rows = (await cardsBaseQuery) as CardListRow[];
 
-  const data = await Promise.all(
-    rows.map(async (row) => ({
-      ...row,
-      members: buildAvatarProxyUrlsInCollection(
-          Array.isArray(row.members)
-            ? (row.members as Array<{ avatar_url?: string | null } & Record<string, unknown>>)
-            : [],
-        ),
-    })),
-  );
+  const data = rows.map((row) => ({
+    ...row,
+    members: buildAvatarProxyUrlsInCollection(row.members),
+  }));
 
   const cardsWithCovers = await resolveCoverImageUrls(
     data as Array<{ id: string; cover_attachment_id?: string | null } & Record<string, unknown>>,


### PR DESCRIPTION
## Summary
- type list/board membership and aggregate card query boundaries
- preserve pagination, label/member aggregation and avatar/cover enrichment
- remove a redundant async mapper

## Validation
- focused ESLint: passed
- client build: passed
- git diff --check: passed
- typecheck: baseline-red; no list.ts diagnostics
- full Bun suite: baseline unchanged (821 passed, 3 skipped, 118 failed, 93 errors)