### PR TITLE
fix(cards): type card detail retrieval

### DIFF
--- a/server/extensions/card/api/get.ts
+++ b/server/extensions/card/api/get.ts
@@ -9,11 +9,52 @@ import { VISIBLE_EVENT_TYPES } from '../../activity/config/visibleEventTypes';
 import { buildAvatarProxyUrlsInCollection } from '../../../common/avatar/resolveAvatarUrl';
 import { resolveCoverImageUrl } from '../../../common/cards/cover';
 
+interface CardRow {
+  id: string;
+  list_id: string;
+  cover_attachment_id: string | null;
+}
+
+interface ListRow {
+  id: string;
+  board_id: string;
+}
+
+interface BoardRow {
+  id: string;
+  workspace_id: string;
+  short_id: string;
+  title: string;
+}
+
+interface ChecklistRow extends Record<string, unknown> {
+  id: string;
+  card_id: string;
+  title: string;
+  position: string;
+}
+
+interface ChecklistItemRow extends Record<string, unknown> {
+  id: string;
+  checklist_id: string | null;
+}
+
+interface ActivityRow extends Record<string, unknown> {
+  actor_id: string | null;
+}
+
+interface ActorRow extends Record<string, unknown> {
+  id: string;
+  name: string | null;
+  email: string | null;
+  avatar_url: string | null;
+}
+
 export async function handleGetCard(req: Request, cardId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const card = await db('cards').where({ id: cardId }).first();
+  const card = await db<CardRow>('cards').where({ id: cardId }).first();
   if (!card) {
     return Response.json(
       { error: { code: 'card-not-found', message: 'Card not found' } },
@@ -21,8 +62,8 @@ export async function handleGetCard(req: Request, cardId: string): Promise<Respo
     );
   }
 
-  const list = await db('lists').where({ id: card.list_id }).first();
-  const board = list ? await db('boards').where({ id: list.board_id }).first() : null;
+  const list = await db<ListRow>('lists').where({ id: card.list_id }).first();
+  const board = list ? await db<BoardRow>('boards').where({ id: list.board_id }).first() : null;
 
   if (!list || !board) {
     return Response.json(
@@ -50,12 +91,12 @@ export async function handleGetCard(req: Request, cardId: string): Promise<Respo
     memberRows as Array<{ avatar_url?: string | null } & Record<string, unknown>>,
   );
 
-  const checklistRows = await db('checklists')
+  const checklistRows = await db<ChecklistRow>('checklists')
     .where({ card_id: cardId })
     .orderBy('created_at', 'asc')
     .orderBy('position', 'asc');
 
-  const checklistItems = await db('checklist_items')
+  const checklistItems = await db<ChecklistItemRow>('checklist_items')
     .where({ card_id: cardId })
     .orderBy('position', 'asc');
 
@@ -64,8 +105,9 @@ export async function handleGetCard(req: Request, cardId: string): Promise<Respo
   const itemsByChecklistId = new Map<string, typeof checklistItems>();
   for (const item of checklistItems) {
     const key = item.checklist_id ?? '__ungrouped__';
-    if (!itemsByChecklistId.has(key)) itemsByChecklistId.set(key, []);
-    itemsByChecklistId.get(key)!.push(item);
+    const items = itemsByChecklistId.get(key) ?? [];
+    items.push(item);
+    itemsByChecklistId.set(key, items);
   }
 
   const checklists = checklistRows.map((cl) => ({
@@ -84,22 +126,22 @@ export async function handleGetCard(req: Request, cardId: string): Promise<Respo
 
   let activities: unknown[] = [];
   if (includes.includes('activities')) {
-    const rows = await db('activities')
+    const rows = await db<ActivityRow>('activities')
       .where({ entity_id: cardId })
       .andWhere((qb) => {
         qb.whereIn('action', VISIBLE_EVENT_TYPES).orWhere('action', 'card.description.updated');
       })
       .orderBy('created_at', 'asc');
 
-    const actorIds = [...new Set(rows.map((a) => a.actor_id))];
+    const actorIds = [...new Set(rows.flatMap((activity) => activity.actor_id ? [activity.actor_id] : []))];
     const rawActors = actorIds.length
-      ? await db('users').whereIn('id', actorIds).select('id', 'name', 'email', 'avatar_url')
+      ? await db<ActorRow>('users').whereIn('id', actorIds).select('id', 'name', 'email', 'avatar_url')
       : [];
     const resolvedActors = buildAvatarProxyUrlsInCollection(rawActors);
     const actorMap = new Map(resolvedActors.map((u) => [u.id, u]));
 
     activities = rows.map((a) => {
-      const actor = actorMap.get(a.actor_id);
+      const actor = a.actor_id ? actorMap.get(a.actor_id) : undefined;
       return { ...a, actor_name: actor?.name ?? null, actor_email: actor?.email ?? null, actor_avatar_url: actor?.avatar_url ?? null };
     });
   }


### PR DESCRIPTION
## Summary
- type card detail query boundaries
- preserve checklist fallback and activity enrichment behaviour

## Validation
- bunx eslint server/extensions/card/api/get.ts
- bun run build:client
- bun run typecheck (baseline-red; no get.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check