### PR TITLE
fix(notifications): type global preference reads

### DIFF
--- a/server/extensions/notifications/api/globalPreference/get.ts
+++ b/server/extensions/notifications/api/globalPreference/get.ts
@@ -4,16 +4,24 @@
 import { db } from '../../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../../auth/middlewares/authentication';
 
+type AuthenticatedUserRequest = AuthenticatedRequest & {
+  currentUser: NonNullable<AuthenticatedRequest['currentUser']>;
+};
+type GlobalNotificationSettingRow = {
+  global_notifications_enabled: boolean;
+  updated_at: string | null;
+};
+
 export async function handleGetGlobalNotificationSetting(req: Request): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const userId = (req as AuthenticatedUserRequest).currentUser.id;
 
-  const row = await db('user_notification_settings')
+  const row = (await db('user_notification_settings')
     .where({ user_id: userId })
     .select('global_notifications_enabled', 'updated_at')
-    .first();
+    .first()) as GlobalNotificationSettingRow | undefined;
 
   return Response.json({
     data: {


### PR DESCRIPTION
## Summary
- type authenticated-user and global-setting read boundaries
- preserve user scoping, opt-out default and response shape

## Validation
- bunx eslint server/extensions/notifications/api/globalPreference/get.ts
- bun run build:client
- bun run typecheck (baseline-red; no get.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check
