### PR TITLE
fix(state-transitions): simplify cache invalidation

### DIFF
--- a/server/extensions/stateTransitions/enforcement/rules.ts
+++ b/server/extensions/stateTransitions/enforcement/rules.ts
@@ -175,7 +175,6 @@ export function invalidateRulesCacheForBoard(boardId: string): void {
 export function invalidateRulesCacheFromStateTransitionEvent(
   event: Pick<StateTransitionUpdatedEvent, 'type' | 'board_id'>,
 ): void {
-  if (event.type !== 'state_transition_updated') return;
   invalidateRulesCacheForBoard(event.board_id);
 }
 


### PR DESCRIPTION
## Summary
- Remove the impossible event-type branch from state-transition cache invalidation.
- The input type already guarantees `state_transition_updated`, so every prior valid call still invalidates the same board cache.

## Validation
- `bunx eslint server/extensions/stateTransitions/enforcement/rules.ts`
- `bun run build:client` (passes; existing chunk-size warnings)
- `git diff --check`
- `bun run typecheck` (baseline exit 2; no changed-route diagnostic)
- `bun test` (baseline exit 1: 821 pass, 3 skip, 118 fail, 93 errors)
