### PR TITLE
fix(comment): intervention recipients + durable eventId in card.commented webhook payload

### DIFF
--- a/server/extensions/activity/mods/createActivityEvent.ts
+++ b/server/extensions/activity/mods/createActivityEvent.ts
@@ -17,22 +17,27 @@ async function fireCardMemberWebhook({
   cardId,
   actorId,
   eventType,
+  eventId,
   payload,
 }: {
   boardId: string;
   cardId: string;
   actorId: string;
   eventType: WebhookEventType;
+  // Persisted activities.id — one logical member action, stable across retries.
+  eventId: string;
   payload: Record<string, unknown>;
 }): Promise<void> {
   if (!env.WEBHOOKS_ENABLED) return;
   const webhooks = await getActiveWebhooksForEvent({ knex: db, eventType });
   for (const wh of webhooks) {
-    dispatchWebhook({
+    // [why] fire-and-forget delivery — failures are recorded per delivery row
+    // by dispatchWebhook and must never block the activity write.
+    void dispatchWebhook({
       endpoint: wh.endpoint_url,
       signingSecret: wh.signing_secret,
       eventType,
-      payload: { ...payload, boardId, cardId, actorId },
+      payload: { ...payload, boardId, cardId, actorId, eventId },
       webhookId: wh.id,
       knex: db,
     });
@@ -152,8 +157,13 @@ export async function emitCardMemberAssigned({
     boardId: payload.boardId,
     cardId: payload.cardId,
     actorId,
+    eventId: activity.id,
     eventType: 'card.member_assigned',
-    payload: { userId: payload.userId, assigneeName: payload.assigneeName, cardTitle: payload.cardTitle },
+    payload: {
+      userId: payload.userId,
+      assigneeName: payload.assigneeName,
+      cardTitle: payload.cardTitle,
+    },
   }).catch(() => {});
   return activity;
 }
@@ -193,8 +203,13 @@ export async function emitCardMemberUnassigned({
     boardId: payload.boardId,
     cardId: payload.cardId,
     actorId,
+    eventId: activity.id,
     eventType: 'card.member_removed',
-    payload: { userId: payload.userId, assigneeName: payload.assigneeName, cardTitle: payload.cardTitle },
+    payload: {
+      userId: payload.userId,
+      assigneeName: payload.assigneeName,
+      cardTitle: payload.cardTitle,
+    },
   }).catch(() => {});
   return activity;
 }

--- a/server/extensions/comment/api/create.ts
+++ b/server/extensions/comment/api/create.ts
@@ -17,6 +17,9 @@ import { createNotificationsForMentions } from '../../notifications/mods/createN
 import { dispatchDirectCardNotification } from '../../notifications/mods/boardActivityDispatch';
 import { resolveCardId } from '../../../common/ids/resolveEntityId';
 import { generateUniqueShortId } from '../../../common/ids/shortId';
+import { getCardRelatedUserIds } from '../../notifications/mods/relatedCardRecipients';
+import { computeInterventionRecipients } from '../common/interventionRecipients';
+import { buildCommentWebhookPayload } from '../common/commentWebhookPayload';
 
 type CardRow = {
   id: string;
@@ -54,6 +57,11 @@ type CommentWithAuthorRow = CommentRow & {
   author_name: string | null;
   author_email: string | null;
   author_avatar_url: string | null;
+};
+
+type UserRow = {
+  name: string | null;
+  nickname: string | null;
 };
 
 export async function handleCreateComment(req: Request, cardId: string): Promise<Response> {
@@ -142,7 +150,9 @@ export async function handleCreateComment(req: Request, cardId: string): Promise
       );
     }
     const normalizedParentId = rawParentId.trim();
-    const parentComment = await db<CommentRow>('comments').where({ id: normalizedParentId }).first();
+    const parentComment = await db<CommentRow>('comments')
+      .where({ id: normalizedParentId })
+      .first();
     if (!parentComment) {
       return Response.json(
         { error: { code: 'comment-not-found', message: 'Parent comment not found' } },
@@ -284,6 +294,24 @@ export async function handleCreateComment(req: Request, cardId: string): Promise
   });
   const commentData = { ...comment, author_avatar_url: authorAvatarUrl };
 
+  // [why] Intervention recipients drive the Duplanet WhatsApp bridge: card assignees,
+  // checklist assignees and the reply target need a targeted alert, but the actor
+  // (no self-notification) and mentioned users (separate mention event) must be
+  // excluded to prevent duplicate or board-wide notifications.
+  const [relatedUserIds, actorRow] = await Promise.all([
+    getCardRelatedUserIds({ cardId: resolvedCardId }),
+    db('users').where({ id: actorId }).select('name', 'nickname').first() as Promise<
+      UserRow | undefined
+    >,
+  ]);
+  const interventionRecipients = computeInterventionRecipients({
+    cardAssigneeIds: Array.from(relatedUserIds),
+    checklistAssigneeIds: [],
+    replyToUserId,
+    actorId,
+    mentionedUserIds,
+  });
+
   // commentPreview strips HTML tags and truncates to 120 chars.
   const rawPreview = trimmedContent.replaceAll(/<[^>]+>/g, '');
   const commentPreview = rawPreview.length > 120 ? rawPreview.slice(0, 117) + '…' : rawPreview;
@@ -294,7 +322,16 @@ export async function handleCreateComment(req: Request, cardId: string): Promise
       boardId: board.id,
       entityId: resolvedCardId,
       actorId,
-      payload: { commentId: id, cardId: resolvedCardId, cardTitle: card.title },
+      payload: buildCommentWebhookPayload({
+        base: { commentId: id, cardId: resolvedCardId, cardTitle: card.title },
+        boardId: board.id,
+        entityId: resolvedCardId,
+        actorId,
+        actor: { nickname: actorRow?.nickname ?? null, name: actorRow?.name ?? null },
+        commentText: trimmedContent,
+        boardTitle: board.title,
+        interventionRecipients,
+      }),
     }),
     writeActivity({
       entityType: 'card',
@@ -314,12 +351,15 @@ export async function handleCreateComment(req: Request, cardId: string): Promise
         JSON.stringify({
           type: 'comment_reply_added',
           payload: { card_id: resolvedCardId, parent_comment_id: parentId, reply: commentData },
-        }),
+        })
       )
       .catch(() => {});
   } else {
     publisher
-      .publish(board.id, JSON.stringify({ type: 'comment_added', payload: { comment: commentData } }))
+      .publish(
+        board.id,
+        JSON.stringify({ type: 'comment_added', payload: { comment: commentData } })
+      )
       .catch(() => {});
   }
 

--- a/server/extensions/comment/common/commentWebhookPayload.ts
+++ b/server/extensions/comment/common/commentWebhookPayload.ts
@@ -1,0 +1,61 @@
+// Builds the additive, backward-compatible card.commented webhook payload.
+// [why] Existing subscribers (bridge/Discord, Trello-compat consumers) parse a fixed
+// payload shape; the intervention contract must only add fields, never rename or
+// re-type existing ones. interventionUserIds is omitted entirely when empty so
+// legacy consumers see byte-identical semantics for non-intervention comments.
+// [why] Display fields delegate to the canonical mention-context helpers so a
+// comment alert and a mention alert format identically downstream (single
+// source of truth for entity decoding, whitespace collapsing, the 200-char
+// total preview cap and the no-email actor name policy).
+
+import {
+  buildActorDisplayName,
+  buildSourcePreview,
+} from '../../notifications/mods/mentionWebhookContext';
+
+export interface BuildCommentWebhookPayloadInput {
+  /** Existing payload fields — forwarded untouched and never mutated. */
+  base: Record<string, unknown>;
+  boardId: string;
+  entityId: string;
+  actorId: string;
+  /** Actor row (nickname + name) used for the email-safe display name. */
+  actor: { nickname?: string | null; name?: string | null };
+  /** Raw comment content (possibly rich text) — bounded to a plain-text preview. */
+  commentText: string;
+  boardTitle: string;
+  /** Deduplicated intervention recipients from computeInterventionRecipients(). */
+  interventionRecipients: string[];
+}
+
+export function buildCommentWebhookPayload({
+  base,
+  boardId,
+  entityId,
+  actorId,
+  actor,
+  commentText,
+  boardTitle,
+  interventionRecipients,
+}: BuildCommentWebhookPayloadInput): Record<string, unknown> {
+  // [why] Spread a fresh object — the caller's base payload must never be mutated.
+  const payload: Record<string, unknown> = { ...base };
+
+  // Backward-compatibility guard: existing fields keep their original values.
+  payload.boardId = boardId;
+  payload.entityId = entityId;
+  payload.actorId = actorId;
+
+  if (interventionRecipients.length > 0) {
+    payload.interventionUserIds = [...interventionRecipients];
+  }
+
+  payload.boardTitle = boardTitle;
+  payload.actorName = buildActorDisplayName({
+    nickname: actor.nickname,
+    name: actor.name,
+  });
+  payload.sourcePreview = buildSourcePreview({ sourceText: commentText });
+
+  return payload;
+}

--- a/server/extensions/comment/common/interventionRecipients.ts
+++ b/server/extensions/comment/common/interventionRecipients.ts
@@ -1,0 +1,49 @@
+// Pure recipient computation for comment intervention alerts.
+// [why] The Duplanet WhatsApp bridge routes card.commented alerts using the
+// interventionUserIds list carried in the webhook payload. A comment must alert
+// only users who are materially involved with the card — card assignees,
+// checklist assignees, and the reply target — never the whole board, never the
+// actor, and never mentioned users (they receive the dedicated mention event,
+// so including them here would double-notify across events).
+
+export interface InterventionRecipientsInput {
+  cardAssigneeIds: ReadonlyArray<string | null | undefined>;
+  checklistAssigneeIds: ReadonlyArray<string | null | undefined>;
+  replyToUserId: string | null;
+  actorId: string;
+  mentionedUserIds: ReadonlyArray<string | null | undefined>;
+}
+
+const isNonEmptyId = (value: string | null | undefined): value is string =>
+  typeof value === 'string' && value.trim() !== '';
+
+/**
+ * Deterministic, deduplicated, order-invariant intervention recipient list:
+ * (card assignees ∪ checklist assignees ∪ reply target) − actor − mentioned users.
+ * The result is sorted so any input permutation yields the identical output —
+ * the bridge can diff/compare payloads without order sensitivity.
+ */
+export function computeInterventionRecipients({
+  cardAssigneeIds,
+  checklistAssigneeIds,
+  replyToUserId,
+  actorId,
+  mentionedUserIds,
+}: InterventionRecipientsInput): string[] {
+  const mentioned = new Set(mentionedUserIds.filter(isNonEmptyId).map((id) => id.trim()));
+
+  const recipients = new Set<string>();
+  const consider = (candidate: string | null | undefined): void => {
+    if (!isNonEmptyId(candidate)) return;
+    const id = candidate.trim();
+    if (id === actorId) return;
+    if (mentioned.has(id)) return;
+    recipients.add(id);
+  };
+
+  for (const id of cardAssigneeIds) consider(id);
+  for (const id of checklistAssigneeIds) consider(id);
+  consider(replyToUserId);
+
+  return Array.from(recipients).sort();
+}

--- a/server/extensions/notifications/mods/__tests__/mentionWebhookContext.test.ts
+++ b/server/extensions/notifications/mods/__tests__/mentionWebhookContext.test.ts
@@ -89,6 +89,8 @@ describe('buildMentionWebhookPayload — stable enriched contract', () => {
         boardName: 'Phoenix Ops',
         sourceText: '<p>Please review\nthis before Friday.</p>',
         actor: { nickname: 'maria', name: 'Maria Silva' },
+        // [why] durable producer event identity (ADR chimedeck-whatsapp-dedupe-contract)
+        eventId: 'mention-event-1',
       })
     ).toEqual({
       boardId: 'board-1',
@@ -101,6 +103,7 @@ describe('buildMentionWebhookPayload — stable enriched contract', () => {
       boardTitle: 'Phoenix Ops',
       sourcePreview: 'Please review this before Friday.',
       actorName: 'maria',
+      eventId: 'mention-event-1',
     });
   });
 });

--- a/server/extensions/notifications/mods/createNotifications.ts
+++ b/server/extensions/notifications/mods/createNotifications.ts
@@ -14,6 +14,7 @@ import { dispatchNotificationEmail } from './emailDispatch';
 import { env } from '../../../config/env';
 import { getActiveWebhooksForEvent } from '../../webhooks/mods/registry';
 import { dispatchWebhook } from '../../webhooks/mods/dispatch';
+import { randomUUID } from 'node:crypto';
 import { buildMentionWebhookPayload, type MentionWebhookPayload } from './mentionWebhookContext';
 import type { Knex } from 'knex';
 
@@ -107,7 +108,7 @@ async function notifyMentionedUser({
       read: false,
       created_at: now,
     },
-    ['*'],
+    ['*']
   );
 
   await publishToUser(userId, {
@@ -160,7 +161,7 @@ export async function createNotificationsForMentions({
   // Fetch actor details once for the WS payload (read-only, outside transaction is fine)
   const actor = await db('users')
     .where({ id: actorId })
-    .select('id', 'nickname', db.raw("COALESCE(name, email) as name"), 'avatar_url')
+    .select('id', 'nickname', db.raw('COALESCE(name, email) as name'), 'avatar_url')
     .first();
 
   const actorPayload = actor
@@ -205,6 +206,11 @@ export async function createNotificationsForMentions({
       boardName,
       sourceText,
       actor: actorPayload as Record<string, unknown>,
+      // [why] Mint ONE durable id per logical mention emission — NOT per
+      // recipient, and deliberately NOT sourceId (card-description mentions are
+      // 1:N across edits and would false-collapse legitimate repeat mentions
+      // at the receiver's semantic dedupe).
+      eventId: randomUUID(),
     });
     fireMentionWebhooks({
       payload,

--- a/server/extensions/notifications/mods/mentionWebhookContext.ts
+++ b/server/extensions/notifications/mods/mentionWebhookContext.ts
@@ -86,6 +86,8 @@ export interface MentionWebhookPayload extends Record<string, unknown> {
   boardTitle: string;
   sourcePreview: string;
   actorName: string | null;
+  /** Durable producer event identity for receiver-side semantic dedupe (ADR). */
+  eventId: string;
 }
 
 export function buildMentionWebhookPayload({
@@ -99,6 +101,7 @@ export function buildMentionWebhookPayload({
   boardName,
   sourceText,
   actor,
+  eventId,
 }: {
   boardId: string;
   cardId: string | null;
@@ -110,6 +113,7 @@ export function buildMentionWebhookPayload({
   boardName?: string | undefined;
   sourceText?: string | undefined;
   actor: Record<string, unknown>;
+  eventId: string;
 }): MentionWebhookPayload {
   const actorNickname = typeof actor['nickname'] === 'string' ? actor['nickname'] : null;
   const actorName = typeof actor['name'] === 'string' ? actor['name'] : null;
@@ -124,5 +128,6 @@ export function buildMentionWebhookPayload({
     boardTitle: boardName ?? '',
     sourcePreview: buildSourcePreview({ sourceText }),
     actorName: buildActorDisplayName({ nickname: actorNickname, name: actorName }),
+    eventId,
   };
 }

--- a/server/mods/events/dispatch.ts
+++ b/server/mods/events/dispatch.ts
@@ -112,6 +112,10 @@ export async function dispatchEvent(input: WriteEventInput): Promise<WrittenEven
                 boardId: event.board_id,
                 entityId: event.entity_id,
                 actorId: event.actor_id,
+                // Durable producer identity (ADR chimedeck-whatsapp-dedupe-contract):
+                // receiver keys semantic dedupe on this, so re-signed retries of
+                // the same logical event collapse into one delivery set.
+                eventId: event.id,
               },
               webhookId: webhook.id,
               knex: db,

--- a/specs/changelog/20260908_173212.md
+++ b/specs/changelog/20260908_173212.md
@@ -1,0 +1,24 @@
+# Changelog — 2026-09-08 17:32:12
+
+## Update
+
+- `POST /cards/:id/comments` now emits an additive `interventionUserIds` list on the `card.commented` / `card_commented` webhook payload: (card assignees ∪ checklist assignees ∪ reply target) − actor − mentioned users, deduplicated and deterministically sorted. Existing payload fields are untouched and the field is omitted entirely when empty, so legacy webhook consumers (including the currently deployed bridge) see no change for non-intervention comments.
+- The comment webhook payload additionally carries `boardTitle`, `actorName` and `sourcePreview`, built by the canonical mention-context helpers (`mentionWebhookContext.ts`) so comment alerts and mention alerts format identically downstream: email-safe actor display name (nickname preferred, `null` when only an email is available — never leaks an address) and a plain-text preview with entity decoding, whitespace collapsing and a 200-char total cap.
+
+## New
+
+- `server/extensions/comment/common/interventionRecipients.ts` — pure, order-invariant recipient computation for comment intervention alerts.
+- `server/extensions/comment/common/commentWebhookPayload.ts` — additive payload builder enforcing the backward-compatibility guard (existing fields forwarded untouched, base payload never mutated, `interventionUserIds` omitted when empty) and delegating display fields to the canonical helpers.
+- Unit contract tests: `tests/unit/server/extensions/comment/interventionRecipients.test.ts` (13 pure-helper/delegation cases) and `tests/unit/server/extensions/comment/commentInterventionContract.test.ts` (4 offline endpoint/dispatch cases covering assignees+reply-target routing, actor/self exclusion, mention exclusion, and identical payload fanout to both `card.commented` and `card_commented` aliases).
+
+## Technical Debt
+
+- `checklistAssigneeIds` is currently fed as an empty array at the call site because `getCardRelatedUserIds()` returns the union of card and checklist assignees as one set; the helper accepts them separately so a future split query can feed it without contract change.
+- A durable producer `eventId` (semantic dedupe contract, ADR on card t_ec5cc8df) is not yet emitted by this change; it lands as a separate transplantable patch from sibling card t_c208ea26 and must be reconciled on this branch before release.
+- The full `bun test` run has ~118 pre-existing failures on origin/main (missing DATABASE_URL, Playwright-in-bun, shared-module mock bleed); this change adds zero new failures. CI gates on `build:client` + `git diff --check` only.
+
+## What Should Be Done Next
+
+- Consume the `eventId` patch from t_c208ea26 at `server/mods/events/dispatch.ts` (payload assembly) plus the two other dispatch sites.
+- Bridge-side consumer work: route `card.commented` only via `interventionUserIds` on the Duplanet WhatsApp bridge (card t_70a7412b).
+- In-app/email `card_commented` behavior is unchanged by design; the pre-existing board-wide in-app notification path is out of scope for this fix.

--- a/specs/changelog/20260908_175632.md
+++ b/specs/changelog/20260908_175632.md
@@ -1,0 +1,18 @@
+# Changelog — 2026-09-08 17:56:32
+
+## Update
+
+- Every producer webhook dispatch site now threads a durable `eventId` into the signed payload (ADR `chimedeck-whatsapp-dedupe-contract`): the pipeline dispatcher uses the persisted `events.id` (`server/mods/events/dispatch.ts`), member-assign events use the persisted `activities.id` (`createActivityEvent.ts`), and each logical mention emission mints one `randomUUID()` — never per-recipient and deliberately not `sourceId`, because card-description mentions are 1:N across edits and would false-collapse legitimate repeat mentions at the receiver's semantic dedupe. The field is additive; in-app/email behavior is untouched.
+
+## New
+
+- `tests/unit/server/extensions/comment/cardEventIdDispatchContract.test.ts` — dispatch-site contract suite transplanted from sibling card t_c208ea26: member-assign events must carry the persisted `activity.id` as `eventId`, one mention emission must send exactly one webhook with a conforming `eventId` (non-empty, ≤128 chars, not `sourceId`), and distinct logical emissions must mint distinct ids. All mocks offline (endpoint `127.0.0.1:1`).
+
+## Technical Debt
+
+- The earlier `20260908_173212.md` "What Should Be Done Next" item — consuming the eventId patch at the three dispatch sites — is now resolved by this change on this branch.
+- Typecheck baseline note: `tsc --noEmit` reports 157 pre-existing errors on `origin/main` (2a37cd1), all in client `src/` files; this change adds zero new errors and leaves all touched server production files error-free in both trees.
+
+## What Should Be Done Next
+
+- Bridge-side consumer: route `card.commented` via `interventionUserIds` + semantic dedupe on `eventId` on the Duplanet WhatsApp bridge (card t_70a7412b, receiver already committed as fb37f55 in the bridge repo).

--- a/tests/unit/server/extensions/comment/cardEventIdDispatchContract.test.ts
+++ b/tests/unit/server/extensions/comment/cardEventIdDispatchContract.test.ts
@@ -1,0 +1,182 @@
+// Dispatch-site payload contract tests (mocked): every producer dispatch site
+// must thread a durable eventId into the signed payload, and the
+// card.commented payload must carry additive interventionUserIds (covered by
+// producer_intervention_contract.test.ts + the receiver suite).
+// All IDs synthetic; endpoint 127.0.0.1:1; no network egress possible.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// [why] transplanted from sibling card t_c208ea26's dispatch-contract suite —
+// the knex/timeline mocks are intentionally loose `any` proxies.
+import { describe, expect, test, mock, beforeEach } from 'bun:test';
+
+const writeActivityMock = mock(async (input: any) => ({
+  id: 'activity-1',
+  action: input.action,
+  actor_id: input.actorId,
+  payload: input.payload,
+  created_at: new Date().toISOString(),
+}));
+const dispatchWebhookMock = mock(() => Promise.resolve());
+
+// Generic chainable knex stand-in: every terminal verb resolves to a value.
+function chain(final: any) {
+  const p: any = Promise.resolve(final);
+  const handler: any = {
+    get(_t: unknown, prop: string) {
+      if (prop === 'then') return p.then.bind(p);
+      if (prop === 'catch') return p.catch.bind(p);
+      if (prop === 'first') return () => p;
+      return () => new Proxy(() => {}, handler);
+    },
+    apply() {
+      return new Proxy(() => {}, handler);
+    },
+  };
+  return new Proxy(() => {}, handler);
+}
+const dbMock = mock((table: string) => {
+  if (table === 'users') return chain(undefined); // actor fetch misses → fallback payload
+  return chain([]);
+});
+(dbMock as any).raw = () => 'RAW';
+const trxMock = mock((table: string) => {
+  if (table === 'notifications') return chain([{ id: 'notif-1' }]);
+  return chain([]);
+});
+
+mock.module('../../../../../server/extensions/activity/mods/write', () => ({
+  writeActivity: writeActivityMock,
+}));
+mock.module('../../../../../server/mods/events/publishCardActivityEvent', () => ({
+  publishCardActivityEvent: mock(() => Promise.resolve()),
+}));
+mock.module('../../../../../server/extensions/activity/mods/mapActivityToNotification', () => ({
+  mapActivityToNotification: mock(() => Promise.resolve()),
+}));
+mock.module('../../../../../server/common/db', () => ({ db: dbMock }));
+mock.module('../../../../../server/config/env', () => ({
+  env: { WEBHOOKS_ENABLED: true, NOTIFICATION_PREFERENCES_ENABLED: false },
+}));
+mock.module('../../../../../server/extensions/webhooks/mods/registry', () => ({
+  getActiveWebhooksForEvent: mock(async () => [
+    { id: 'wh-1', endpoint_url: 'http://127.0.0.1:1/hook', signing_secret: 's' },
+  ]),
+}));
+mock.module('../../../../../server/extensions/webhooks/mods/dispatch', () => ({
+  dispatchWebhook: dispatchWebhookMock,
+}));
+
+// Mention-site dependencies (notifications module).
+mock.module('../../../../../server/extensions/realtime/userChannel', () => ({
+  publishToUser: mock(() => Promise.resolve()),
+}));
+mock.module('../../../../../server/extensions/notifications/mods/preferenceGuard', () => ({
+  preferenceGuard: mock(async () => ({ in_app_enabled: true })),
+}));
+mock.module('../../../../../server/extensions/notifications/mods/boardPreferenceGuard', () => ({
+  boardPreferenceGuard: mock(async () => true),
+}));
+mock.module('../../../../../server/extensions/notifications/mods/globalPreferenceGuard', () => ({
+  globalPreferenceGuard: mock(async () => true),
+}));
+mock.module('../../../../../server/extensions/notifications/mods/emailDispatch', () => ({
+  dispatchNotificationEmail: mock(() => Promise.resolve()),
+}));
+
+const { emitCardMemberAssigned, emitCardMemberUnassigned } =
+  await import('../../../../../server/extensions/activity/mods/createActivityEvent');
+const { createNotificationsForMentions } =
+  await import('../../../../../server/extensions/notifications/mods/createNotifications');
+
+// fire-and-forget webhook helpers need a microtask/timer flush before asserts.
+const flush = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+beforeEach(() => {
+  writeActivityMock.mockClear();
+  dispatchWebhookMock.mockClear();
+});
+
+describe('member webhook dispatch carries durable eventId', () => {
+  test('emitCardMemberAssigned threads the persisted activity.id as eventId', async () => {
+    await emitCardMemberAssigned({
+      actorId: 'actor-1',
+      cardId: 'card-1',
+      cardTitle: 'Card title',
+      userId: 'user-2',
+      assigneeName: 'Bob',
+      boardId: 'board-1',
+      workspaceId: 'workspace-1',
+    });
+    await flush();
+
+    expect(dispatchWebhookMock).toHaveBeenCalledTimes(1);
+    const call = dispatchWebhookMock.mock.calls[0][0];
+    // eventId must be the persisted activities.id UUID (from writeActivity).
+    expect(call.payload.eventId).toBe('activity-1');
+    expect(call.eventType).toBe('card.member_assigned');
+  });
+
+  test('emitCardMemberUnassigned threads the persisted activity.id as eventId', async () => {
+    await emitCardMemberUnassigned({
+      actorId: 'actor-1',
+      cardId: 'card-1',
+      cardTitle: 'Card title',
+      userId: 'user-2',
+      assigneeName: 'Bob',
+      boardId: 'board-1',
+      workspaceId: 'workspace-1',
+    });
+    await flush();
+
+    expect(dispatchWebhookMock).toHaveBeenCalledTimes(1);
+    const call = dispatchWebhookMock.mock.calls[0][0];
+    expect(call.payload.eventId).toBe('activity-1');
+    expect(call.eventType).toBe('card.member_removed');
+  });
+});
+
+describe('mention webhook dispatch carries durable eventId', () => {
+  test('one mention emission sends ONE webhook with a conforming eventId', async () => {
+    await createNotificationsForMentions({
+      trx: trxMock as any,
+      addedUserIds: ['user-a', 'user-b'],
+      actorId: 'actor-1',
+      sourceType: 'comment',
+      sourceId: 'comment-1',
+      cardId: 'card-1',
+      boardId: 'board-1',
+    });
+    await flush();
+
+    expect(dispatchWebhookMock).toHaveBeenCalledTimes(1);
+    const call = dispatchWebhookMock.mock.calls[0][0];
+    expect(call.eventType).toBe('mention');
+    // Conforming eventId: non-empty string, ≤128 chars, NOT the sourceId.
+    const eventId = call.payload.eventId;
+    expect(typeof eventId).toBe('string');
+    expect(eventId.length).toBeGreaterThan(0);
+    expect(eventId.length).toBeLessThanOrEqual(128);
+    expect(eventId).not.toBe('comment-1');
+    expect(eventId).not.toBe('card-1');
+    // Mention context is preserved alongside the new field.
+    expect(call.payload.mentionedUserIds).toEqual(['user-a', 'user-b']);
+  });
+
+  test('distinct logical mention emissions mint distinct eventIds', async () => {
+    for (let i = 0; i < 2; i++) {
+      await createNotificationsForMentions({
+        trx: trxMock as any,
+        addedUserIds: ['user-a'],
+        actorId: 'actor-1',
+        sourceType: 'card_description',
+        sourceId: 'card-1',
+        cardId: 'card-1',
+        boardId: 'board-1',
+      });
+      await flush();
+    }
+    expect(dispatchWebhookMock).toHaveBeenCalledTimes(2);
+    const first = dispatchWebhookMock.mock.calls[0][0].payload.eventId;
+    const second = dispatchWebhookMock.mock.calls[1][0].payload.eventId;
+    expect(first).not.toBe(second);
+  });
+});

--- a/tests/unit/server/extensions/comment/commentInterventionContract.test.ts
+++ b/tests/unit/server/extensions/comment/commentInterventionContract.test.ts
@@ -249,7 +249,13 @@ mock.module('../../../../../server/config/env', () => ({
   },
 }));
 
+// [why] Snapshot the REAL avatar module before overriding: bun's mock.module is
+// process-global, so the override must forward every other export untouched —
+// otherwise later test files in the same process (e.g. the eventId dispatch
+// suite) break on missing named exports (cross-file mock bleed).
+const realAvatarModule = await import('../../../../../server/common/avatar/resolveAvatarUrl');
 mock.module('../../../../../server/common/avatar/resolveAvatarUrl', () => ({
+  ...realAvatarModule,
   buildAvatarProxyUrl: ({ avatarUrl }: { avatarUrl: string | null }) =>
     avatarUrl ? '/api/v1/users/u/avatar' : null,
 }));
@@ -306,6 +312,10 @@ describe('handleCreateComment → card.commented intervention contract', () => {
     expect(payload!.sourcePreview).toBe('Please review');
     expect(payload!.actorName).toBe('Test Actor');
     expect((payload!.actorName as string).includes('@')).toBe(false);
+    // [why] durable producer event identity (ADR chimedeck-whatsapp-dedupe-contract):
+    // the persisted events.id so the receiver can semantically dedupe re-signed retries
+    expect(typeof payload!.eventId).toBe('string');
+    expect((payload!.eventId as string).length).toBeGreaterThan(0);
   });
 
   it('includes the reply target for threaded replies', async () => {

--- a/tests/unit/server/extensions/comment/commentInterventionContract.test.ts
+++ b/tests/unit/server/extensions/comment/commentInterventionContract.test.ts
@@ -1,0 +1,369 @@
+// Endpoint/dispatch contract test — comment intervention webhook payload.
+// [why] The QA investigation proved the deployed card.commented payload can never
+// queue a WhatsApp delivery (no per-user target). This test pins the contract:
+// handleCreateComment must build its webhook payload via the intervention payload
+// builder, carrying deduplicated interventionUserIds (assignees + reply target
+// − actor − mentioned) plus boardTitle/actorName/sourcePreview, and dispatchEvent
+// must fan the exact payload out to every card.commented/card_commented webhook.
+// Runs fully offline: db and pubsub are replaced with an in-memory fake.
+import { describe, expect, it, mock } from 'bun:test';
+import type { Knex } from 'knex';
+
+// ── Module mocks (must be registered before importing the modules under test) ──
+
+type Row = Record<string, unknown>;
+
+// Any table the comment-creation flow touches (directly or via imports).
+const KNOWN_TABLES = [
+  'cards',
+  'lists',
+  'boards',
+  'comments',
+  'card_members',
+  'checklist_items',
+  'users',
+  'activities',
+  'events',
+  'mentions',
+  'notifications',
+  'webhooks',
+] as const;
+
+const state: Record<(typeof KNOWN_TABLES)[number], Row[]> = Object.fromEntries(
+  KNOWN_TABLES.map((name) => [name, []])
+) as Record<(typeof KNOWN_TABLES)[number], Row[]>;
+
+function table(name: string): Row[] {
+  if ((KNOWN_TABLES as readonly string[]).includes(name)) {
+    return state[name as (typeof KNOWN_TABLES)[number]];
+  }
+  // [why] The handler passes the transaction handle through too; accept it as
+  // a valid (comments-backed) table to keep the fake permissive.
+  return state.comments;
+}
+
+// Minimal chainable knex-like query builder over the in-memory state.
+// [why] The chainable no-op methods intentionally ignore their arguments — they
+// exist only to satisfy the knex call shapes the handler uses.
+/* eslint-disable @typescript-eslint/no-unused-vars */
+function builder(name: string): Record<string, unknown> {
+  const rows = table(name);
+  const api = {
+    _rows: rows,
+    where(_cond: Row | string, _value?: unknown) {
+      return this;
+    },
+    orWhere(_col: string, _value: unknown) {
+      return this;
+    },
+    whereNotNull(_col: string) {
+      return this;
+    },
+    whereIn(_col: string, _values: unknown[]) {
+      return this;
+    },
+    join(_join: string, _on: string) {
+      return this;
+    },
+    leftJoin(_table: string, _a: string, _b: string) {
+      return this;
+    },
+    select(..._cols: unknown[]) {
+      return this;
+    },
+    // [why] knex builders are thenable and resolve to row arrays — mirror that so
+    // callers can await queries directly (e.g. inside Promise.all).
+    then(onFulfilled?: (rows: Row[]) => unknown, onRejected?: (err: unknown) => unknown) {
+      return Promise.resolve([...rows]).then(onFulfilled, onRejected);
+    },
+    first() {
+      return Promise.resolve(rows[0] ?? undefined);
+    },
+    pluck(_col: string) {
+      return Promise.resolve([] as unknown[]);
+    },
+    insert(row: Row, _returning?: unknown) {
+      // [why] Postgres jsonb round-trip: the caller stringifies payloads on write and
+      // the pg driver hands back a parsed object on read — mimic that here, and
+      // synthesize the events table's bigserial sequence/created_at columns.
+      const stored: Row = { ...row };
+      if (typeof stored.payload === 'string') {
+        stored.payload = JSON.parse(stored.payload as string) as unknown;
+      }
+      if ('entity_id' in stored && !('sequence' in stored)) {
+        stored.sequence = BigInt(rows.length + 1);
+        stored.created_at = new Date().toISOString();
+      }
+      rows.push(stored);
+      return Promise.resolve([stored]) as unknown as Record<string, unknown>;
+    },
+  };
+  return api;
+}
+
+const fakeDb = (() => {
+  const dbFn = (name: string) => builder(name);
+  (
+    dbFn as unknown as {
+      transaction: (cb: (trx: unknown) => Promise<void>) => Promise<void>;
+    }
+  ).transaction = async (cb) => {
+    // trx must be callable (trx('table')) — build a function carrying the builder API.
+    const trx = Object.assign((tableName: string) => builder(tableName), builder('__trx__'));
+    await cb(trx);
+  };
+  (dbFn as unknown as { raw: (sql: string) => unknown }).raw = (sql: string) => ({ __raw: sql });
+  return dbFn as unknown as Knex;
+})();
+
+mock.module('../../../../../server/common/db', () => ({ db: fakeDb }));
+
+const published: Array<{ channel: string; message: string }> = [];
+mock.module('../../../../../server/mods/pubsub/publisher', () => ({
+  publisher: {
+    publish: (channel: string, message: string) => {
+      published.push({ channel, message });
+      return Promise.resolve();
+    },
+  },
+}));
+
+// Capture webhook dispatches — the contract under test.
+// [why] Import the real modules BEFORE mocking and snapshot the original functions:
+// bun's mock.module is process-global, so the mock must pass through to the real
+// implementation whenever it is called with a foreign knex instance — otherwise
+// unrelated suites in the same full-suite process (e.g. webhooks dispatch tests)
+// would observe the mock and fail (cross-file mock bleed).
+const realWebhookDispatchModule =
+  await import('../../../../../server/extensions/webhooks/mods/dispatch');
+const realDispatchWebhook = realWebhookDispatchModule.dispatchWebhook;
+const webhookDispatches: Array<{ eventType: string; payload: Row }> = [];
+mock.module('../../../../../server/extensions/webhooks/mods/dispatch', () => ({
+  dispatchWebhook: (input: { eventType: string; payload: Row; knex: unknown }) => {
+    if (input.knex !== fakeDb) return realDispatchWebhook(input);
+    webhookDispatches.push({ eventType: input.eventType, payload: input.payload });
+    return Promise.resolve();
+  },
+}));
+
+// [why] Same passthrough pattern for the registry: fake-db callers get deterministic
+// subscribers (dot + underscore alias) so fanout/dedupe is observable; everyone else
+// hits the real registry.
+const realRegistryModule = await import('../../../../../server/extensions/webhooks/mods/registry');
+const realGetActiveWebhooksForEvent = realRegistryModule.getActiveWebhooksForEvent;
+mock.module('../../../../../server/extensions/webhooks/mods/registry', () => ({
+  getActiveWebhooksForEvent: (input: { knex: unknown; eventType: string }) => {
+    if (input.knex !== fakeDb) return realGetActiveWebhooksForEvent(input);
+    return Promise.resolve([
+      {
+        id: `wh-${input.eventType}`,
+        created_by: 'u-system',
+        label: `bridge-${input.eventType}`,
+        endpoint_url: 'https://bridge.example.test/hook',
+        signing_secret: 'test-secret',
+        event_types: [input.eventType],
+        is_active: true,
+      },
+    ]);
+  },
+}));
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const WORKSPACE_ID = 'ws-1';
+const BOARD_ID = 'board-1';
+const BOARD_TITLE = 'AutoBag';
+const CARD_ID = 'card-1';
+const CARD_TITLE = 'Fix login flow';
+const ACTOR_ID = 'u-actor';
+const CARD_ASSIGNEE = 'u-card-assignee';
+const CHECKLIST_ASSIGNEE = 'u-checklist-assignee';
+const REPLY_TARGET = 'u-reply-target';
+
+function seedBaseState(): void {
+  for (const rows of Object.values(state)) rows.length = 0;
+
+  state.boards.push({
+    id: BOARD_ID,
+    workspace_id: WORKSPACE_ID,
+    state: 'ACTIVE',
+    title: BOARD_TITLE,
+  });
+  state.lists.push({ id: 'list-1', board_id: BOARD_ID });
+  state.cards.push({ id: CARD_ID, list_id: 'list-1', title: CARD_TITLE });
+  state.card_members.push({ card_id: CARD_ID, user_id: CARD_ASSIGNEE });
+  state.checklist_items.push({ card_id: CARD_ID, assigned_member_id: CHECKLIST_ASSIGNEE });
+  state.users.push({ id: ACTOR_ID, name: 'Test Actor', nickname: null });
+}
+
+function makeRequest(body: Row): Request {
+  return new Request(`http://localhost/api/v1/cards/${CARD_ID}/comments`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as Request & { currentUser?: { id: string; email: string } };
+}
+
+// The auth + permission middlewares read these via the mocked modules below;
+// handler auth is bypassed because authenticate() is overridden to resolve
+// the injected current user.
+const CURRENT_USER = { id: ACTOR_ID, email: 'actor@example.test' };
+
+mock.module('../../../../../server/extensions/auth/middlewares/authentication', () => ({
+  authenticate: async (req: { currentUser?: { id: string; email: string } }) => {
+    (req as { currentUser?: { id: string; email: string } }).currentUser = CURRENT_USER;
+    return null;
+  },
+}));
+
+mock.module('../../../../../server/middlewares/permissionManager', () => ({
+  requireWorkspaceMembership: async () => null,
+  requireMemberOrBoardGuestMember: async () => null,
+}));
+
+mock.module('../../../../../server/common/ids/resolveEntityId', () => ({
+  resolveCardId: async (identifier: string) => (identifier === CARD_ID ? CARD_ID : null),
+}));
+
+mock.module('../../../../../server/common/ids/shortId', () => ({
+  generateUniqueShortId: async () => 'sh0rtId1',
+}));
+
+mock.module('../../../../../server/common/mentions/sync', () => ({
+  syncMentions: async () => ({ addedUserIds: [] }),
+}));
+
+mock.module('../../../../../server/extensions/notifications/mods/createNotifications', () => ({
+  createNotificationsForMentions: async () => {},
+}));
+
+mock.module('../../../../../server/extensions/notifications/mods/boardActivityDispatch', () => ({
+  dispatchDirectCardNotification: async () => {},
+  handleBoardActivityNotification: async () => {},
+}));
+
+mock.module('../../../../../server/config/env', () => ({
+  env: {
+    WEBHOOKS_ENABLED: true,
+    NOTIFICATION_PREFERENCES_ENABLED: false,
+  },
+}));
+
+mock.module('../../../../../server/common/avatar/resolveAvatarUrl', () => ({
+  buildAvatarProxyUrl: ({ avatarUrl }: { avatarUrl: string | null }) =>
+    avatarUrl ? '/api/v1/users/u/avatar' : null,
+}));
+
+const flush = () => new Promise((r) => setTimeout(r, 50));
+
+// [why] Import the REAL dispatch module alongside the mocks: bun's mock.module is
+// process-global, and without a real-path import here the dispatcher loaded by
+// another test file in the same full-suite process would keep the mocked
+// dispatchWebhook — breaking unrelated suites (cross-file mock bleed).
+await import('../../../../../server/mods/events/dispatch');
+// [why] Loaded after all mock.module registrations so the handler resolves the
+// mocked db/auth/mentions/notification modules.
+const { handleCreateComment } = await import('../../../../../server/extensions/comment/api/create');
+
+/** Latest captured comment payload with the given legacy commentId, if any. */
+function capturedCommentPayload(): Record<string, unknown> | undefined {
+  for (let i = webhookDispatches.length - 1; i >= 0; i -= 1) {
+    const candidate = webhookDispatches[i].payload as Record<string, unknown>;
+    if (candidate && typeof candidate.commentId === 'string') return candidate;
+  }
+  return undefined;
+}
+
+// ── Contract tests ───────────────────────────────────────────────────────────
+
+describe('handleCreateComment → card.commented intervention contract', () => {
+  it('dispatches interventionUserIds with assignees + reply target, minus actor and mentioned, plus display fields', async () => {
+    seedBaseState();
+    webhookDispatches.length = 0;
+
+    const response = await handleCreateComment(makeRequest({ content: 'Please review' }), CARD_ID);
+    expect(response.status).toBe(201);
+
+    await flush();
+
+    const payload = capturedCommentPayload();
+    expect(payload).toBeDefined();
+
+    // Legacy fields preserved
+    expect(payload!.commentId).toBeTypeOf('string');
+    expect(payload!.cardId).toBe(CARD_ID);
+    expect(payload!.cardTitle).toBe(CARD_TITLE);
+    expect(payload!.boardId).toBe(BOARD_ID);
+    expect(payload!.entityId).toBe(CARD_ID);
+    expect(payload!.actorId).toBe(ACTOR_ID);
+
+    // New intervention contract
+    expect((payload!.interventionUserIds as string[]).sort()).toEqual(
+      [CARD_ASSIGNEE, CHECKLIST_ASSIGNEE].sort()
+    );
+    expect(payload!.boardTitle).toBe(BOARD_TITLE);
+    // [why] canonical preview semantics: plain text passes through unchanged
+    expect(payload!.sourcePreview).toBe('Please review');
+    expect(payload!.actorName).toBe('Test Actor');
+    expect((payload!.actorName as string).includes('@')).toBe(false);
+  });
+
+  it('includes the reply target for threaded replies', async () => {
+    seedBaseState();
+    // Parent comment authored by the reply target
+    state.comments.push({
+      id: 'parent-1',
+      card_id: CARD_ID,
+      user_id: REPLY_TARGET,
+      content: 'original',
+      parent_id: null,
+    });
+    webhookDispatches.length = 0;
+
+    const response = await handleCreateComment(
+      makeRequest({ content: 'a reply', parent_id: 'parent-1' }),
+      CARD_ID
+    );
+    expect(response.status).toBe(201);
+    await flush();
+
+    const payload = capturedCommentPayload();
+    expect(payload).toBeDefined();
+    expect((payload!.interventionUserIds as string[]).sort()).toEqual(
+      [CARD_ASSIGNEE, CHECKLIST_ASSIGNEE, REPLY_TARGET].sort()
+    );
+  });
+
+  it('self comment on a fully self-assigned card dispatches no interventionUserIds', async () => {
+    seedBaseState();
+    // Self comment: actor is the only assignee → no intervention targets.
+    state.card_members.length = 0;
+    state.checklist_items.length = 0;
+    state.card_members.push({ card_id: CARD_ID, user_id: ACTOR_ID });
+    webhookDispatches.length = 0;
+
+    const response = await handleCreateComment(makeRequest({ content: 'note to self' }), CARD_ID);
+    expect(response.status).toBe(201);
+    await flush();
+
+    const payload = capturedCommentPayload();
+    expect(payload).toBeDefined();
+    expect('interventionUserIds' in payload!).toBe(false);
+  });
+
+  it('fans the identical payload out to both card.commented and card_commented alias subscribers', async () => {
+    seedBaseState();
+    webhookDispatches.length = 0;
+
+    await handleCreateComment(makeRequest({ content: 'alias check' }), CARD_ID);
+    await flush();
+
+    const types = webhookDispatches.map((d) => d.eventType).sort();
+    expect(types).toEqual(['card.commented', 'card_commented']);
+    const dot = webhookDispatches.find((d) => d.eventType === 'card.commented')!;
+    const underscore = webhookDispatches.find((d) => d.eventType === 'card_commented')!;
+    expect(underscore.payload).toEqual(dot.payload);
+    // The exact captured payload must be what every alias receives.
+    expect(dot.payload).toEqual(capturedCommentPayload());
+  });
+});

--- a/tests/unit/server/extensions/comment/interventionRecipients.test.ts
+++ b/tests/unit/server/extensions/comment/interventionRecipients.test.ts
@@ -1,0 +1,244 @@
+// contract: intervention recipient contract for card.commented webhooks
+// [why] Spec is fixed by the QA investigation (parent card t_4552dce2): the WhatsApp
+// bridge can only route a comment alert when the payload itself carries the per-user
+// targets. Recipients: card assignees + checklist assignees + reply target, minus
+// actor and mentioned users, deduplicated, deterministic. Never board-wide.
+// Display fields reuse the canonical mention-context helpers so comment and mention
+// alerts format identically on the bridge.
+import { describe, expect, it } from 'bun:test';
+import { computeInterventionRecipients } from '../../../../../server/extensions/comment/common/interventionRecipients';
+import { buildCommentWebhookPayload } from '../../../../../server/extensions/comment/common/commentWebhookPayload';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ACTOR = 'u-actor';
+const CARD_ASSIGNEE = 'u-card-assignee';
+const CHECKLIST_ASSIGNEE = 'u-checklist-assignee';
+const REPLY_TARGET = 'u-reply-target';
+const MENTIONED = 'u-mentioned';
+const BYSTANDER = 'u-bystander';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computeInterventionRecipients — pure helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('computeInterventionRecipients', () => {
+  it('returns union of card assignees, checklist assignees and reply target', () => {
+    const recipients = computeInterventionRecipients({
+      cardAssigneeIds: [CARD_ASSIGNEE],
+      checklistAssigneeIds: [CHECKLIST_ASSIGNEE],
+      replyToUserId: REPLY_TARGET,
+      actorId: ACTOR,
+      mentionedUserIds: [],
+    });
+    expect(recipients.sort()).toEqual([CARD_ASSIGNEE, CHECKLIST_ASSIGNEE, REPLY_TARGET].sort());
+  });
+
+  it('deduplicates a user who is both card assignee and checklist assignee', () => {
+    const recipients = computeInterventionRecipients({
+      cardAssigneeIds: [CARD_ASSIGNEE],
+      checklistAssigneeIds: [CARD_ASSIGNEE, CHECKLIST_ASSIGNEE],
+      replyToUserId: null,
+      actorId: ACTOR,
+      mentionedUserIds: [],
+    });
+    expect(recipients).toEqual([CARD_ASSIGNEE, CHECKLIST_ASSIGNEE]);
+  });
+
+  it('excludes the actor even when the actor is card assignee, checklist assignee or reply target', () => {
+    const recipients = computeInterventionRecipients({
+      cardAssigneeIds: [ACTOR, CARD_ASSIGNEE],
+      checklistAssigneeIds: [ACTOR, CHECKLIST_ASSIGNEE],
+      replyToUserId: ACTOR,
+      actorId: ACTOR,
+      mentionedUserIds: [],
+    });
+    expect(recipients.sort()).toEqual([CARD_ASSIGNEE, CHECKLIST_ASSIGNEE].sort());
+  });
+
+  it('excludes mentioned users so they receive only the separate mention event', () => {
+    const recipients = computeInterventionRecipients({
+      cardAssigneeIds: [MENTIONED, CARD_ASSIGNEE],
+      checklistAssigneeIds: [],
+      replyToUserId: MENTIONED,
+      actorId: ACTOR,
+      mentionedUserIds: [MENTIONED],
+    });
+    expect(recipients).toEqual([CARD_ASSIGNEE]);
+  });
+
+  it('is deterministic regardless of input order', () => {
+    const a = computeInterventionRecipients({
+      cardAssigneeIds: [CARD_ASSIGNEE, BYSTANDER],
+      checklistAssigneeIds: [CHECKLIST_ASSIGNEE],
+      replyToUserId: REPLY_TARGET,
+      actorId: ACTOR,
+      mentionedUserIds: [],
+    });
+    const b = computeInterventionRecipients({
+      cardAssigneeIds: [BYSTANDER, CARD_ASSIGNEE],
+      checklistAssigneeIds: [CHECKLIST_ASSIGNEE],
+      replyToUserId: REPLY_TARGET,
+      actorId: ACTOR,
+      mentionedUserIds: [],
+    });
+    expect(a).toEqual(b);
+  });
+
+  it('ignores null/undefined/whitespace entries defensively', () => {
+    const recipients = computeInterventionRecipients({
+      cardAssigneeIds: [CARD_ASSIGNEE, ' ', ''] as string[],
+      checklistAssigneeIds: [null as unknown as string, CHECKLIST_ASSIGNEE],
+      replyToUserId: null,
+      actorId: ACTOR,
+      mentionedUserIds: [undefined as unknown as string],
+    });
+    expect(recipients.sort()).toEqual([CARD_ASSIGNEE, CHECKLIST_ASSIGNEE].sort());
+  });
+
+  it('self comment on an assigned card produces no intervention recipient', () => {
+    const recipients = computeInterventionRecipients({
+      cardAssigneeIds: [ACTOR],
+      checklistAssigneeIds: [],
+      replyToUserId: null,
+      actorId: ACTOR,
+      mentionedUserIds: [],
+    });
+    expect(recipients).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildCommentWebhookPayload — additive, backward-compatible payload builder
+// reusing the canonical mention-context display helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildCommentWebhookPayload', () => {
+  const base = { commentId: 'c-1', cardId: 'card-1', cardTitle: 'Fix login' };
+  const commonInput = {
+    base,
+    boardId: 'board-1',
+    entityId: 'card-1',
+    actorId: ACTOR,
+    boardTitle: 'Ops',
+  };
+
+  it('preserves all existing payload fields untouched', () => {
+    const payload = buildCommentWebhookPayload({
+      ...commonInput,
+      actor: { name: 'Ana', nickname: null },
+      commentText: 'hello',
+      interventionRecipients: [CARD_ASSIGNEE],
+    });
+    expect(payload.commentId).toBe('c-1');
+    expect(payload.cardId).toBe('card-1');
+    expect(payload.cardTitle).toBe('Fix login');
+    // existing keys must not be re-typed or renamed
+    expect(Object.keys(payload)).toEqual(
+      expect.arrayContaining(['commentId', 'cardId', 'cardTitle'])
+    );
+  });
+
+  it('adds interventionUserIds only when recipients exist', () => {
+    const payload = buildCommentWebhookPayload({
+      ...commonInput,
+      actor: { name: 'Ana', nickname: null },
+      commentText: 'hello',
+      interventionRecipients: [CARD_ASSIGNEE, CHECKLIST_ASSIGNEE],
+    });
+    expect(payload.interventionUserIds).toEqual([CARD_ASSIGNEE, CHECKLIST_ASSIGNEE]);
+  });
+
+  it('omits interventionUserIds when there are no recipients (old consumers see zero change)', () => {
+    const payload = buildCommentWebhookPayload({
+      ...commonInput,
+      actor: { name: 'Ana', nickname: null },
+      commentText: 'hello',
+      interventionRecipients: [],
+    });
+    expect('interventionUserIds' in payload).toBe(false);
+  });
+
+  it('uses the canonical actor display name: nickname preferred, email never leaked, null when unavailable', () => {
+    const withNickname = buildCommentWebhookPayload({
+      ...commonInput,
+      actor: { name: 'ana@corp.example', nickname: 'ana.ops' },
+      commentText: 'hello',
+      interventionRecipients: [CARD_ASSIGNEE],
+    });
+    expect(withNickname.actorName).toBe('ana.ops');
+
+    const nameOnly = buildCommentWebhookPayload({
+      ...commonInput,
+      actor: { name: 'Ana Silva', nickname: null },
+      commentText: 'hello',
+      interventionRecipients: [CARD_ASSIGNEE],
+    });
+    expect(nameOnly.actorName).toBe('Ana Silva');
+
+    const emailOnly = buildCommentWebhookPayload({
+      ...commonInput,
+      actor: { name: 'ana@corp.example', nickname: 'ana@corp.example' },
+      commentText: 'hello',
+      interventionRecipients: [CARD_ASSIGNEE],
+    });
+    // [why] canonical helper returns null rather than a placeholder — the bridge
+    // decides its own fallback formatting
+    expect(emailOnly.actorName).toBeNull();
+    expect(JSON.stringify(emailOnly).includes('ana@corp.example')).toBe(false);
+  });
+
+  it('builds sourcePreview with canonical semantics via the shared mention-context helper', async () => {
+    const { buildSourcePreview } = await import(
+      '../../../../../server/extensions/notifications/mods/mentionWebhookContext'
+    );
+
+    // [why] delegation contract: the comment payload preview IS the canonical
+    // helper's output for the same input (entity decoding, whitespace collapse,
+    // 200-char total cap) — compared against the helper itself so this test does
+    // not depend on the shared sanitize module's load-order state.
+    const rich = '<p>Hi <b>@bob</b>, please&nbsp;review</p>';
+    const decoded = buildCommentWebhookPayload({
+      ...commonInput,
+      actor: { name: 'Ana', nickname: null },
+      commentText: rich,
+      interventionRecipients: [CARD_ASSIGNEE],
+    });
+    expect(decoded.sourcePreview).toBe(buildSourcePreview({ sourceText: rich }));
+
+    const long = buildCommentWebhookPayload({
+      ...commonInput,
+      actor: { name: 'Ana', nickname: null },
+      commentText: 'x'.repeat(500),
+      interventionRecipients: [CARD_ASSIGNEE],
+    });
+    // 199 chars + ellipsis = 200 total, matching the mention payload contract
+    expect((long.sourcePreview as string).length).toBe(200);
+    expect((long.sourcePreview as string).endsWith('…')).toBe(true);
+
+    const short = buildCommentWebhookPayload({
+      ...commonInput,
+      actor: { name: 'Ana', nickname: null },
+      commentText: 'y'.repeat(200),
+      interventionRecipients: [CARD_ASSIGNEE],
+    });
+    expect(short.sourcePreview).toBe('y'.repeat(200));
+  });
+
+  it('does not mutate the base payload object', () => {
+    const baseObj = { commentId: 'c-1', cardId: 'card-1', cardTitle: 'Fix login' };
+    buildCommentWebhookPayload({
+      base: baseObj,
+      boardId: 'board-1',
+      entityId: 'card-1',
+      actorId: ACTOR,
+      actor: { name: 'Ana', nickname: null },
+      commentText: 'hello',
+      boardTitle: 'Ops',
+      interventionRecipients: [CARD_ASSIGNEE],
+    });
+    expect(Object.keys(baseObj)).toEqual(['commentId', 'cardId', 'cardTitle']);
+  });
+});

--- a/tests/unit/server/extensions/comment/interventionRecipients.test.ts
+++ b/tests/unit/server/extensions/comment/interventionRecipients.test.ts
@@ -191,9 +191,8 @@ describe('buildCommentWebhookPayload', () => {
   });
 
   it('builds sourcePreview with canonical semantics via the shared mention-context helper', async () => {
-    const { buildSourcePreview } = await import(
-      '../../../../../server/extensions/notifications/mods/mentionWebhookContext'
-    );
+    const { buildSourcePreview } =
+      await import('../../../../../server/extensions/notifications/mods/mentionWebhookContext');
 
     // [why] delegation contract: the comment payload preview IS the canonical
     // helper's output for the same input (entity decoding, whitespace collapse,


### PR DESCRIPTION
## Summary

- `card.commented` webhook payload now includes intervention recipients: members ∪ checklist assignees ∪ reply target − actor − mentioned, sorted, additive-only (no existing field changes).
- Threads a durable `eventId` through all three producer dispatch sites so the receiver can key semantic dedupe on `sha256(canonical type + NUL + eventId)`.

## Changes

- 2 commits over `main` @ 2a37cd1:
  - ac87e39 fix(comment): add intervention recipients to card.commented webhook payload
  - 48a0e90 feat(webhooks): thread durable eventId through all producer dispatch sites

## Testing

- Focused suites (bun): 33/33 pass across 4 suites.
- Full gate review for the ChimeDeck→Duplanet WhatsApp split verified this exact head 48a0e9023c4f37ab37887f963d3b38987573d213 (diff read hunk-by-hunk; fresh-clone suites re-executed).