### PR TITLE
fix(comments): type comment creation

### DIFF
--- a/server/extensions/comment/api/create.ts
+++ b/server/extensions/comment/api/create.ts
@@ -18,6 +18,44 @@ import { dispatchDirectCardNotification } from '../../notifications/mods/boardAc
 import { resolveCardId } from '../../../common/ids/resolveEntityId';
 import { generateUniqueShortId } from '../../../common/ids/shortId';
 
+type CardRow = {
+  id: string;
+  list_id: string;
+  title: string;
+};
+
+type ListRow = {
+  id: string;
+  board_id: string;
+};
+
+type BoardRow = {
+  id: string;
+  workspace_id: string;
+  state: string;
+  title: string;
+};
+
+type CommentRow = {
+  id: string;
+  short_id: string;
+  card_id: string;
+  user_id: string;
+  content: string;
+  idempotency_key: string | null;
+  version: number;
+  deleted: boolean;
+  parent_id: string | null;
+  created_at: string | Date;
+  updated_at: string | Date;
+};
+
+type CommentWithAuthorRow = CommentRow & {
+  author_name: string | null;
+  author_email: string | null;
+  author_avatar_url: string | null;
+};
+
 export async function handleCreateComment(req: Request, cardId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
@@ -30,7 +68,7 @@ export async function handleCreateComment(req: Request, cardId: string): Promise
     );
   }
 
-  const card = await db('cards').where({ id: resolvedCardId }).first();
+  const card = await db<CardRow>('cards').where({ id: resolvedCardId }).first();
   if (!card) {
     return Response.json(
       { error: { code: 'card-not-found', message: 'Card not found' } },
@@ -38,8 +76,8 @@ export async function handleCreateComment(req: Request, cardId: string): Promise
     );
   }
 
-  const list = await db('lists').where({ id: card.list_id }).first();
-  const board = list ? await db('boards').where({ id: list.board_id }).first() : null;
+  const list = await db<ListRow>('lists').where({ id: card.list_id }).first();
+  const board = list ? await db<BoardRow>('boards').where({ id: list.board_id }).first() : null;
   if (!board) {
     return Response.json(
       { error: { code: 'board-not-found', message: 'Board not found' } },
@@ -66,7 +104,7 @@ export async function handleCreateComment(req: Request, cardId: string): Promise
   const roleError = await requireMemberOrBoardGuestMember(scopedReq, board.id);
   if (roleError) return roleError;
 
-  const actorId = (req as AuthenticatedRequest).currentUser!.id;
+  const actorId = (req as AuthenticatedRequest & { currentUser: { id: string } }).currentUser.id;
 
   let body: { content?: string; idempotency_key?: string; parent_id?: string; parentId?: string };
   try {
@@ -104,7 +142,7 @@ export async function handleCreateComment(req: Request, cardId: string): Promise
       );
     }
     const normalizedParentId = rawParentId.trim();
-    const parentComment = await db('comments').where({ id: normalizedParentId }).first();
+    const parentComment = await db<CommentRow>('comments').where({ id: normalizedParentId }).first();
     if (!parentComment) {
       return Response.json(
         { error: { code: 'comment-not-found', message: 'Parent comment not found' } },
@@ -117,14 +155,14 @@ export async function handleCreateComment(req: Request, cardId: string): Promise
         { status: 400 }
       );
     }
-    if (parentComment.parent_id !== null && parentComment.parent_id !== undefined) {
+    if (parentComment.parent_id !== null) {
       return Response.json(
         { error: { name: 'reply-depth-exceeded', message: 'Replies to replies are not allowed' } },
         { status: 422 }
       );
     }
     parentId = normalizedParentId;
-    replyToUserId = (parentComment.user_id as string | undefined) ?? null;
+    replyToUserId = parentComment.user_id;
   }
 
   // [why] If the client provided an idempotency_key (e.g. during offline replay), check
@@ -138,7 +176,7 @@ export async function handleCreateComment(req: Request, cardId: string): Promise
       );
     }
 
-    const existing = await db('comments')
+    const existing = (await db<CommentRow>('comments')
       .leftJoin('users', 'comments.user_id', 'users.id')
       .where('comments.user_id', actorId)
       .where('comments.idempotency_key', body.idempotency_key.trim())
@@ -155,12 +193,12 @@ export async function handleCreateComment(req: Request, cardId: string): Promise
         'users.email as author_email',
         'users.avatar_url as author_avatar_url'
       )
-      .first();
+      .first()) as CommentWithAuthorRow | undefined;
 
     if (existing) {
       const authorAvatarUrl = buildAvatarProxyUrl({
         userId: actorId,
-        avatarUrl: ((existing as Record<string, unknown>).author_avatar_url as string | null) ?? null,
+        avatarUrl: existing.author_avatar_url,
       });
       return Response.json(
         { data: { ...existing, author_avatar_url: authorAvatarUrl } },
@@ -176,7 +214,7 @@ export async function handleCreateComment(req: Request, cardId: string): Promise
   let mentionedUserIds: string[] = [];
 
   await db.transaction(async (trx) => {
-    await trx('comments').insert({
+    await trx<CommentRow>('comments').insert({
       id,
       short_id: shortId,
       card_id: resolvedCardId,
@@ -214,7 +252,7 @@ export async function handleCreateComment(req: Request, cardId: string): Promise
     });
   });
 
-  const comment = await db('comments')
+  const comment = (await db<CommentRow>('comments')
     .leftJoin('users', 'comments.user_id', 'users.id')
     .where('comments.id', id)
     .select(
@@ -231,11 +269,18 @@ export async function handleCreateComment(req: Request, cardId: string): Promise
       'users.email as author_email',
       'users.avatar_url as author_avatar_url'
     )
-    .first();
+    .first()) as CommentWithAuthorRow | undefined;
+
+  if (!comment) {
+    return Response.json(
+      { error: { code: 'comment-not-found', message: 'Created comment not found' } },
+      { status: 404 }
+    );
+  }
 
   const authorAvatarUrl = buildAvatarProxyUrl({
     userId: actorId,
-    avatarUrl: ((comment as Record<string, unknown>).author_avatar_url as string | null) ?? null,
+    avatarUrl: comment.author_avatar_url,
   });
   const commentData = { ...comment, author_avatar_url: authorAvatarUrl };
 


### PR DESCRIPTION
## Summary
- type card, list, board, parent, idempotency and created-comment database boundaries
- preserve access checks, reply-depth rules, idempotency replay, sanitisation, mentions, notifications, events, activity and realtime events

## Validation
- bunx eslint server/extensions/comment/api/create.ts
- bun run build:client
- bun run typecheck (baseline-red; no create.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check