### PR TITLE
fix(state-transitions): type error helper

### DIFF
--- a/server/extensions/stateTransitions/common/errors.ts
+++ b/server/extensions/stateTransitions/common/errors.ts
@@ -13,12 +13,12 @@ export type StateTransitionErrorName =
   | 'state-transition-rules-invalid';
 
 export type StateTransitionErrorResponse = {
-  name: StateTransitionErrorName | string;
+  name: string;
   data?: Record<string, unknown>;
 };
 
 export function stateTransitionError(
-  name: StateTransitionErrorName | string,
+  name: string,
   data?: Record<string, unknown>,
 ): StateTransitionErrorResponse {
   return data ? { name, data } : { name };


### PR DESCRIPTION
## Summary
- Make the state-transition error helper’s open-string runtime contract explicit.
- Preserve the existing response shape and all accepted error names, including names used outside the literal alias.

## Validation
- `bunx eslint server/extensions/stateTransitions/common/errors.ts`
- `bun run build:client` (passes; existing chunk-size warnings)
- `git diff --check`
- `bun run typecheck` (baseline exit 2; no changed-file diagnostic)
- `bun test` (baseline exit 1: 821 pass, 3 skip, 118 fail, 93 errors)
