### PR TITLE
fix(automation): type automation listing

### DIFF
--- a/server/extensions/automation/api/list.ts
+++ b/server/extensions/automation/api/list.ts
@@ -12,7 +12,10 @@ export async function handleListAutomations(req: Request, boardId: string): Prom
 
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
-  const currentUser = (req as AuthenticatedRequest).currentUser!;
+  const currentUser = (req as AuthenticatedRequest).currentUser;
+  if (!currentUser) {
+    return Response.json({ error: { name: 'unauthorized' } }, { status: 401 });
+  }
 
   // Automations are private to their creator — each user only sees their own.
   const automations = await db('automations')


### PR DESCRIPTION
## Summary
- replace the unsafe authenticated-user assertion with an explicit 401 boundary
- preserve feature gating, creator-scoped board automation listing, trigger/action loading, ordering and response shape

## Validation
- bunx eslint server/extensions/automation/api/list.ts
- bun run build:client
- bun run typecheck (baseline-red; no automation/api/list.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check
