### PR TITLE
fix(notifications): type bulk deletion

### DIFF
--- a/server/extensions/notifications/api/deleteAll.ts
+++ b/server/extensions/notifications/api/deleteAll.ts
@@ -2,11 +2,15 @@
 import { db } from '../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../auth/middlewares/authentication';
 
+type AuthenticatedUserRequest = AuthenticatedRequest & {
+  currentUser: NonNullable<AuthenticatedRequest['currentUser']>;
+};
+
 export async function handleDeleteAllNotifications(req: Request): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const userId = (req as AuthenticatedUserRequest).currentUser.id;
 
   await db('notifications').where({ user_id: userId }).delete();
 


### PR DESCRIPTION
## Summary
- type the successful-authentication boundary for bulk notification deletion
- preserve caller-scoped deletion and 204 response

## Validation
- bunx eslint server/extensions/notifications/api/deleteAll.ts
- bun run build:client
- bun run typecheck (baseline-red; no deleteAll.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check