### PR TITLE
fix(workspaces): type invite inspection

### DIFF
--- a/server/extensions/workspace/api/invite/inspect.ts
+++ b/server/extensions/workspace/api/invite/inspect.ts
@@ -1,8 +1,19 @@
 // GET /api/v1/invites/:token — inspect invite status; no authentication required.
 import { db } from '../../../../common/db';
 
+type InviteInspectionRow = {
+  id: string;
+  workspace_id: string;
+  invited_email: string;
+  role: string;
+  expires_at: Date;
+  accepted_at: Date | null;
+};
+
 export async function handleInspectInvite(req: Request, token: string): Promise<Response> {
-  const invite = await db('invites').where({ token }).first();
+  const invite = (await db('invites')
+    .where({ token })
+    .first()) as InviteInspectionRow | undefined;
 
   if (!invite) {
     return Response.json(


### PR DESCRIPTION
## Summary
- type the invite inspection readback
- preserve unauthenticated access, expiry/used flags and response mapping

## Validation
- bunx eslint server/extensions/workspace/api/invite/inspect.ts
- bun run build:client
- bun run typecheck (baseline-red; no inspect.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check