### PR TITLE
fix(workspaces): type member role update

### DIFF
--- a/server/extensions/workspace/api/members/updateRole.ts
+++ b/server/extensions/workspace/api/members/updateRole.ts
@@ -11,6 +11,12 @@ import {
 
 const VALID_ROLES: Role[] = ['OWNER', 'ADMIN', 'MEMBER', 'VIEWER'];
 
+type MembershipRow = {
+  user_id: string;
+  workspace_id: string;
+  role: Role;
+};
+
 export async function handleUpdateMemberRole(
   req: Request,
   workspaceId: string,
@@ -43,7 +49,7 @@ export async function handleUpdateMemberRole(
     );
   }
 
-  const targetMembership = await db('memberships')
+  const targetMembership = await db<MembershipRow>('memberships')
     .where({ user_id: userId, workspace_id: workspaceId })
     .first();
 
@@ -71,9 +77,9 @@ export async function handleUpdateMemberRole(
     }
   }
 
-  const updated = await db('memberships')
+  const updated = (await db<MembershipRow>('memberships')
     .where({ user_id: userId, workspace_id: workspaceId })
-    .update({ role: newRole }, ['*']);
+    .update({ role: newRole }, ['*'])) as MembershipRow[];
 
   return Response.json({ data: updated[0] });
 }


### PR DESCRIPTION
## Summary
- type target membership and update-return boundaries in workspace member role changes
- preserve ADMIN enforcement, role validation, member-not-found handling and last-owner protection

## Validation
- bunx eslint server/extensions/workspace/api/members/updateRole.ts
- bun run build:client
- bun run typecheck (baseline-red; no members/updateRole.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check