### PR TITLE
fix(automation): type run history

### DIFF
--- a/server/extensions/automation/api/runs.ts
+++ b/server/extensions/automation/api/runs.ts
@@ -9,6 +9,8 @@ import { automationConfig } from '../config';
 
 const MAX_PER_PAGE = 50;
 const DEFAULT_PER_PAGE = 20;
+type BoardRow = { workspace_id: string };
+type AutomationRunRow = Record<string, unknown>;
 
 export async function handleGetAutomationRuns(
   req: Request,
@@ -23,7 +25,7 @@ export async function handleGetAutomationRuns(
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const board = await db('boards').where({ id: boardId }).first();
+  const board = (await db('boards').where({ id: boardId }).first()) as BoardRow | undefined;
   if (!board) {
     return Response.json({ error: { name: 'board-not-found' } }, { status: 404 });
   }
@@ -36,13 +38,14 @@ export async function handleGetAutomationRuns(
   );
   if (membershipError) {
     // Fall back: check if the caller is a guest on this board.
-    const currentUser = (req as AuthenticatedRequest).currentUser!;
-    const guest = await db('board_guests').where({ board_id: boardId, user_id: currentUser.id }).first().catch(() => null);
+    const currentUser = (req as AuthenticatedRequest).currentUser;
+    if (!currentUser) return membershipError;
+    const guest = (await db('board_guests').where({ board_id: boardId, user_id: currentUser.id }).first().catch(() => null)) as Record<string, unknown> | null;
     if (!guest) return membershipError;
   }
 
   // Verify automation belongs to this board.
-  const automation = await db('automations').where({ id: automationId, board_id: boardId }).first();
+  const automation = (await db('automations').where({ id: automationId, board_id: boardId }).first()) as Record<string, unknown> | undefined;
   if (!automation) {
     return Response.json({ error: { name: 'automation-not-found' } }, { status: 404 });
   }
@@ -63,19 +66,19 @@ export async function handleGetAutomationRuns(
     query = query.where('r.status', statusFilter);
   }
 
-  const [{ count }] = await db('automation_run_log as r')
+  const [{ count }] = (await db('automation_run_log as r')
     .where('r.automation_id', automationId)
     .modify((q) => {
       if (statusFilter && validStatuses.includes(statusFilter)) {
         q.where('r.status', statusFilter);
       }
     })
-    .count('r.id as count');
+    .count('r.id as count')) as [{ count: string | number }];
 
   const totalCount = parseInt(String(count), 10);
   const totalPage = Math.ceil(totalCount / perPage);
 
-  const rows = await query
+  const rows = (await query
     .limit(perPage)
     .offset((page - 1) * perPage)
     .leftJoin('users as u', 'r.triggered_by_user_id', 'u.id')
@@ -90,9 +93,9 @@ export async function handleGetAutomationRuns(
       'r.ran_at as ranAt',
       'r.context',
       'r.error_message as errorMessage',
-    );
+    )) as AutomationRunRow[];
 
-  const data = rows.map((row: Record<string, unknown>) => ({
+  const data = rows.map((row) => ({
     id: row.id,
     status: row.status,
     cardId: row.cardId ?? null,
@@ -102,7 +105,7 @@ export async function handleGetAutomationRuns(
         ? { id: row.triggeredByUserId, name: row.triggeredByUserName ?? null }
         : null,
     ranAt: row.ranAt,
-    context: typeof row.context === 'string' ? JSON.parse(row.context) : (row.context ?? {}),
+    context: typeof row.context === 'string' ? JSON.parse(row.context) as unknown : (row.context ?? {}),
     errorMessage: row.errorMessage ?? null,
   }));
 


### PR DESCRIPTION
## Summary
- type board, guest, automation, aggregate and run-result query boundaries
- preserve access control, status filters, pagination, ordering and response output

## Validation
- bunx eslint server/extensions/automation/api/runs.ts
- bun run build:client
- bun run typecheck (baseline-red; no automation/api/runs.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check
