### PR TITLE
fix(boards): type board follows

### DIFF
--- a/server/extensions/board/api/follow.ts
+++ b/server/extensions/board/api/follow.ts
@@ -3,13 +3,16 @@
 import { db } from '../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../auth/middlewares/authentication';
 
+type BoardRow = { id: string };
+type AuthenticatedUserRequest = AuthenticatedRequest & { currentUser: { id: string } };
+
 export async function handleFollowBoard(req: Request, boardId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const userId = (req as AuthenticatedUserRequest).currentUser.id;
 
-  const board = await db('boards').where({ id: boardId }).first();
+  const board = await db<BoardRow>('boards').where({ id: boardId }).first();
   if (!board) {
     return Response.json(
       { error: { code: 'board-not-found', message: 'Board not found' } },
@@ -30,9 +33,9 @@ export async function handleUnfollowBoard(req: Request, boardId: string): Promis
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const userId = (req as AuthenticatedUserRequest).currentUser.id;
 
-  const board = await db('boards').where({ id: boardId }).first();
+  const board = await db<BoardRow>('boards').where({ id: boardId }).first();
   if (!board) {
     return Response.json(
       { error: { code: 'board-not-found', message: 'Board not found' } },


### PR DESCRIPTION
## Summary
- type authenticated-user and board lookup boundaries for idempotent board follow/unfollow
- preserve missing-board response, conflict-ignore follow and no-op unfollow behaviour

## Validation
- bunx eslint server/extensions/board/api/follow.ts
- bun run build:client
- bun run typecheck (baseline-red; no follow.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check