### PR TITLE
fix(cards): type due date retrieval

### DIFF
--- a/server/extensions/card/api/dueDate.ts
+++ b/server/extensions/card/api/dueDate.ts
@@ -4,15 +4,18 @@ import { db } from '../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../auth/middlewares/authentication';
 import {
   requireWorkspaceMembership,
-  requireRole,
   type WorkspaceScopedRequest,
 } from '../../../middlewares/permissionManager';
+
+interface WorkspaceRow {
+  id: string;
+}
 
 export async function handleListDueCards(req: Request, workspaceId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const workspace = await db('workspaces').where({ id: workspaceId }).first();
+  const workspace = await db<WorkspaceRow>('workspaces').where({ id: workspaceId }).first();
   if (!workspace) {
     return Response.json(
       { error: { code: 'workspace-not-found', message: 'Workspace not found' } },
@@ -42,7 +45,7 @@ export async function handleListDueCards(req: Request, workspaceId: string): Pro
     );
   }
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const userId = (req as AuthenticatedRequest & { currentUser: { id: string } }).currentUser.id;
 
   // Cards assigned to caller where due_date < before, within the workspace
   const cards = await db('cards')


### PR DESCRIPTION
## Summary
- type due-date workspace lookup and post-auth actor boundary
- preserve workspace-scoped assigned-card filtering

## Validation
- bunx eslint server/extensions/card/api/dueDate.ts
- bun run build:client
- bun run typecheck (baseline-red; no dueDate.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check