### PR TITLE
fix(board): type board page API boundary

### DIFF
--- a/src/extensions/Board/containers/BoardPage/BoardPage.duck.ts
+++ b/src/extensions/Board/containers/BoardPage/BoardPage.duck.ts
@@ -19,6 +19,11 @@ interface BoardPageState {
   fetchError: SerializedError | null;
 }
 
+type BoardPageResponse = {
+  data: Board;
+  includes: { lists: List[]; cards: unknown[] };
+};
+
 const initialState: BoardPageState = {
   board: null,
   includes: { lists: [], cards: [] },
@@ -31,7 +36,8 @@ const initialState: BoardPageState = {
 export const fetchBoardThunk = createAppAsyncThunk(
   'boardPage/fetch',
   async ({ boardId }: { boardId: string }, { extra }) => {
-    return getBoard({ api: extra.api, boardId });
+    const { api } = extra as { api: { get: <T>(url: string) => Promise<T> } };
+    return (await getBoard({ api, boardId })) as BoardPageResponse;
   },
 );
 


### PR DESCRIPTION
## Summary
- Type the BoardPage thunk’s injected API and established board response boundary.
- Preserve the existing board fetch request, reducer state assignment, loading/error transitions and selectors.

## Validation
- `bunx eslint src/extensions/Board/containers/BoardPage/BoardPage.duck.ts`
- `bun run build:client` (passes; existing chunk-size warnings)
- `git diff --check`
- `bun run typecheck` (baseline exit 2; no changed-file diagnostic)
- `bun test` (baseline exit 1: 821 pass, 3 skip, 118 fail, 93 errors)
