### PR TITLE
fix(workspaces): type member removal

### DIFF
--- a/server/extensions/workspace/api/members/remove.ts
+++ b/server/extensions/workspace/api/members/remove.ts
@@ -8,6 +8,12 @@ import {
   type WorkspaceScopedRequest,
 } from '../../../../middlewares/permissionManager';
 
+type MembershipRow = {
+  user_id: string;
+  workspace_id: string;
+  role: string;
+};
+
 export async function handleRemoveMember(
   req: Request,
   workspaceId: string,
@@ -23,7 +29,7 @@ export async function handleRemoveMember(
   const roleError = requireRole(scopedReq, 'ADMIN');
   if (roleError) return roleError;
 
-  const targetMembership = await db('memberships')
+  const targetMembership = await db<MembershipRow>('memberships')
     .where({ user_id: userId, workspace_id: workspaceId })
     .first();
 


### PR DESCRIPTION
## Summary
- type target membership lookup in workspace member removal
- preserve ADMIN enforcement, member-not-found response, last-owner invariant and deletion behavior

## Validation
- bunx eslint server/extensions/workspace/api/members/remove.ts
- bun run build:client
- bun run typecheck (baseline-red; no members/remove.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check