### PR TITLE
fix(boards): type guest creation

### DIFF
--- a/server/extensions/board/api/guests/create.ts
+++ b/server/extensions/board/api/guests/create.ts
@@ -13,6 +13,22 @@ import { requireBoardAccess, type BoardScopedRequest } from '../../middlewares/r
 import { writeEvent } from '../../../../mods/events/index';
 import type { GuestType } from '../../types';
 
+type AuthenticatedUserRequest = AuthenticatedRequest & {
+  currentUser: NonNullable<AuthenticatedRequest['currentUser']>;
+};
+type ResolvedBoardRequest = BoardScopedRequest & { board: { workspace_id: string } };
+type InviteGuestBody = { email?: string; guestType?: string };
+type UserRow = { id: string; name: string | null };
+type ExistingRow = { id: string };
+type GuestGrantRow = {
+  id: string;
+  email: string;
+  name: string;
+  guestType: GuestType;
+  grantedAt: string;
+  grantedBy: string;
+};
+
 function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
@@ -21,11 +37,11 @@ export async function handleInviteGuestByEmail(req: Request, boardId: string): P
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const boardReq = req as BoardScopedRequest;
+  const boardReq = req as ResolvedBoardRequest;
   const accessError = await requireBoardAccess(boardReq, boardId);
   if (accessError) return accessError;
 
-  const board = boardReq.board!;
+  const board = boardReq.board;
   const scopedReq = req as WorkspaceScopedRequest;
   const membershipError = await requireWorkspaceMembership(scopedReq, board.workspace_id);
   if (membershipError) return membershipError;
@@ -33,9 +49,9 @@ export async function handleInviteGuestByEmail(req: Request, boardId: string): P
   const roleError = requireRole(scopedReq, 'ADMIN');
   if (roleError) return roleError;
 
-  let body: { email?: string; guestType?: string };
+  let body: InviteGuestBody;
   try {
-    body = await req.json();
+    body = (await req.json()) as InviteGuestBody;
   } catch {
     return Response.json(
       { name: 'invalid-request-body', data: { message: 'Request body must be JSON' } },
@@ -58,14 +74,14 @@ export async function handleInviteGuestByEmail(req: Request, boardId: string): P
       { status: 400 },
     );
   }
-  const guestType: GuestType = (rawGuestType as GuestType | undefined) ?? 'VIEWER';
+  const guestType: GuestType = rawGuestType ?? 'VIEWER';
 
   // Prevent inviting existing workspace members (non-GUEST) as guests.
   const existingMember = await db('memberships')
     .join('users', 'memberships.user_id', 'users.id')
     .where({ 'users.email': email, 'memberships.workspace_id': board.workspace_id })
     .whereNot('memberships.role', 'GUEST')
-    .first();
+    .first() as ExistingRow | undefined;
 
   if (existingMember) {
     return Response.json(
@@ -75,7 +91,7 @@ export async function handleInviteGuestByEmail(req: Request, boardId: string): P
   }
 
   // Resolve or create user.
-  let user = await db('users').where({ email }).first();
+  let user = (await db('users').where({ email }).first()) as UserRow | undefined;
   if (!user) {
     // [why] Stub account: minimal row so the invite can be stored.
     // The user can claim the account later via a future invite-acceptance flow.
@@ -85,15 +101,16 @@ export async function handleInviteGuestByEmail(req: Request, boardId: string): P
       email,
       name: email.split('@')[0] ?? email,
     });
-    user = await db('users').where({ id: userId }).first();
+    user = (await db('users').where({ id: userId }).first()) as UserRow | undefined;
   }
 
-  const userId = user.id as string;
+  const resolvedUser = user as UserRow;
+  const userId = resolvedUser.id;
 
   // Check for duplicate board guest access.
   const existing = await db('board_guest_access')
     .where({ user_id: userId, board_id: boardId })
-    .first();
+    .first() as ExistingRow | undefined;
 
   if (existing) {
     return Response.json(
@@ -105,7 +122,7 @@ export async function handleInviteGuestByEmail(req: Request, boardId: string): P
   // Get or create GUEST workspace membership.
   const existingMembership = await db('memberships')
     .where({ user_id: userId, workspace_id: board.workspace_id })
-    .first();
+    .first() as ExistingRow | undefined;
 
   await db.transaction(async (trx) => {
     if (!existingMembership) {
@@ -121,11 +138,11 @@ export async function handleInviteGuestByEmail(req: Request, boardId: string): P
       user_id: userId,
       board_id: boardId,
       guest_type: guestType,
-      granted_by: (req as AuthenticatedRequest).currentUser!.id,
+      granted_by: (req as AuthenticatedUserRequest).currentUser.id,
     });
   });
 
-  const grantRow = await db('board_guest_access')
+  const grantRow = (await db('board_guest_access')
     .join('users', 'board_guest_access.user_id', 'users.id')
     .where({ 'board_guest_access.user_id': userId, 'board_guest_access.board_id': boardId })
     .select(
@@ -136,17 +153,17 @@ export async function handleInviteGuestByEmail(req: Request, boardId: string): P
       'board_guest_access.granted_at as grantedAt',
       'board_guest_access.granted_by as grantedBy',
     )
-    .first();
+    .first()) as GuestGrantRow | undefined;
 
   writeEvent({
     type: 'member_joined',
     boardId,
     entityId: boardId,
-    actorId: (req as AuthenticatedRequest).currentUser!.id,
+    actorId: (req as AuthenticatedUserRequest).currentUser.id,
     payload: {
       scope: 'board',
       userId,
-      displayName: (user.name as string | undefined) ?? email,
+      displayName: resolvedUser.name ?? email,
       role: 'GUEST',
       joinedAt: new Date().toISOString(),
     },


### PR DESCRIPTION
## Summary
- type board, authenticated-user, parsed-body and query-result boundaries in guest creation
- preserve ADMIN access, user/membership reconciliation, duplicate checks and event dispatch

## Validation
- bunx eslint server/extensions/board/api/guests/create.ts
- bun run build:client
- bun run typecheck (baseline-red; no create.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check