### PR TITLE
fix(notifications): type preference reads

### DIFF
--- a/server/extensions/notifications/api/preferences/get.ts
+++ b/server/extensions/notifications/api/preferences/get.ts
@@ -5,15 +5,25 @@ import { db } from '../../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../../auth/middlewares/authentication';
 import { NOTIFICATION_TYPES } from '../../mods/preferenceGuard';
 
+type AuthenticatedUserRequest = AuthenticatedRequest & {
+  currentUser: NonNullable<AuthenticatedRequest['currentUser']>;
+};
+type NotificationPreferenceRow = {
+  type: string;
+  in_app_enabled: boolean;
+  email_enabled: boolean;
+  updated_at: string | null;
+};
+
 export async function handleGetPreferences(req: Request): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const userId = (req as AuthenticatedUserRequest).currentUser.id;
 
-  const rows = await db('notification_preferences')
+  const rows = (await db('notification_preferences')
     .where({ user_id: userId })
-    .select('type', 'in_app_enabled', 'email_enabled', 'updated_at');
+    .select('type', 'in_app_enabled', 'email_enabled', 'updated_at')) as NotificationPreferenceRow[];
 
   const rowByType = new Map(rows.map((r) => [r.type, r]));
 


### PR DESCRIPTION
## Summary
- type authenticated-user and preference-row collection boundaries
- preserve user scoping, all-type expansion, enabled-channel defaults and response shape

## Validation
- bunx eslint server/extensions/notifications/api/preferences/get.ts
- bun run build:client
- bun run typecheck (baseline-red; no get.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check
