### PR TITLE
fix(notifications): type board preference updates

### DIFF
--- a/server/extensions/notifications/api/boardTypePreferences/update.ts
+++ b/server/extensions/notifications/api/boardTypePreferences/update.ts
@@ -13,6 +13,11 @@ interface PatchBody {
   in_app_enabled?: unknown;
   email_enabled?: unknown;
 }
+type ResolvedBoardPreferenceRequest = BoardVisibilityScopedRequest & {
+  board: { id: string };
+  currentUser: NonNullable<AuthenticatedRequest['currentUser']>;
+};
+type BoardTypePreferenceRow = { id: string };
 
 export async function handleUpdateBoardTypePreference(
   req: Request,
@@ -20,13 +25,14 @@ export async function handleUpdateBoardTypePreference(
 ): Promise<Response> {
   const visibilityError = await applyBoardVisibility(req, boardId);
   if (visibilityError) return visibilityError;
-  const resolvedBoardId = (req as BoardVisibilityScopedRequest).board!.id;
+  const resolvedReq = req as ResolvedBoardPreferenceRequest;
+  const resolvedBoardId = resolvedReq.board.id;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const userId = resolvedReq.currentUser.id;
 
   let body: PatchBody;
   try {
-    body = await req.json();
+    body = await req.json() as PatchBody;
   } catch {
     return Response.json(
       { error: { name: 'invalid-request-body', data: { message: 'Invalid JSON body' } } },
@@ -85,9 +91,9 @@ export async function handleUpdateBoardTypePreference(
   }
 
   const now = new Date().toISOString();
-  const existing = await db('board_notification_type_preferences')
+  const existing = (await db('board_notification_type_preferences')
     .where({ user_id: userId, board_id: resolvedBoardId, type })
-    .first();
+    .first()) as BoardTypePreferenceRow | undefined;
 
   if (existing) {
     const updates: Record<string, unknown> = { updated_at: now };


### PR DESCRIPTION
## Summary
- type resolved board/user, parsed body and existing preference boundaries
- preserve visibility enforcement, validation, upsert defaults and updated-list readback

## Validation
- bunx eslint server/extensions/notifications/api/boardTypePreferences/update.ts
- bun run build:client
- bun run typecheck (baseline-red; no update.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check
