### PR TITLE
fix(notifications): type single unread marking

### DIFF
--- a/server/extensions/notifications/api/markUnread.ts
+++ b/server/extensions/notifications/api/markUnread.ts
@@ -2,13 +2,20 @@
 import { db } from '../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../auth/middlewares/authentication';
 
+type AuthenticatedUserRequest = AuthenticatedRequest & {
+  currentUser: NonNullable<AuthenticatedRequest['currentUser']>;
+};
+type NotificationOwnerRow = { user_id: string };
+
 export async function handleMarkUnread(req: Request, notificationId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const userId = (req as AuthenticatedUserRequest).currentUser.id;
 
-  const notification = await db('notifications').where({ id: notificationId }).first();
+  const notification = (await db('notifications')
+    .where({ id: notificationId })
+    .first()) as NotificationOwnerRow | undefined;
   if (!notification) {
     return Response.json(
       { error: { code: 'notification-not-found', message: 'Notification not found' } },


### PR DESCRIPTION
## Summary
- type authenticated-user and notification ownership lookup boundaries for single unread marking
- preserve 404, caller ownership 403, unread update and response semantics

## Validation
- bunx eslint server/extensions/notifications/api/markUnread.ts
- bun run build:client
- bun run typecheck (baseline-red; no markUnread.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check
