### PR TITLE
fix(boards): type board page callbacks

### DIFF
--- a/src/extensions/Board/containers/BoardPage/BoardPage.tsx
+++ b/src/extensions/Board/containers/BoardPage/BoardPage.tsx
@@ -220,7 +220,6 @@ const BoardPage = () => {
   );
 
   const initialCardsPerList = useMemo(() => {
-    if (globalThis.window === undefined) return 50;
     if (globalThis.window.innerWidth < 900) return 25;
     return 50;
   }, []);
@@ -266,11 +265,12 @@ const BoardPage = () => {
     token: accessToken ?? '',
     lastSequence,
     onEvent: handleEvent,
-    onMutationConflict: () =>
-      addToast('A mutation conflicted with a remote change and was discarded.', 'conflict'),
+    onMutationConflict: () => {
+      addToast('A mutation conflicted with a remote change and was discarded.', 'conflict');
+    },
     onQueueOverflow: () => {
       // Full reload on overflow so state is not stale
-      if (boardId) dispatch(fetchBoardDataThunk({ boardId }));
+      if (boardId) void dispatch(fetchBoardDataThunk({ boardId }));
     },
   });
 
@@ -279,11 +279,13 @@ const BoardPage = () => {
     boardId: realtimeBoardId,
     active: pollingActive,
     lastSequence,
-    onEvents: (events) => { events.forEach(handleEvent); },
+    onEvents: (events) => {
+      events.forEach(handleEvent);
+    },
   });
 
   useEffect(() => {
-    if (boardId) dispatch(fetchBoardDataThunk({ boardId, initialCardsPerList }));
+    if (boardId) void dispatch(fetchBoardDataThunk({ boardId, initialCardsPerList }));
   }, [dispatch, boardId, initialCardsPerList]);
 
   useEffect(() => {
@@ -304,7 +306,7 @@ const BoardPage = () => {
 
       const targetCard = cards[cardId] as { short_id?: string | null; title?: string | null } | undefined;
       const routeCardId = targetCard?.short_id ?? cardId;
-      const boardRouteTarget = (board?.short_id as string | undefined) ?? resolvedBoardRouteId ?? boardId;
+      const boardRouteTarget = board?.short_id ?? resolvedBoardRouteId ?? boardId;
 
       // Keep the board route mounted and open the modal via query param so
       // board-local UI state (e.g. active filters) is not reset.
@@ -326,7 +328,7 @@ const BoardPage = () => {
   );
 
   const handleRouteCardClose = useCallback(() => {
-    const boardRouteTarget = (board?.short_id as string | undefined) ?? resolvedBoardRouteId ?? boardId;
+    const boardRouteTarget = board?.short_id ?? resolvedBoardRouteId ?? boardId;
     if (!boardRouteTarget) return;
     navigate(boardPath({
       id: boardRouteTarget,
@@ -342,7 +344,7 @@ const BoardPage = () => {
         await updateBoard({ api, boardId, title });
       } catch {
         // Rollback — re-fetch authoritative state
-        dispatch(fetchBoardDataThunk({ boardId }));
+        void dispatch(fetchBoardDataThunk({ boardId }));
       }
     },
     [api, board, boardId, dispatch],
@@ -437,7 +439,7 @@ const BoardPage = () => {
       // Optimistic: update local state; fire API in background
       updateList({ api, listId, title }).catch(() => {
         // On failure, re-fetch to restore authoritative state
-        if (boardId) dispatch(fetchBoardDataThunk({ boardId }));
+        if (boardId) void dispatch(fetchBoardDataThunk({ boardId }));
       });
     },
     [api, boardId, dispatch],
@@ -448,7 +450,7 @@ const BoardPage = () => {
     async (listId: string) => {
       try {
         await archiveList({ api, listId });
-        if (boardId) dispatch(fetchBoardDataThunk({ boardId }));
+        if (boardId) void dispatch(fetchBoardDataThunk({ boardId }));
       } catch {
         // TODO: surface error to user
       }
@@ -460,7 +462,7 @@ const BoardPage = () => {
     async (listId: string) => {
       try {
         await deleteList({ api, listId });
-        if (boardId) dispatch(fetchBoardDataThunk({ boardId }));
+        if (boardId) void dispatch(fetchBoardDataThunk({ boardId }));
       } catch (err: unknown) {
         // 409 means the list has cards — open confirmation dialog.
         const resp = (err as { response?: { status?: number; data?: { name?: string; data?: { cardCount?: number } } } }).response;
@@ -486,7 +488,7 @@ const BoardPage = () => {
         const response = await sortListCards({ api, listId, sortBy });
         dispatch(boardSliceActions.applySortedListFromServer({ listId, cards: response.data }));
       } catch {
-        if (boardId) dispatch(fetchBoardDataThunk({ boardId }));
+        if (boardId) void dispatch(fetchBoardDataThunk({ boardId }));
         addToast('Failed to sort list.', 'error');
       }
     },
@@ -502,7 +504,7 @@ const BoardPage = () => {
       try {
         await updateListColor({ api, listId, color });
       } catch {
-        if (boardId) dispatch(fetchBoardDataThunk({ boardId }));
+        if (boardId) void dispatch(fetchBoardDataThunk({ boardId }));
         addToast('Failed to update list color.', 'error');
       }
     },
@@ -524,7 +526,7 @@ const BoardPage = () => {
       try {
         await reorderLists({ api, boardId, order: newOrder });
       } catch {
-        dispatch(fetchBoardDataThunk({ boardId }));
+        void dispatch(fetchBoardDataThunk({ boardId }));
         addToast('Failed to move list.', 'error');
       }
     },
@@ -551,9 +553,9 @@ const BoardPage = () => {
           // Chain moves so cards keep their original relative order in the destination list.
           afterCardId = cardId;
         }
-        dispatch(fetchBoardDataThunk({ boardId }));
+        void dispatch(fetchBoardDataThunk({ boardId }));
       } catch {
-        dispatch(fetchBoardDataThunk({ boardId }));
+        void dispatch(fetchBoardDataThunk({ boardId }));
         addToast('Failed to move all cards.', 'error');
       }
     },
@@ -567,9 +569,9 @@ const BoardPage = () => {
       if (cardIds.length === 0) return;
       try {
         await Promise.all(cardIds.map((cardId) => archiveCard({ api, cardId })));
-        dispatch(fetchBoardDataThunk({ boardId }));
+        void dispatch(fetchBoardDataThunk({ boardId }));
       } catch {
-        dispatch(fetchBoardDataThunk({ boardId }));
+        void dispatch(fetchBoardDataThunk({ boardId }));
         addToast('Failed to archive all cards in this list.', 'error');
       }
     },
@@ -598,7 +600,7 @@ const BoardPage = () => {
             keepMembers: true,
           });
         }
-        dispatch(fetchBoardDataThunk({ boardId }));
+        void dispatch(fetchBoardDataThunk({ boardId }));
       } catch {
         addToast('Failed to copy list.', 'error');
       }
@@ -611,7 +613,7 @@ const BoardPage = () => {
     if (!boardId || !board) return;
     try {
       await archiveBoard({ api, boardId });
-      dispatch(fetchBoardDataThunk({ boardId }));
+      void dispatch(fetchBoardDataThunk({ boardId }));
     } catch {
       addToast('Failed to archive board.', 'error');
     }
@@ -625,7 +627,7 @@ const BoardPage = () => {
       setSettingsOpen(false);
       setMembersOpen(false);
       automationPanel.closePanel();
-      navigate(`/workspace/${board?.workspaceId}/boards`, {
+      navigate(`/workspace/${board?.workspaceId ?? ''}/boards`, {
         state: { successToast: 'Board deleted' },
       });
     } catch (err: unknown) {
@@ -718,15 +720,33 @@ const BoardPage = () => {
                 onDragRollback={handleDragRollback}
                 onAddCard={handleAddCard}
                 onAddList={handleAddList}
-                onRenameList={handleRenameList}
-                onCopyList={handleCopyList}
-                onMoveList={handleMoveList}
-                onMoveAllCards={handleMoveAllCards}
-                onArchiveList={handleArchiveList}
-                onArchiveAllCards={handleArchiveAllCards}
-                onDeleteList={handleDeleteList}
-                onChangeListColor={handleChangeListColor}
-                onSortList={handleSortList}
+                onRenameList={(listId, title) => {
+                  handleRenameList(listId, title);
+                }}
+                onCopyList={(listId) => {
+                  void handleCopyList(listId);
+                }}
+                onMoveList={(listId, targetIndex) => {
+                  void handleMoveList(listId, targetIndex);
+                }}
+                onMoveAllCards={(fromListId, targetListId) => {
+                  void handleMoveAllCards(fromListId, targetListId);
+                }}
+                onArchiveList={(listId) => {
+                  void handleArchiveList(listId);
+                }}
+                onArchiveAllCards={(listId) => {
+                  void handleArchiveAllCards(listId);
+                }}
+                onDeleteList={(listId) => {
+                  void handleDeleteList(listId);
+                }}
+                onChangeListColor={(listId, color) => {
+                  void handleChangeListColor(listId, color);
+                }}
+                onSortList={(listId, sortBy) => {
+                  void handleSortList(listId, sortBy);
+                }}
                 listColors={listColors}
                 listSummaries={listSummaries}
                 onCardClick={handleCardClick}
@@ -750,14 +770,14 @@ const BoardPage = () => {
                 onCardClick={handleCardClick}
                 addToast={addToast}
               />
-            ) : activeView === 'TIMELINE' ? (
+            ) : (
               <TimelineView
                 cards={Object.values(filteredCards)}
                 lists={lists}
                 onCardClick={handleCardClick}
                 addToast={addToast}
               />
-            ) : null}
+            )}
             <AutomationPanel
               boardId={boardId ?? ''}
               isOpen={automationPanel.isOpen}
@@ -791,7 +811,7 @@ const BoardPage = () => {
           <BoardArchivedCardsPanel
             boardId={boardId ?? ''}
             onCardUnarchived={() => {
-              if (boardId) dispatch(fetchBoardDataThunk({ boardId }));
+              if (boardId) void dispatch(fetchBoardDataThunk({ boardId }));
               setActiveTab('board');
             }}
           />
@@ -825,14 +845,26 @@ const BoardPage = () => {
         hasBackground={!!board.background}
         useParentGlass={!!board.background}
         isGuest={isGuest}
-        onOpenSettings={() => setSettingsOpen(true)}
-        onOpenMembers={() => setMembersOpen(true)}
+        onOpenSettings={() => {
+          setSettingsOpen(true);
+        }}
+        onOpenMembers={() => {
+          setMembersOpen(true);
+        }}
         {...(!isGuest && {
-          onArchive: handleBoardArchive,
-          onDelete: handleBoardDelete,
+          onArchive: () => {
+            void handleBoardArchive();
+          },
+          onDelete: () => {
+            void handleBoardDelete();
+          },
         })}
-        onStar={handleStar}
-        onUnstar={handleUnstar}
+        onStar={() => {
+          void handleStar();
+        }}
+        onUnstar={() => {
+          void handleUnstar();
+        }}
       />
       {board.state === 'ARCHIVED' && (
         <div className="mx-6 mt-1 rounded border border-yellow-700 bg-yellow-900/30 px-4 py-2 text-sm text-yellow-400">
@@ -860,7 +892,9 @@ const BoardPage = () => {
             return (
               <button
                 key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
+                onClick={() => {
+                  setActiveTab(tab.id);
+                }}
                 className={`px-3 py-2.5 text-sm font-medium ${tabClass}`}
               >
                 {tab.label}
@@ -895,7 +929,9 @@ const BoardPage = () => {
                 return (
                   <button
                     type="button"
-                    onClick={() => setFilterPanelOpen((v) => !v)}
+                    onClick={() => {
+                      setFilterPanelOpen((value) => !value);
+                    }}
                     className={`${btnBase} ${btnVariant}`}
                   >
                     <FunnelIcon className="h-3.5 w-3.5" aria-hidden="true" />
@@ -909,7 +945,9 @@ const BoardPage = () => {
               {filterPanelOpen && (
                 <BoardFilterPanel
                   containerRef={filterContainerRef}
-                  onClose={() => setFilterPanelOpen(false)}
+                  onClose={() => {
+                    setFilterPanelOpen(false);
+                  }}
                   filters={filters}
                   onChange={setFilters}
                   boardMembers={boardMembers}
@@ -935,7 +973,9 @@ const BoardPage = () => {
       {/* Board settings panel */}
       {settingsOpen && (
         <BoardSettings
-          onClose={() => setSettingsOpen(false)}
+          onClose={() => {
+            setSettingsOpen(false);
+          }}
           isGuest={isGuest}
           isViewerGuest={isViewerGuest}
           isBoardParticipant={canManageOwnBoardNotifications}
@@ -943,7 +983,9 @@ const BoardPage = () => {
       )}
       {/* Board members panel (Sprint 79) */}
       {membersOpen && (
-        <BoardMembersPanel onClose={() => setMembersOpen(false)} isGuest={isGuest} />
+        <BoardMembersPanel onClose={() => {
+          setMembersOpen(false);
+        }} isGuest={isGuest} />
       )}
 
       {/* Board delete confirmation dialog — shown when server returns 409 with nested content counts */}
@@ -953,9 +995,10 @@ const BoardPage = () => {
           listCount={boardDeleteDialog.listCount}
           cardCount={boardDeleteDialog.cardCount}
           onConfirm={async () => {
+            if (!boardId) return;
             setBoardDeleteDialog(null);
             try {
-              await deleteBoard({ api, boardId: boardId!, confirm: true });
+              await deleteBoard({ api, boardId, confirm: true });
               setSettingsOpen(false);
               setMembersOpen(false);
               automationPanel.closePanel();
@@ -966,7 +1009,9 @@ const BoardPage = () => {
               addToast('Failed to delete board.', 'error');
             }
           }}
-          onCancel={() => setBoardDeleteDialog(null)}
+          onCancel={() => {
+            setBoardDeleteDialog(null);
+          }}
         />
       )}
 
@@ -979,9 +1024,11 @@ const BoardPage = () => {
             const { listId } = listDeleteDialog;
             setListDeleteDialog(null);
             await deleteList({ api, listId, confirm: true });
-            if (boardId) dispatch(fetchBoardDataThunk({ boardId }));
+            if (boardId) void dispatch(fetchBoardDataThunk({ boardId }));
           }}
-          onCancel={() => setListDeleteDialog(null)}
+          onCancel={() => {
+            setListDeleteDialog(null);
+          }}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- Make BoardPage refresh, async callback, modal, tab and filter boundaries explicit.
- Retain awaited add-card/add-list contracts; use void only for void-only fire-and-forget handlers.
- Preserve routing, board/list/card API calls, optimistic updates and rollback/reload flows.

## Validation
- `bunx eslint src/extensions/Board/containers/BoardPage/BoardPage.tsx`
- `bun run build:client` (passes; existing chunk-size warnings)
- `git diff --check`
- `bun run typecheck` (baseline exit 2; no changed-file diagnostic)
- `bun test` (baseline exit 1: 821 pass, 3 skip, 118 fail, 93 errors)
- IPv4 Vite UI entrypoint: `http://127.0.0.1:5173/` returned 200.

## UI coverage limitation
- No focused executable BoardPage E2E spec was identified; the UI server smoke is recorded separately from behavioural UI coverage.
