### PR TITLE
fix(notifications): type bulk read marking

### DIFF
--- a/server/extensions/notifications/api/markAllRead.ts
+++ b/server/extensions/notifications/api/markAllRead.ts
@@ -2,11 +2,15 @@
 import { db } from '../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../auth/middlewares/authentication';
 
+type AuthenticatedUserRequest = AuthenticatedRequest & {
+  currentUser: NonNullable<AuthenticatedRequest['currentUser']>;
+};
+
 export async function handleMarkAllRead(req: Request): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const userId = (req as AuthenticatedUserRequest).currentUser.id;
 
   const updated = await db('notifications')
     .where({ user_id: userId, read: false })


### PR DESCRIPTION
## Summary
- type the middleware-established authenticated-user boundary for bulk notification read marking
- preserve the caller-scoped unread update, count and response

## Validation
- bunx eslint server/extensions/notifications/api/markAllRead.ts
- bun run build:client
- bun run typecheck (baseline-red; no markAllRead.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check
