### PR TITLE
fix(notifications): type board activity dispatch

### DIFF
--- a/server/extensions/notifications/mods/boardActivityDispatch.ts
+++ b/server/extensions/notifications/mods/boardActivityDispatch.ts
@@ -16,6 +16,18 @@ import type { WrittenEvent } from '../../../mods/events/index';
 
 type SupportedEventType = 'card.created' | 'card.moved';
 
+type BoardRow = { id: string; title: string; workspace_id?: string | null };
+type ParticipantRow = { user_id: string };
+type ActorRow = { id: string; nickname: string | null; name: string | null; avatar_url: string | null };
+type ListRow = { title: string | null };
+type CommentRow = { parent_id: string | null };
+type NotificationRow = Record<string, unknown>;
+
+async function getBoardTitle(boardId: string): Promise<string> {
+  const board = (await db('boards').where({ id: boardId }).select('title').first()) as ListRow | undefined;
+  return board?.title ?? '';
+}
+
 // Direct-dispatch payload union for card mutation and comment events.
 // These are fired from card/comment endpoints directly rather than via the events pipeline.
 // card_commented stores commentId in source_id so recipients can navigate to the exact comment.
@@ -31,7 +43,6 @@ export type DirectCardNotificationPayload =
       replyToUserId?: string | null;
     };
 
-const SUPPORTED_EVENTS = new Set<string>(['card.created', 'card.moved']);
 
 export async function handleBoardActivityNotification({
   event,
@@ -42,10 +53,11 @@ export async function handleBoardActivityNotification({
   boardId: string;
   actorId: string;
 }): Promise<void> {
-  if (!SUPPORTED_EVENTS.has(event.type)) return;
+  if (event.type !== 'card.created' && event.type !== 'card.moved') return;
+  const eventType: SupportedEventType = event.type;
 
   try {
-    const board = await db('boards').where({ id: boardId }).select('id', 'title', 'workspace_id').first();
+    const board = (await db('boards').where({ id: boardId }).select('id', 'title', 'workspace_id').first()) as BoardRow | undefined;
     if (!board) return;
 
     // Fetch all board participants (joined members + explicit board guests), excluding actor.
@@ -62,28 +74,28 @@ export async function handleBoardActivityNotification({
 
     const recipientIds = Array.from(
       new Set([
-        ...members.map((m: { user_id: string }) => m.user_id),
-        ...guests.map((g: { user_id: string }) => g.user_id),
+        ...(members as ParticipantRow[]).map((member) => member.user_id),
+        ...(guests as ParticipantRow[]).map((guest) => guest.user_id),
       ]),
     );
 
     if (recipientIds.length === 0) return;
 
     const templateData = await buildTemplateData({
-      eventType: event.type as SupportedEventType,
+      eventType,
       event,
       boardName: board.title,
       actorId,
     });
     if (!templateData) return;
 
-    const notificationType = eventTypeToNotificationType(event.type as SupportedEventType);
+    const notificationType = eventTypeToNotificationType(eventType);
 
     // Fetch actor details once for the WS payload
-    const actor = await db('users')
+    const actor = (await db('users')
       .where({ id: actorId })
       .select('id', 'nickname', db.raw("COALESCE(name, email) as name"), 'avatar_url')
-      .first();
+      .first()) as ActorRow | undefined;
     const actorAvatarUrl = actor?.avatar_url
       ? buildAvatarProxyUrl({ userId: actorId, avatarUrl: actor.avatar_url })
       : null;
@@ -97,7 +109,7 @@ export async function handleBoardActivityNotification({
     const now = new Date().toISOString();
 
     // Derive card_id and board_id for the notification row from event payload
-    const payload = event.payload as Record<string, unknown>;
+    const payload = event.payload;
     const cardId = (
       (payload.card as { id?: string } | undefined)?.id ??
       (payload.cardId as string | undefined) ??
@@ -107,7 +119,7 @@ export async function handleBoardActivityNotification({
 
     // For card_moved, include the destination list name in the WS payload
     // so the client can render "{actorName} moved {cardTitle} to {listName}" without an extra fetch.
-    const listTitle = notificationType === 'card_moved' ? (templateData?.toList ?? null) : null;
+    const listTitle = notificationType === 'card_moved' ? (templateData.toList ?? null) : null;
 
     // Fire-and-forget per recipient — failures never block the mutation path
     for (const recipientId of recipientIds) {
@@ -164,7 +176,8 @@ export async function handleBoardActivityNotification({
             read: false,
             created_at: now,
           }, ['*'])
-          .then(([inserted]) => {
+          .then((rows) => {
+            const [inserted] = rows as [NotificationRow | undefined];
             if (inserted) {
               return publishToUser(recipientId, {
                 type: 'notification_created',
@@ -211,20 +224,20 @@ async function buildTemplateData({
   eventType,
   event,
   boardName,
-  actorId,
+  actorId: _actorId,
 }: {
   eventType: SupportedEventType;
   event: WrittenEvent;
   boardName: string;
   actorId: string;
 }): Promise<Record<string, string> | null> {
-  const payload = event.payload as Record<string, unknown>;
+  const payload = event.payload;
 
   if (eventType === 'card.created') {
     const card = payload.card as { id: string; title: string; list_id: string } | undefined;
     if (!card) return null;
-    const list = await db('lists').where({ id: card.list_id }).select('title').first();
-    const cardUrl = `/boards/${event.board_id}/cards/${card.id}`;
+    const list = (await db('lists').where({ id: card.list_id }).select('title').first()) as ListRow | undefined;
+    const cardUrl = `/boards/${event.board_id ?? ''}/cards/${card.id}`;
     return {
       cardTitle: card.title,
       boardName,
@@ -233,25 +246,21 @@ async function buildTemplateData({
     };
   }
 
-  if (eventType === 'card.moved') {
-    const card = payload.card as { id: string; title: string; list_id: string } | undefined;
-    if (!card) return null;
-    const fromListId = payload.fromListId as string | undefined;
-    const [toList, fromList] = await Promise.all([
+  const card = payload.card as { id: string; title: string; list_id: string } | undefined;
+  if (!card) return null;
+  const fromListId = payload.fromListId as string | undefined;
+  const [toList, fromList] = (await Promise.all([
       db('lists').where({ id: card.list_id }).select('title').first(),
       fromListId ? db('lists').where({ id: fromListId }).select('title').first() : Promise.resolve(null),
-    ]);
-    const cardUrl = `/boards/${event.board_id}/cards/${card.id}`;
-    return {
-      cardTitle: card.title,
-      boardName,
-      fromList: fromList?.title ?? '',
-      toList: toList?.title ?? '',
-      cardUrl,
-    };
-  }
-
-  return null;
+    ])) as [ListRow | undefined, ListRow | null | undefined];
+  const cardUrl = `/boards/${event.board_id ?? ''}/cards/${card.id}`;
+  return {
+    cardTitle: card.title,
+    boardName,
+    fromList: fromList?.title ?? '',
+    toList: toList?.title ?? '',
+    cardUrl,
+  };
 }
 
 // Dispatches in-app notifications to all board members (except actor) for direct card mutations.
@@ -290,17 +299,17 @@ export async function dispatchDirectCardNotification({
 
     const recipients = Array.from(
       new Set([
-        ...members.map((m: { user_id: string }) => m.user_id),
-        ...guests.map((g: { user_id: string }) => g.user_id),
+        ...(members as ParticipantRow[]).map((member) => member.user_id),
+        ...(guests as ParticipantRow[]).map((guest) => guest.user_id),
       ]),
     ).filter((recipientId) => !excludedRecipientIds.has(recipientId));
 
     if (recipients.length === 0) return;
 
-    const actor = await db('users')
+    const actor = (await db('users')
       .where({ id: actorId })
       .select('id', 'nickname', db.raw("COALESCE(name, email) as name"), 'avatar_url')
-      .first();
+      .first()) as ActorRow | undefined;
     const actorAvatarUrl = actor?.avatar_url
       ? buildAvatarProxyUrl({ userId: actorId, avatarUrl: actor.avatar_url })
       : null;
@@ -322,48 +331,48 @@ export async function dispatchDirectCardNotification({
     // Use an event-unique source id for non-comment events so board_activity dedupe
     // does not collapse repeated actions on the same card over time.
     // Comment notifications keep commentId for deep-linking.
-    let emailTemplateData: Record<string, string> | null = null;
+    let emailTemplateData: Record<string, string>;
     let sourceId = `${cardId}:${now}`;
 
     if (payload.type === 'card_commented') {
       sourceId = payload.commentId;
-      const sourceComment = await db('comments')
+      const sourceComment = (await db('comments')
         .where({ id: payload.commentId })
         .select('parent_id')
-        .first();
-      sourceParentId = (sourceComment?.parent_id as string | undefined) ?? null;
-      const board = await db('boards').where({ id: boardId }).select('title').first();
+        .first()) as CommentRow | undefined;
+      sourceParentId = sourceComment?.parent_id ?? null;
+      const boardTitle = await getBoardTitle(boardId);
       emailTemplateData = {
         actorName: actor?.name ?? 'Someone',
         cardTitle: payload.cardTitle,
-        boardName: board?.title ?? '',
+        boardName: boardTitle,
         commentPreview: payload.commentPreview,
         cardUrl: `/boards/${boardId}/cards/${cardId}`,
       };
     } else if (payload.type === 'card_updated') {
-      const board = await db('boards').where({ id: boardId }).select('title').first();
+      const boardTitle = await getBoardTitle(boardId);
       emailTemplateData = {
         actorName: actor?.name ?? 'Someone',
         cardTitle: payload.cardTitle,
-        boardName: board?.title ?? '',
+        boardName: boardTitle,
         // Serialise changedFields as JSON so emailDispatch can parse the array
         changedFields: JSON.stringify(payload.changedFields),
         cardUrl: `/boards/${boardId}/cards/${cardId}`,
       };
     } else if (payload.type === 'card_deleted') {
-      const board = await db('boards').where({ id: boardId }).select('title').first();
+      const boardTitle = await getBoardTitle(boardId);
       emailTemplateData = {
         actorName: actor?.name ?? 'Someone',
         cardTitle: payload.cardTitle,
-        boardName: board?.title ?? '',
+        boardName: boardTitle,
         boardUrl: `/boards/${boardId}`,
       };
-    } else if (payload.type === 'card_archived') {
-      const board = await db('boards').where({ id: boardId }).select('title').first();
+    } else {
+      const boardTitle = await getBoardTitle(boardId);
       emailTemplateData = {
         actorName: actor?.name ?? 'Someone',
         cardTitle: payload.cardTitle,
-        boardName: board?.title ?? '',
+        boardName: boardTitle,
         // Serialise boolean as string; emailDispatch uses !== 'false' to parse
         archived: String(payload.archived),
         cardUrl: `/boards/${boardId}/cards/${cardId}`,
@@ -422,7 +431,8 @@ export async function dispatchDirectCardNotification({
             read: false,
             created_at: now,
           }, ['*'])
-          .then(([inserted]) => {
+          .then((rows) => {
+            const [inserted] = rows as [NotificationRow | undefined];
             if (inserted) {
               return publishToUser(recipientId, {
                 type: 'notification_created',
@@ -430,7 +440,7 @@ export async function dispatchDirectCardNotification({
                   notification: {
                     ...inserted,
                     card_title: cardTitle,
-                    board_title: emailTemplateData?.boardName ?? null,
+                    board_title: emailTemplateData.boardName,
                     list_title: null,
                     comment_content: payload.type === 'card_commented' ? payload.commentPreview : null,
                     source_parent_id: payload.type === 'card_commented' ? sourceParentId : null,
@@ -443,15 +453,13 @@ export async function dispatchDirectCardNotification({
           .catch(() => {});
       }
 
-      // Dispatch email for card_commented
-      if (emailTemplateData) {
-        dispatchNotificationEmail({
-          recipientId,
-          type: notificationType,
-          templateData: emailTemplateData,
-          emailEnabled,
-        }).catch(() => {});
-      }
+      // Dispatch email for direct card events.
+      dispatchNotificationEmail({
+        recipientId,
+        type: notificationType,
+        templateData: emailTemplateData,
+        emailEnabled,
+      }).catch(() => {});
     }
   } catch (err) {
     console.warn('[boardActivityDispatch] dispatchDirectCardNotification failed:', err);


### PR DESCRIPTION
## Summary
- Establish narrow typed boundaries for board, participant, actor, list, comment and notification database results.
- Preserve supported board event filtering, recipient deduplication, fail-open preference checks, channel resolution, realtime publishing and fire-and-forget email dispatch.

## Validation
- `bunx eslint server/extensions/notifications/mods/boardActivityDispatch.ts`
- `bun run build:client` (passes; existing chunk-size warnings)
- `git diff --check`
- `bun run typecheck` (baseline exit 2; no changed-file diagnostic)
- `bun test` (baseline exit 1: 821 pass, 3 skip, 118 fail, 93 errors)

## Focused test baseline debt
- `bun test server/extensions/notifications/mods/__tests__/boardActivityDispatch.test.ts` fails before tests execute because its mock omits `resolveBoardNotificationPreference`. The exact failure reproduces unchanged in an isolated `origin/main` worktree, so it is baseline test debt rather than this PR regression.
