### PR TITLE
fix(automation): type automation creation

### DIFF
--- a/server/extensions/automation/api/create.ts
+++ b/server/extensions/automation/api/create.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'crypto';
 import { db } from '../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../auth/middlewares/authentication';
 import { automationConfig } from '../config';
-import type { AutomationType } from '../common/types';
+import type { AutomationActionRow, AutomationRow, AutomationTriggerRow, AutomationType } from '../common/types';
 import { validateTrigger } from '../engine/triggers/validate';
 // Ensure trigger registry is populated.
 import '../engine/triggers/index';
@@ -16,6 +16,8 @@ const VALID_AUTOMATION_TYPES: AutomationType[] = [
   'SCHEDULED',
   'DUE_DATE',
 ];
+type BoardRow = { workspace_id: string };
+type MembershipRow = { role: string };
 
 interface CreateAutomationBody {
   name?: unknown;
@@ -40,17 +42,18 @@ export async function handleCreateAutomation(req: Request, boardId: string): Pro
 
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
-  const currentUser = (req as AuthenticatedRequest).currentUser!;
+  const currentUser = (req as AuthenticatedRequest).currentUser;
+  if (!currentUser) return Response.json({ error: { name: 'unauthorized' } }, { status: 401 });
 
-  const board = await db('boards').where({ id: boardId }).first();
+  const board = (await db('boards').where({ id: boardId }).first()) as BoardRow | undefined;
   if (!board) {
     return Response.json({ error: { name: 'board-not-found' } }, { status: 404 });
   }
 
   // Only workspace members with at least MEMBER role can manage automations.
-  const membership = await db('memberships')
+  const membership = (await db('memberships')
     .where({ user_id: currentUser.id, workspace_id: board.workspace_id })
-    .first();
+    .first()) as MembershipRow | undefined;
   if (!membership || !['OWNER', 'ADMIN', 'MEMBER'].includes(membership.role)) {
     return Response.json({ error: { name: 'insufficient-role' } }, { status: 403 });
   }
@@ -143,11 +146,11 @@ export async function handleCreateAutomation(req: Request, boardId: string): Pro
     }
   });
 
-  const [automation, trigger, actions] = await Promise.all([
+  const [automation, trigger, actions] = (await Promise.all([
     db('automations').where({ id: automationId }).first(),
     db('automation_triggers').where({ automation_id: automationId }).first(),
     db('automation_actions').where({ automation_id: automationId }).orderBy('position', 'asc').select('*'),
-  ]);
+  ])) as [AutomationRow, AutomationTriggerRow | undefined, AutomationActionRow[]];
 
   return Response.json({ data: formatAutomation(automation, trigger ?? null, actions) }, { status: 201 });
 }


### PR DESCRIPTION
## Summary
- type authenticated-user, board, membership and post-create readback query boundaries
- preserve validation, transactional writes and 201 response formatting

## Validation
- bunx eslint server/extensions/automation/api/create.ts
- bun run build:client
- bun run typecheck (baseline-red; no automation/api/create.ts diagnostic)
- bun test (baseline: 821 pass, 3 skip, 118 fail, 93 errors)
- git diff --check
