### PR TITLE
fix(notifications): type global preference updates

### DIFF
--- a/server/extensions/notifications/api/globalPreference/update.ts
+++ b/server/extensions/notifications/api/globalPreference/update.ts
@@ -6,16 +6,23 @@ import { authenticate, type AuthenticatedRequest } from '../../../auth/middlewar
 interface PatchBody {
   global_notifications_enabled?: unknown;
 }
+type AuthenticatedUserRequest = AuthenticatedRequest & {
+  currentUser: NonNullable<AuthenticatedRequest['currentUser']>;
+};
+type NotificationSettingRow = {
+  global_notifications_enabled: boolean;
+  updated_at: string | null;
+};
 
 export async function handleUpdateGlobalNotificationSetting(req: Request): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const userId = (req as AuthenticatedUserRequest).currentUser.id;
 
   let body: PatchBody;
   try {
-    body = await req.json();
+    body = await req.json() as PatchBody;
   } catch {
     return Response.json(
       { error: { name: 'invalid-request-body', data: { message: 'Invalid JSON body' } } },
@@ -38,23 +45,25 @@ export async function handleUpdateGlobalNotificationSetting(req: Request): Promi
   }
 
   const now = new Date().toISOString();
-  const existing = await db('user_notification_settings').where({ user_id: userId }).first();
+  const existing = (await db('user_notification_settings')
+    .where({ user_id: userId })
+    .first()) as { user_id: string } | undefined;
 
-  let row: Record<string, unknown>;
+  let row: NotificationSettingRow;
 
   if (existing) {
-    const [updated] = await db('user_notification_settings')
+    const [updated] = (await db('user_notification_settings')
       .where({ user_id: userId })
       .update({ global_notifications_enabled, updated_at: now }, [
         'global_notifications_enabled',
         'updated_at',
-      ]);
+      ])) as [NotificationSettingRow];
     row = updated;
   } else {
-    const [inserted] = await db('user_notification_settings').insert(
+    const [inserted] = (await db('user_notification_settings').insert(
       { user_id: userId, global_notifications_enabled, updated_at: now },
       ['global_notifications_enabled', 'updated_at'],
-    );
+    )) as [NotificationSettingRow];
     row = inserted;
   }
 


### PR DESCRIPTION
## Summary
- type authenticated-user, parsed body, existence check and returning-row boundaries
- preserve boolean validation, update-versus-insert behaviour, returned fields and response shape

## Validation
- bunx eslint server/extensions/notifications/api/globalPreference/update.ts
- bun run build:client
- bun run typecheck (baseline-red; no update.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check
