### PR TITLE
fix(card): clarify label removal callback

### DIFF
--- a/src/extensions/Card/containers/CardModal/sections/LabelsSection.tsx
+++ b/src/extensions/Card/containers/CardModal/sections/LabelsSection.tsx
@@ -19,7 +19,11 @@ export const LabelsSection = ({ allLabels, assignedLabels, onAttach, onDetach, d
         <LabelChip
           key={label.id}
           label={label}
-          {...(!disabled && { onRemove: () => onDetach(label.id) })}
+          {...(!disabled && {
+            onRemove: () => {
+              void onDetach(label.id);
+            },
+          })}
         />
       ))}
       {!disabled && (


### PR DESCRIPTION
## Summary
- Explicitly discard the label-detach promise in the chip’s void-only callback.
- Preserve label removal, picker attach/detach, and disabled rendering behaviour.

## Validation
- `bunx eslint src/extensions/Card/containers/CardModal/sections/LabelsSection.tsx`
- `bun run build:client` (passes; existing chunk-size warnings)
- `git diff --check`
- `bun run typecheck` (baseline exit 2; no changed-file diagnostic)
- `bun test` (baseline exit 1: 821 pass, 3 skip, 118 fail, 93 errors)
