### PR TITLE
fix(boards): type background proxy

### DIFF
--- a/server/extensions/board/api/backgroundProxy.ts
+++ b/server/extensions/board/api/backgroundProxy.ts
@@ -7,9 +7,13 @@ import { presignGetUrl } from '../../attachment/common/presign';
 import { extractS3KeyFromBackgroundUrl } from '../common/resolveBackgroundUrl';
 
 const PROXY_TTL_SECONDS = 60;
+type BoardBackgroundRow = { id: string; background: string | null };
 
 export async function handleGetBackground(req: Request, boardId: string): Promise<Response> {
-  const board = await db('boards').where({ id: boardId }).select('background').first();
+  const board = await db<BoardBackgroundRow>('boards')
+    .where({ id: boardId })
+    .select('background')
+    .first<BoardBackgroundRow | undefined>();
 
   if (!board?.background) {
     return Response.json({ name: 'background-not-found' }, { status: 404 });


### PR DESCRIPTION
## Summary
- type the board background query result
- preserve missing-background and external/S3 redirect paths

## Validation
- bunx eslint server/extensions/board/api/backgroundProxy.ts
- bun run build:client
- bun run typecheck (baseline-red; no backgroundProxy.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check