### PR TITLE
fix(boards): type board deletion

### DIFF
--- a/server/extensions/board/api/delete.ts
+++ b/server/extensions/board/api/delete.ts
@@ -10,11 +10,13 @@ import {
 } from '../../../middlewares/permissionManager';
 import { guestGuard } from '../../../middlewares/guestGuard';
 
+type BoardRow = { id: string; workspace_id: string };
+
 export async function handleDeleteBoard(req: Request, boardId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const board = await db('boards').where({ id: boardId }).first();
+  const board = await db<BoardRow>('boards').where({ id: boardId }).first<BoardRow | undefined>();
   if (!board) {
     return Response.json(
       { error: { code: 'board-not-found', message: 'Board not found' } },


### PR DESCRIPTION
## Summary
- type board lookup boundary for hard board deletion
- preserve confirmation requirements, access guards, deletion and workspace notification

## Validation
- bunx eslint server/extensions/board/api/delete.ts
- bun run build:client
- bun run typecheck (baseline-red; no delete.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check