### PR TITLE
fix(cards): type card deletion

### DIFF
--- a/server/extensions/card/api/delete.ts
+++ b/server/extensions/card/api/delete.ts
@@ -10,11 +10,28 @@ import {
   type WorkspaceScopedRequest,
 } from '../../../middlewares/permissionManager';
 
+type CardRow = {
+  id: string;
+  list_id: string;
+  title: string;
+};
+
+type ListRow = {
+  id: string;
+  board_id: string;
+};
+
+type BoardRow = {
+  id: string;
+  workspace_id: string;
+  state: string;
+};
+
 export async function handleDeleteCard(req: Request, cardId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const card = await db('cards').where({ id: cardId }).first();
+  const card = await db<CardRow>('cards').where({ id: cardId }).first();
   if (!card) {
     return Response.json(
       { error: { code: 'card-not-found', message: 'Card not found' } },
@@ -22,8 +39,8 @@ export async function handleDeleteCard(req: Request, cardId: string): Promise<Re
     );
   }
 
-  const list = await db('lists').where({ id: card.list_id }).first();
-  const board = list ? await db('boards').where({ id: list.board_id }).first() : null;
+  const list = await db<ListRow>('lists').where({ id: card.list_id }).first();
+  const board = list ? await db<BoardRow>('boards').where({ id: list.board_id }).first() : null;
 
   if (!list || !board) {
     return Response.json(


### PR DESCRIPTION
## Summary
- type card, list and board boundaries in the hard-delete route
- preserve archived-board protection, membership/admin gate, pre-delete notification/activity and delete event

## Validation
- bunx eslint server/extensions/card/api/delete.ts
- bun run build:client
- bun run typecheck (baseline-red; no delete.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check