### PR TITLE
fix(boards): type member suggestions

### DIFF
--- a/server/extensions/board/api/members/suggestions.ts
+++ b/server/extensions/board/api/members/suggestions.ts
@@ -10,6 +10,8 @@ import { authenticate, type AuthenticatedRequest } from '../../../auth/middlewar
 import { requireBoardAccess, type BoardScopedRequest } from '../../middlewares/requireBoardAccess';
 import { buildAvatarProxyUrlsInCollection } from '../../../../common/avatar/resolveAvatarUrl';
 
+type BoardSuggestionScope = { id: string; workspace_id: string; visibility: string };
+
 export async function handleGetMemberSuggestions(req: Request, boardId: string): Promise<Response> {
   const authReq = req as AuthenticatedRequest;
   const authError = await authenticate(authReq);
@@ -29,10 +31,10 @@ export async function handleGetMemberSuggestions(req: Request, boardId: string):
   const url = new URL(req.url);
   const q = (url.searchParams.get('q') ?? '').toLowerCase().trim();
 
-  const board = await db('boards')
+  const board = await db<BoardSuggestionScope>('boards')
     .where({ id: boardId })
     .select('workspace_id', 'visibility')
-    .first();
+    .first<BoardSuggestionScope | undefined>();
 
   if (!board) {
     return Response.json(


### PR DESCRIPTION
## Summary
- type board scope read boundary for member suggestions
- preserve private/workspace/public candidate scopes, guest inclusion, self exclusion and avatar response

## Validation
- bunx eslint server/extensions/board/api/members/suggestions.ts
- bun run build:client
- bun run typecheck (baseline-red; no members/suggestions.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check