### PR TITLE
fix(notifications): type board preference reads

### DIFF
--- a/server/extensions/notifications/api/boardPreference/get.ts
+++ b/server/extensions/notifications/api/boardPreference/get.ts
@@ -5,32 +5,44 @@ import { db } from '../../../../common/db';
 import { type AuthenticatedRequest } from '../../../auth/middlewares/authentication';
 import { applyBoardVisibility, type BoardVisibilityScopedRequest } from '../../../../middlewares/boardVisibility';
 
+type ResolvedBoardPreferenceRequest = BoardVisibilityScopedRequest & {
+  board: { id: string };
+  currentUser: NonNullable<AuthenticatedRequest['currentUser']>;
+};
+type BoardParticipantRow = { user_id: string };
+type BoardNotificationPreferenceRow = {
+  notifications_enabled: boolean;
+  only_related_to_me: boolean;
+  updated_at: string | null;
+};
+
 export async function handleGetBoardNotificationPreference(
   req: Request,
   boardId: string,
 ): Promise<Response> {
   const visibilityError = await applyBoardVisibility(req, boardId);
   if (visibilityError) return visibilityError;
-  const resolvedBoardId = (req as BoardVisibilityScopedRequest).board!.id;
+  const resolvedReq = req as ResolvedBoardPreferenceRequest;
+  const resolvedBoardId = resolvedReq.board.id;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const userId = resolvedReq.currentUser.id;
 
   // [why] Notifications apply to board participants (joined members OR board guests).
   // Non-participants (e.g. admins who can view a board via workspace visibility)
   // still default to OFF unless they explicitly opt in.
-  const [boardMember, boardGuest] = await Promise.all([
+  const [boardMember, boardGuest] = (await Promise.all([
     db('board_members')
       .where({ board_id: resolvedBoardId, user_id: userId })
       .first(),
     db('board_guest_access')
       .where({ board_id: resolvedBoardId, user_id: userId })
       .first(),
-  ]);
+  ])) as [BoardParticipantRow | undefined, BoardParticipantRow | undefined];
 
-  const row = await db('board_notification_preferences')
+  const row = (await db('board_notification_preferences')
     .where({ user_id: userId, board_id: resolvedBoardId })
     .select('notifications_enabled', 'only_related_to_me', 'updated_at')
-    .first();
+    .first()) as BoardNotificationPreferenceRow | undefined;
 
   return Response.json({
     data: {


### PR DESCRIPTION
## Summary
- type resolved board/user, participant checks and preference-row boundaries
- preserve board visibility, participant-aware default, user scoping and response shape

## Validation
- bunx eslint server/extensions/notifications/api/boardPreference/get.ts
- bun run build:client
- bun run typecheck (baseline-red; no get.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check
