### PR TITLE
fix(boards): type workspace board listing

### DIFF
--- a/server/extensions/board/api/workspaceBoards.ts
+++ b/server/extensions/board/api/workspaceBoards.ts
@@ -4,28 +4,33 @@
 import { db } from '../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../auth/middlewares/authentication';
 
+type AuthenticatedUserRequest = AuthenticatedRequest & { currentUser: { id: string } };
+type BoardRow = { id: string; workspace_id: string };
+type MembershipRow = { user_id: string; workspace_id: string };
+type WorkspaceBoardRow = { id: string; title: string; workspace_id: string; state: string };
+
 export async function handleGetWorkspaceBoards(req: Request, boardId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
-  const currentUser = (req as AuthenticatedRequest).currentUser!;
+  const currentUser = (req as AuthenticatedUserRequest).currentUser;
 
-  const board = await db('boards').where({ id: boardId }).first();
+  const board = await db<BoardRow>('boards').where({ id: boardId }).first<BoardRow | undefined>();
   if (!board) {
     return Response.json({ error: { name: 'board-not-found' } }, { status: 404 });
   }
 
   // Caller must be a workspace member to enumerate boards.
-  const membership = await db('memberships')
+  const membership = await db<MembershipRow>('memberships')
     .where({ user_id: currentUser.id, workspace_id: board.workspace_id })
-    .first();
+    .first<MembershipRow | undefined>();
   if (!membership) {
     return Response.json({ error: { name: 'not-a-workspace-member' } }, { status: 403 });
   }
 
-  const boards = await db('boards')
+  const boards = (await db<WorkspaceBoardRow>('boards')
     .where({ workspace_id: board.workspace_id, state: 'ACTIVE' })
     .orderBy('created_at', 'asc')
-    .select('id', 'title');
+    .select('id', 'title')) as WorkspaceBoardRow[];
 
   return Response.json({ data: boards });
 }


### PR DESCRIPTION
## Summary
- type actor, board, membership and active-board query boundaries
- preserve missing-board and membership responses plus active-board picker results

## Validation
- bunx eslint server/extensions/board/api/workspaceBoards.ts
- bun run build:client
- bun run typecheck (baseline-red; no workspaceBoards.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check