### PR TITLE
fix(boards): type board duplication

### DIFF
--- a/server/extensions/board/api/duplicate.ts
+++ b/server/extensions/board/api/duplicate.ts
@@ -10,11 +10,15 @@ import {
 import { guestGuard } from '../../../middlewares/guestGuard';
 import { duplicateBoard } from '../mods/duplicate/index';
 
+type BoardDuplicateSource = { workspace_id: string; title: string };
+
 export async function handleDuplicateBoard(req: Request, boardId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const board = await db('boards').where({ id: boardId }).first();
+  const board = (await db('boards')
+    .where({ id: boardId })
+    .first()) as BoardDuplicateSource | undefined;
   if (!board) {
     return Response.json(
       { error: { code: 'board-not-found', message: 'Board not found' } },


### PR DESCRIPTION
## Summary
- type the source-board lookup used by board duplication
- preserve authentication, member access, duplication and event behaviour

## Validation
- bunx eslint server/extensions/board/api/duplicate.ts
- bun run build:client
- bun run typecheck (baseline-red; no duplicate.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check