### PR TITLE
fix(board): clarify visibility selection callback

### DIFF
--- a/src/extensions/Board/containers/BoardSettings/VisibilitySelector.tsx
+++ b/src/extensions/Board/containers/BoardSettings/VisibilitySelector.tsx
@@ -45,7 +45,9 @@ const VisibilitySelector = ({ value, onChange, disabled = false }: Props) => {
             name="board-visibility"
             value={opt.value}
             checked={value === opt.value}
-            onChange={() => !disabled && onChange(opt.value)}
+            onChange={() => {
+              if (!disabled) onChange(opt.value);
+            }}
             disabled={disabled}
             className="mt-0.5 accent-blue-500"
           />


### PR DESCRIPTION
## Summary
- Expand the board-visibility radio callback to avoid a conditional void expression.
- Preserve disabled-state and selected-visibility behaviour.

## Validation
- `bunx eslint src/extensions/Board/containers/BoardSettings/VisibilitySelector.tsx`
- `bun run build:client` (passes; existing chunk-size warnings)
- `git diff --check`
- `bun run typecheck` (baseline exit 2; no changed-file diagnostic)
- `bun test` (baseline exit 1: 821 pass, 3 skip, 118 fail, 93 errors)
