### PR TITLE
fix(boards): type member retrieval context

### DIFF
--- a/server/extensions/board/api/members/get.ts
+++ b/server/extensions/board/api/members/get.ts
@@ -11,8 +11,10 @@ import {
 import { buildAvatarProxyUrl } from '../../../../common/avatar/resolveAvatarUrl';
 
 export async function handleGetBoardMembers(req: Request, boardId: string): Promise<Response> {
-  const scopedReq = req as BoardVisibilityScopedRequest;
-  const board = scopedReq.board!;
+  const scopedReq = req as BoardVisibilityScopedRequest & {
+    board: NonNullable<BoardVisibilityScopedRequest['board']>;
+  };
+  const board = scopedReq.board;
 
   // [why] Board guests should be able to see board participants, but still cannot
   // manage membership (POST/PATCH/DELETE remain ADMIN-restricted).


### PR DESCRIPTION
## Summary
- narrow board-visibility request context in board-member retrieval
- preserve guest visibility, workspace-role checks, guest filtering and avatar response shaping

## Validation
- bunx eslint server/extensions/board/api/members/get.ts
- bun run build:client
- bun run typecheck (baseline-red; no members/get.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check