### PR TITLE
fix(workspaces): type update return

### DIFF
--- a/server/extensions/workspace/api/update.ts
+++ b/server/extensions/workspace/api/update.ts
@@ -7,6 +7,11 @@ import {
   type WorkspaceScopedRequest,
 } from '../../../middlewares/permissionManager';
 
+type WorkspaceRow = {
+  id: string;
+  name: string;
+};
+
 export async function handleUpdateWorkspace(req: Request, workspaceId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
@@ -35,9 +40,9 @@ export async function handleUpdateWorkspace(req: Request, workspaceId: string): 
     );
   }
 
-  const updated = await db('workspaces')
+  const updated = (await db<WorkspaceRow>('workspaces')
     .where({ id: workspaceId })
-    .update({ name: body.name.trim() }, ['*']);
+    .update({ name: body.name.trim() }, ['*'])) as WorkspaceRow[];
 
   if (!updated.length) {
     return Response.json(


### PR DESCRIPTION
## Summary
- type workspace update-return query boundary
- preserve membership, ADMIN, validation and missing-workspace handling

## Validation
- bunx eslint server/extensions/workspace/api/update.ts
- bun run build:client
- bun run typecheck (baseline-red; no update.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check