### PR TITLE
fix(notifications): type board preference reset

### DIFF
--- a/server/extensions/notifications/api/boardTypePreferences/reset.ts
+++ b/server/extensions/notifications/api/boardTypePreferences/reset.ts
@@ -5,15 +5,21 @@ import { db } from '../../../../common/db';
 import { type AuthenticatedRequest } from '../../../auth/middlewares/authentication';
 import { applyBoardVisibility, type BoardVisibilityScopedRequest } from '../../../../middlewares/boardVisibility';
 
+type ResolvedBoardPreferenceRequest = BoardVisibilityScopedRequest & {
+  board: { id: string };
+  currentUser: NonNullable<AuthenticatedRequest['currentUser']>;
+};
+
 export async function handleResetBoardTypePreferences(
   req: Request,
   boardId: string,
 ): Promise<Response> {
   const visibilityError = await applyBoardVisibility(req, boardId);
   if (visibilityError) return visibilityError;
-  const resolvedBoardId = (req as BoardVisibilityScopedRequest).board!.id;
+  const resolvedReq = req as ResolvedBoardPreferenceRequest;
+  const resolvedBoardId = resolvedReq.board.id;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const userId = resolvedReq.currentUser.id;
 
   await db('board_notification_type_preferences').where({ user_id: userId, board_id: resolvedBoardId }).delete();
 


### PR DESCRIPTION
## Summary
- type resolved board and authenticated-user boundaries for board-type preference reset
- preserve caller-and-board scoped deletion and fallback semantics

## Validation
- bunx eslint server/extensions/notifications/api/boardTypePreferences/reset.ts
- bun run build:client
- bun run typecheck (baseline-red; no reset.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check