### PR TITLE
fix(automation): type move all cards action

### DIFF
--- a/server/extensions/automation/engine/actions/list/moveAllCards.ts
+++ b/server/extensions/automation/engine/actions/list/moveAllCards.ts
@@ -3,12 +3,15 @@
 
 import { z } from 'zod';
 import { between, HIGH_SENTINEL } from '../../../../list/mods/fractional';
-import type { ActionHandler, ActionContext } from '../../../../common/types';
+import type { ActionHandler, ActionContext } from '../../../common/types';
 
 const configSchema = z.object({
   fromListId: z.string().min(1),
   toListId: z.string().min(1),
 });
+
+type ListRow = { board_id: string };
+type CardRow = { id: string; position: string };
 
 export const listMoveAllCardsAction: ActionHandler = {
   type: 'list.move_all_cards',
@@ -16,38 +19,40 @@ export const listMoveAllCardsAction: ActionHandler = {
   category: 'list',
   configSchema,
   async execute({ action, automation, trx }: ActionContext): Promise<void> {
-    const config = configSchema.parse(action.config);
+    const config = configSchema.parse((action as { config: unknown }).config);
+    const transaction = trx;
+    const automationBoardId = (automation as { board_id: string }).board_id;
 
     if (config.fromListId === config.toListId) return;
 
-    const fromList = await trx('lists').where({ id: config.fromListId }).first();
+    const fromList = (await transaction('lists').where({ id: config.fromListId }).first()) as ListRow | undefined;
     if (!fromList) throw new Error('from-list-not-found');
 
     // Guard: both lists must belong to the same board as the automation.
-    if (fromList.board_id !== automation.board_id) throw new Error('from-list-on-different-board');
+    if (fromList.board_id !== automationBoardId) throw new Error('from-list-on-different-board');
 
-    const toList = await trx('lists').where({ id: config.toListId }).first();
+    const toList = (await transaction('lists').where({ id: config.toListId }).first()) as ListRow | undefined;
     if (!toList) throw new Error('to-list-not-found');
 
-    if (toList.board_id !== automation.board_id) throw new Error('to-list-on-different-board');
+    if (toList.board_id !== automationBoardId) throw new Error('to-list-on-different-board');
 
-    const movingCards = await trx('cards')
+    const movingCards = (await transaction('cards')
       .where({ list_id: config.fromListId, archived: false })
-      .orderBy('position', 'asc');
+      .orderBy('position', 'asc')) as CardRow[];
 
     if (movingCards.length === 0) return;
 
     // Find the current last position in the target list to append after.
-    const lastTargetCard = await trx('cards')
+    const lastTargetCard = (await transaction('cards')
       .where({ list_id: config.toListId, archived: false })
       .orderBy('position', 'desc')
-      .first();
+      .first()) as CardRow | undefined;
 
     let prev = lastTargetCard ? lastTargetCard.position : '';
 
     for (const card of movingCards) {
       const newPos = between(prev, HIGH_SENTINEL);
-      await trx('cards')
+      await transaction('cards')
         .where({ id: card.id })
         .update({ list_id: config.toListId, position: newPos, updated_at: new Date().toISOString() });
       prev = newPos;


### PR DESCRIPTION
## Scope
- Correct the local `ActionContext` import path and formalise the transaction, action config, list and card row boundaries in `moveAllCards.ts`.
- Preserve same-board guards, non-archived selection, position order, target-list append semantics and per-card transactional update order.

## Validation
- `bunx eslint server/extensions/automation/engine/actions/list/moveAllCards.ts`
- `bun test tests/integration/automation/actions.test.ts` — baseline blocked by empty `DATABASE_URL`; reproduced on untouched `origin/main`
- `bun run typecheck` — existing exit 2; no changed-file diagnostic
- `bun test` — existing baseline exit 1
- `bun run build:client`
- `git diff --check`
