### PR TITLE
fix(automation): type automation retrieval

### DIFF
--- a/server/extensions/automation/api/get.ts
+++ b/server/extensions/automation/api/get.ts
@@ -2,6 +2,7 @@
 import { db } from '../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../auth/middlewares/authentication';
 import { automationConfig } from '../config';
+import type { AutomationActionRow, AutomationRow, AutomationTriggerRow } from '../common/types';
 import { formatAutomation } from './format';
 
 export async function handleGetAutomation(
@@ -15,20 +16,23 @@ export async function handleGetAutomation(
 
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
-  const currentUser = (req as AuthenticatedRequest).currentUser!;
+  const currentUser = (req as AuthenticatedRequest).currentUser;
+  if (!currentUser) {
+    return Response.json({ error: { name: 'unauthorized' } }, { status: 401 });
+  }
 
   // Automations are private to their creator.
-  const automation = await db('automations')
+  const automation = (await db('automations')
     .where({ id: automationId, board_id: boardId, created_by: currentUser.id })
-    .first();
+    .first()) as AutomationRow | undefined;
   if (!automation) {
     return Response.json({ error: { name: 'automation-not-found' } }, { status: 404 });
   }
 
-  const [trigger, actions] = await Promise.all([
+  const [trigger, actions] = (await Promise.all([
     db('automation_triggers').where({ automation_id: automationId }).first(),
     db('automation_actions').where({ automation_id: automationId }).orderBy('position', 'asc').select('*'),
-  ]);
+  ])) as [AutomationTriggerRow | undefined, AutomationActionRow[]];
 
   return Response.json({ data: formatAutomation(automation, trigger ?? null, actions) });
 }


### PR DESCRIPTION
## Summary
- type the authenticated-user, automation, trigger and action query boundaries
- preserve feature gating, creator-only lookup, 404 semantics, action ordering and formatted response output

## Validation
- bunx eslint server/extensions/automation/api/get.ts
- bun run build:client
- bun run typecheck (baseline-red; no automation/api/get.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check
