### PR TITLE
fix(boards): remove unused router import

### DIFF
--- a/server/extensions/board/api/index.ts
+++ b/server/extensions/board/api/index.ts
@@ -3,7 +3,6 @@ import { applyBoardVisibility } from '../../../middlewares/boardVisibility';
 import { handleCreateBoard } from './create';
 import { handleListBoards } from './list';
 import { handleGetBoard } from './get';
-import { handleUpdateBoard } from './update';
 import { handlePatchBoard } from './patch';
 import { handleArchiveBoard } from './archive';
 import { handleDeleteBoard } from './delete';


### PR DESCRIPTION
## Summary
- remove the unused board update handler import from the board router
- preserve all router dispatch behaviour

## Validation
- bunx eslint server/extensions/board/api/index.ts
- bun run build:client
- bun run typecheck (baseline-red; no index.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check