### PR TITLE
fix(boards): remove redundant activity cursor assertion

### DIFF
--- a/server/extensions/board/api/boardActivities.ts
+++ b/server/extensions/board/api/boardActivities.ts
@@ -19,7 +19,7 @@ interface CursorPayload {
 }
 
 function encodeCursor(created_at: string | Date, id: string): string {
-  const iso = typeof created_at === 'string' ? created_at : (created_at as Date).toISOString();
+  const iso = typeof created_at === 'string' ? created_at : created_at.toISOString();
   return Buffer.from(JSON.stringify({ created_at: iso, id })).toString('base64');
 }
 


### PR DESCRIPTION
## Summary
- remove redundant Date type assertion in board activity cursor encoding
- preserve timeline pagination and cursor output behaviour

## Validation
- bunx eslint server/extensions/board/api/boardActivities.ts
- bun run build:client
- bun run typecheck (baseline-red; no boardActivities.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check