### PR TITLE
fix(comments): type card comment creation

### DIFF
--- a/server/extensions/card/api/comments.ts
+++ b/server/extensions/card/api/comments.ts
@@ -19,6 +19,24 @@ import { requireCardWritable, type CardScopedRequest } from '../middlewares/requ
 import { buildAvatarProxyUrl } from '../../../common/avatar/resolveAvatarUrl';
 import { generateUniqueShortId } from '../../../common/ids/shortId';
 
+type BoardRow = {
+  id: string;
+  workspace_id: string;
+  title: string;
+};
+
+type CardTitleRow = {
+  id: string;
+  title: string;
+};
+
+type UserRow = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  avatar_url: string | null;
+};
+
 export async function handleCreateCardComment(req: Request, cardId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
@@ -27,7 +45,8 @@ export async function handleCreateCardComment(req: Request, cardId: string): Pro
   const writableError = await requireCardWritable(cardReq, cardId);
   if (writableError) return writableError;
 
-  const board = cardReq.board!;
+  const writableCardReq = cardReq as CardScopedRequest & { board: BoardRow };
+  const board = writableCardReq.board;
 
   const scopedReq = req as WorkspaceScopedRequest;
   const membershipError = await requireWorkspaceMembership(scopedReq, board.workspace_id);
@@ -62,13 +81,13 @@ export async function handleCreateCardComment(req: Request, cardId: string): Pro
     );
   }
 
-  const actorId = (req as AuthenticatedRequest).currentUser!.id;
+  const actorId = (req as AuthenticatedRequest & { currentUser: { id: string } }).currentUser.id;
   const id = randomUUID();
   const shortId = await generateUniqueShortId('comments');
   const content = sanitizeRichText(rawText.trim());
   const now = new Date().toISOString();
 
-  const card = await db('cards').where({ id: cardId }).select('title').first();
+  const card = await db<CardTitleRow>('cards').where({ id: cardId }).select('id', 'title').first();
 
   await db.transaction(async (trx) => {
     await trx('comments').insert({
@@ -101,12 +120,15 @@ export async function handleCreateCardComment(req: Request, cardId: string): Pro
       sourceText: content,
       cardId,
       boardId: board.id,
-      cardTitle: card?.title,
+      cardTitle: card?.title ?? '',
       boardName: board.title,
     });
   });
 
-  const author = await db('users').where({ id: actorId }).select('name', 'email', 'avatar_url').first();
+  const author = await db<UserRow>('users')
+    .where({ id: actorId })
+    .select('id', 'name', 'email', 'avatar_url')
+    .first();
 
   const rawPreview = content.replaceAll(/<[^>]+>/g, '');
   const commentPreview = rawPreview.length > 120 ? rawPreview.slice(0, 117) + '…' : rawPreview;


### PR DESCRIPTION
## Summary
- type board, card-title and author query boundaries in external card comment creation
- preserve comment API contract, mention sync, notification, event/activity and avatar response behaviour

## Validation
- bunx eslint server/extensions/card/api/comments.ts
- bun run build:client
- bun run typecheck (baseline-red; no comments.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check