### PR TITLE
fix(automation): type board run listing

### DIFF
--- a/server/extensions/automation/api/boardRuns.ts
+++ b/server/extensions/automation/api/boardRuns.ts
@@ -9,6 +9,8 @@ import { automationConfig } from '../config';
 
 const BOARD_RUN_CAP = 200;
 const DEFAULT_PER_PAGE = 50;
+type BoardRow = { workspace_id: string };
+type BoardRunRow = Record<string, unknown>;
 
 export async function handleGetBoardRuns(req: Request, boardId: string): Promise<Response> {
   if (!automationConfig.enabled) {
@@ -18,7 +20,7 @@ export async function handleGetBoardRuns(req: Request, boardId: string): Promise
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const board = await db('boards').where({ id: boardId }).first();
+  const board = (await db('boards').where({ id: boardId }).first()) as BoardRow | undefined;
   if (!board) {
     return Response.json({ error: { name: 'board-not-found' } }, { status: 404 });
   }
@@ -28,8 +30,12 @@ export async function handleGetBoardRuns(req: Request, boardId: string): Promise
     board.workspace_id,
   );
   if (membershipError) {
-    const currentUser = (req as AuthenticatedRequest).currentUser!;
-    const guest = await db('board_guests').where({ board_id: boardId, user_id: currentUser.id }).first().catch(() => null);
+    const currentUser = (req as AuthenticatedRequest).currentUser;
+    if (!currentUser) return membershipError;
+    const guest = (await db('board_guests')
+      .where({ board_id: boardId, user_id: currentUser.id })
+      .first()
+      .catch(() => null)) as Record<string, unknown> | null;
     if (!guest) return membershipError;
   }
 
@@ -61,13 +67,13 @@ export async function handleGetBoardRuns(req: Request, boardId: string): Promise
       'r.error_message as errorMessage',
     );
 
-  const allRows = await recentRuns;
+  const allRows = (await recentRuns) as BoardRunRow[];
 
   const totalCount = allRows.length;
   const totalPage = Math.ceil(totalCount / perPage);
   const pageRows = allRows.slice((page - 1) * perPage, page * perPage);
 
-  const data = pageRows.map((row: Record<string, unknown>) => ({
+  const data = pageRows.map((row) => ({
     id: row.id,
     automationId: row.automationId,
     automationName: row.automationName,
@@ -80,7 +86,7 @@ export async function handleGetBoardRuns(req: Request, boardId: string): Promise
         ? { id: row.triggeredByUserId, name: row.triggeredByUserName ?? null }
         : null,
     ranAt: row.ranAt,
-    context: typeof row.context === 'string' ? JSON.parse(row.context) : (row.context ?? {}),
+    context: typeof row.context === 'string' ? JSON.parse(row.context) as unknown : (row.context ?? {}),
     errorMessage: row.errorMessage ?? null,
   }));
 


### PR DESCRIPTION
## Summary
- type board, board-guest and run-result query boundaries
- retain the 200-row cap, descending order, pagination, JSON context parsing and response schema

## Validation
- bunx eslint server/extensions/automation/api/boardRuns.ts
- bun run build:client
- bun run typecheck (baseline-red; no automation/api/boardRuns.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check
