### PR TITLE
fix(comments): type comment listing

### DIFF
--- a/server/extensions/comment/api/list.ts
+++ b/server/extensions/comment/api/list.ts
@@ -22,6 +22,43 @@ interface ReactionSummary {
   reactors: Array<{ userId: string; name: string | null }>;
 }
 
+type ReactionAggregate = {
+  count: number;
+  meReacted: boolean;
+  reactors: Array<{ userId: string; name: string | null }>;
+};
+
+interface CardRow {
+  id: string;
+  list_id: string;
+}
+
+interface ListRow {
+  id: string;
+  board_id: string;
+}
+
+interface BoardRow {
+  id: string;
+  workspace_id: string;
+}
+
+interface CommentListRow {
+  id: string;
+  card_id: string;
+  user_id: string;
+  content: string;
+  version: number;
+  deleted: boolean;
+  parent_id: string | null;
+  created_at: string | Date;
+  updated_at: string | Date;
+  author_name: string | null;
+  author_email: string | null;
+  author_avatar_url: string | null;
+  reply_count: number;
+}
+
 export async function handleListComments(req: Request, cardId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
@@ -34,7 +71,7 @@ export async function handleListComments(req: Request, cardId: string): Promise<
     );
   }
 
-  const card = await db('cards').where({ id: resolvedCardId }).first();
+  const card = await db<CardRow>('cards').where({ id: resolvedCardId }).first();
   if (!card) {
     return Response.json(
       { error: { code: 'card-not-found', message: 'Card not found' } },
@@ -42,8 +79,8 @@ export async function handleListComments(req: Request, cardId: string): Promise<
     );
   }
 
-  const list = await db('lists').where({ id: card.list_id }).first();
-  const board = list ? await db('boards').where({ id: list.board_id }).first() : null;
+  const list = await db<ListRow>('lists').where({ id: card.list_id }).first();
+  const board = list ? await db<BoardRow>('boards').where({ id: list.board_id }).first() : null;
   if (!board) {
     return Response.json(
       { error: { code: 'board-not-found', message: 'Board not found' } },
@@ -58,7 +95,7 @@ export async function handleListComments(req: Request, cardId: string): Promise<
   );
   if (membershipError) return membershipError;
 
-  const comments = await db('comments')
+  const comments = (await db<CommentListRow>('comments')
     .leftJoin('users', 'comments.user_id', 'users.id')
     .where('comments.card_id', resolvedCardId)
     .whereNull('comments.parent_id')
@@ -80,14 +117,14 @@ export async function handleListComments(req: Request, cardId: string): Promise<
       db.raw(
         '(SELECT COUNT(*) FROM comments AS replies WHERE replies.parent_id = comments.id AND replies.deleted = false)::int AS reply_count',
       ),
-    );
+    )) as CommentListRow[];
 
-  const callerUserId = (req as AuthenticatedRequest).currentUser!.id;
-  const commentIds = comments.map((c) => (c as Record<string, unknown>).id as string);
+  const callerUserId = (req as AuthenticatedRequest & { currentUser: { id: string } }).currentUser.id;
+  const commentIds = comments.map((comment) => comment.id);
 
   // Single extra query — no N+1; group reactions in-process.
-  const reactionRows = commentIds.length
-    ? await db('comment_reactions')
+  const reactionRows: ReactionRow[] = commentIds.length
+    ? ((await db<ReactionRow>('comment_reactions')
         .leftJoin('users as reactor', 'comment_reactions.user_id', 'reactor.id')
         .whereIn('comment_id', commentIds)
         .select(
@@ -95,24 +132,23 @@ export async function handleListComments(req: Request, cardId: string): Promise<
           'comment_reactions.emoji',
           'comment_reactions.user_id',
           db.raw("COALESCE(reactor.name, reactor.email) as reactor_name"),
-        )
+        )) as ReactionRow[])
     : [];
 
   // Build Map<commentId, Map<emoji, { count, meReacted, reactors }>>
-  const reactionMap = new Map<string, Map<string, { count: number; meReacted: boolean; reactors: Array<{ userId: string; name: string | null }> }>>();
-  for (const row of reactionRows as ReactionRow[]) {
-    if (!reactionMap.has(row.comment_id)) reactionMap.set(row.comment_id, new Map());
-    const emojiMap = reactionMap.get(row.comment_id)!;
-    const existing = emojiMap.get(row.emoji) ?? { count: 0, meReacted: false, reactors: [] };
+  const reactionMap = new Map<string, Map<string, ReactionAggregate>>();
+  for (const row of reactionRows) {
+    const emojiMap = reactionMap.get(row.comment_id) ?? new Map<string, ReactionAggregate>();
+    const existing: ReactionAggregate = emojiMap.get(row.emoji) ?? { count: 0, meReacted: false, reactors: [] };
     existing.count += 1;
     existing.reactors.push({ userId: row.user_id, name: row.reactor_name ?? null });
     if (row.user_id === callerUserId) existing.meReacted = true;
     emojiMap.set(row.emoji, existing);
+    reactionMap.set(row.comment_id, emojiMap);
   }
 
-  const data = comments.map((c) => {
-    const commentId = (c as Record<string, unknown>).id as string;
-    const emojiMap = reactionMap.get(commentId);
+  const data = comments.map((comment) => {
+    const emojiMap = reactionMap.get(comment.id);
     const reactions: ReactionSummary[] = emojiMap
       ? Array.from(emojiMap.entries())
           .map(([emoji, { count, meReacted, reactors }]) => ({ emoji, count, reactedByMe: meReacted, reactors }))
@@ -120,10 +156,10 @@ export async function handleListComments(req: Request, cardId: string): Promise<
       : [];
 
     return {
-      ...c,
+      ...comment,
       author_avatar_url: buildAvatarProxyUrl({
-        userId: (c as Record<string, unknown>).user_id as string,
-        avatarUrl: (c as Record<string, unknown>).author_avatar_url as string | null ?? null,
+        userId: comment.user_id,
+        avatarUrl: comment.author_avatar_url,
       }),
       reactions,
     };


### PR DESCRIPTION
## Summary
- type card, list, board, joined comment and reaction query boundaries in comment listing
- preserve membership checks, reply-count query, batched reaction aggregation and avatar response shaping

## Validation
- bunx eslint server/extensions/comment/api/list.ts
- bun run build:client
- bun run typecheck (baseline-red; no list.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check