### PR TITLE
fix(board): clarify filter panel callbacks

### DIFF
--- a/src/extensions/Board/components/BoardFilterPanel.tsx
+++ b/src/extensions/Board/components/BoardFilterPanel.tsx
@@ -91,8 +91,7 @@ function passesDueDate(card: Card, dueDate: BoardFilters['dueDate']): boolean {
   if (dueDate === 'overdue') return dueTs !== null && dueTs < now && !card.due_complete;
   if (dueDate === 'dueDay') return dueTs !== null && dueTs <= now + DAY && !card.due_complete;
   if (dueDate === 'dueWeek') return dueTs !== null && dueTs <= now + 7 * DAY && !card.due_complete;
-  if (dueDate === 'dueMonth') return dueTs !== null && dueTs <= now + 30 * DAY && !card.due_complete;
-  return true;
+  return dueTs !== null && dueTs <= now + 30 * DAY && !card.due_complete;
 }
 
 function passesLabelsFilter(card: Card, filters: BoardFilters): boolean {
@@ -116,8 +115,7 @@ function passesActivity(card: Card, activity: BoardFilters['activity']): boolean
   if (activity === 'week') return age <= WEEK;
   if (activity === 'twoWeeks') return age <= 2 * WEEK;
   if (activity === 'fourWeeks') return age <= 4 * WEEK;
-  if (activity === 'noActivity') return age > 4 * WEEK;
-  return true;
+  return age > 4 * WEEK;
 }
 
 /** Returns true when the card passes all active filters. */
@@ -285,7 +283,7 @@ export default function BoardFilterPanel({
       }
     };
     document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    return () => { document.removeEventListener('mousedown', handler); };
   }, [containerRef, onClose]);
 
   // Close on Escape
@@ -294,10 +292,10 @@ export default function BoardFilterPanel({
       if (e.key === 'Escape') onClose();
     };
     document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
+    return () => { document.removeEventListener('keydown', handler); };
   }, [onClose]);
 
-  const set = (patch: Partial<BoardFilters>) => onChange({ ...filters, ...patch });
+  const set = (patch: Partial<BoardFilters>) => { onChange({ ...filters, ...patch }); };
 
   const resetFilters = () => {
     onChange({
@@ -324,13 +322,13 @@ export default function BoardFilterPanel({
   };
 
   const toggleDueDate = (v: BoardFilters['dueDate']) =>
-    set({ dueDate: filters.dueDate === v ? 'all' : v });
+    { set({ dueDate: filters.dueDate === v ? 'all' : v }); };
 
   const toggleDueComplete = (v: 'complete' | 'incomplete') =>
-    set({ dueComplete: filters.dueComplete === v ? 'all' : v });
+    { set({ dueComplete: filters.dueComplete === v ? 'all' : v }); };
 
   const toggleActivity = (v: BoardFilters['activity']) =>
-    set({ activity: filters.activity === v ? 'all' : v });
+    { set({ activity: filters.activity === v ? 'all' : v }); };
 
   // Derived member data
   const currentMember = boardMembers.find((m) => m.user_id === currentUserId);
@@ -386,7 +384,7 @@ export default function BoardFilterPanel({
             type="search"
             placeholder="Enter a keyword..."
             value={filters.keyword}
-            onChange={(e) => set({ keyword: e.target.value })}
+            onChange={(e) => { set({ keyword: e.target.value }); }}
             className="flex-1 bg-transparent text-sm text-base placeholder:text-muted focus:outline-none"
             // [why] autoFocus so the user can start typing immediately after opening the panel
             autoFocus
@@ -400,7 +398,7 @@ export default function BoardFilterPanel({
         {/* Static rows */}
         <CheckRow
           checked={filters.noMembers}
-          onChange={() => set({ noMembers: !filters.noMembers })}
+          onChange={() => { set({ noMembers: !filters.noMembers }); }}
         >
           No members
         </CheckRow>
@@ -408,12 +406,12 @@ export default function BoardFilterPanel({
           <MemberCheckRow
             member={currentMember}
             checked={filters.assignedToMe}
-            onChange={() => set({ assignedToMe: !filters.assignedToMe })}
+            onChange={() => { set({ assignedToMe: !filters.assignedToMe }); }}
           />
         ) : (
           <CheckRow
             checked={filters.assignedToMe}
-            onChange={() => set({ assignedToMe: !filters.assignedToMe })}
+            onChange={() => { set({ assignedToMe: !filters.assignedToMe }); }}
           >
             Cards assigned to me
           </CheckRow>
@@ -427,7 +425,7 @@ export default function BoardFilterPanel({
               key={m.user_id}
               member={m}
               checked
-              onChange={() => toggleMemberId(m.user_id)}
+              onChange={() => { toggleMemberId(m.user_id); }}
             />
           ))}
 
@@ -436,7 +434,7 @@ export default function BoardFilterPanel({
           <div className="mt-1">
             <button
               type="button"
-              onClick={() => setMemberDropdownOpen((v) => !v)}
+              onClick={() => { setMemberDropdownOpen((v) => !v); }}
               className="flex w-full items-center justify-between rounded border border-border bg-bg-overlay px-2.5 py-1.5 text-sm text-muted hover:text-base transition-colors"
             >
               <span>Select members</span>
@@ -455,7 +453,7 @@ export default function BoardFilterPanel({
                     type="search"
                     placeholder="Search members..."
                     value={memberSearch}
-                    onChange={(e) => setMemberSearch(e.target.value)}
+                    onChange={(e) => { setMemberSearch(e.target.value); }}
                     className="flex-1 bg-transparent text-xs text-base placeholder:text-muted focus:outline-none"
                   />
                 </div>
@@ -469,7 +467,7 @@ export default function BoardFilterPanel({
                         key={m.user_id}
                         member={m}
                         checked={filters.memberIds.has(m.user_id)}
-                        onChange={() => toggleMemberId(m.user_id)}
+                        onChange={() => { toggleMemberId(m.user_id); }}
                       />
                     ))
                   )}
@@ -483,32 +481,32 @@ export default function BoardFilterPanel({
         <SectionHeading icon={<BoltIcon className="h-3.5 w-3.5" />}>Card status</SectionHeading>
         <CheckRow
           checked={filters.dueComplete === 'complete'}
-          onChange={() => toggleDueComplete('complete')}
+          onChange={() => { toggleDueComplete('complete'); }}
         >
           Marked as complete
         </CheckRow>
         <CheckRow
           checked={filters.dueComplete === 'incomplete'}
-          onChange={() => toggleDueComplete('incomplete')}
+          onChange={() => { toggleDueComplete('incomplete'); }}
         >
           Not marked as complete
         </CheckRow>
 
         {/* ── Due date ── */}
         <SectionHeading icon={<CalendarDaysIcon className="h-3.5 w-3.5" />}>Due date</SectionHeading>
-        <CheckRow checked={filters.dueDate === 'noDate'} onChange={() => toggleDueDate('noDate')}>
+        <CheckRow checked={filters.dueDate === 'noDate'} onChange={() => { toggleDueDate('noDate'); }}>
           No dates
         </CheckRow>
-        <CheckRow checked={filters.dueDate === 'overdue'} onChange={() => toggleDueDate('overdue')}>
+        <CheckRow checked={filters.dueDate === 'overdue'} onChange={() => { toggleDueDate('overdue'); }}>
           Overdue
         </CheckRow>
-        <CheckRow checked={filters.dueDate === 'dueDay'} onChange={() => toggleDueDate('dueDay')}>
+        <CheckRow checked={filters.dueDate === 'dueDay'} onChange={() => { toggleDueDate('dueDay'); }}>
           Due in the next day
         </CheckRow>
-        <CheckRow checked={filters.dueDate === 'dueWeek'} onChange={() => toggleDueDate('dueWeek')}>
+        <CheckRow checked={filters.dueDate === 'dueWeek'} onChange={() => { toggleDueDate('dueWeek'); }}>
           Due in the next week
         </CheckRow>
-        <CheckRow checked={filters.dueDate === 'dueMonth'} onChange={() => toggleDueDate('dueMonth')}>
+        <CheckRow checked={filters.dueDate === 'dueMonth'} onChange={() => { toggleDueDate('dueMonth'); }}>
           Due in the next month
         </CheckRow>
 
@@ -516,7 +514,7 @@ export default function BoardFilterPanel({
         <SectionHeading icon={<TagIcon className="h-3.5 w-3.5" />}>Labels</SectionHeading>
         <CheckRow
           checked={filters.noLabels}
-          onChange={() => set({ noLabels: !filters.noLabels })}
+          onChange={() => { set({ noLabels: !filters.noLabels }); }}
         >
           No labels
         </CheckRow>
@@ -526,7 +524,7 @@ export default function BoardFilterPanel({
           <CheckRow
             key={label.id}
             checked={filters.labelIds.has(label.id)}
-            onChange={() => toggleLabelId(label.id)}
+            onChange={() => { toggleLabelId(label.id); }}
             swatch={{ color: label.color }}
           >
             {label.name}
@@ -538,7 +536,7 @@ export default function BoardFilterPanel({
           <CheckRow
             key={label.id}
             checked
-            onChange={() => toggleLabelId(label.id)}
+            onChange={() => { toggleLabelId(label.id); }}
             swatch={{ color: label.color }}
           >
             {label.name}
@@ -550,7 +548,7 @@ export default function BoardFilterPanel({
           <div className="mt-1">
             <button
               type="button"
-              onClick={() => setLabelDropdownOpen((v) => !v)}
+              onClick={() => { setLabelDropdownOpen((v) => !v); }}
               className="flex w-full items-center justify-between rounded border border-border bg-bg-overlay px-2.5 py-1.5 text-sm text-muted hover:text-base transition-colors"
             >
               <span>Select labels</span>
@@ -569,7 +567,7 @@ export default function BoardFilterPanel({
                     type="search"
                     placeholder="Search labels..."
                     value={labelSearch}
-                    onChange={(e) => setLabelSearch(e.target.value)}
+                    onChange={(e) => { setLabelSearch(e.target.value); }}
                     className="flex-1 bg-transparent text-xs text-base placeholder:text-muted focus:outline-none"
                   />
                 </div>
@@ -582,7 +580,7 @@ export default function BoardFilterPanel({
                       <CheckRow
                         key={label.id}
                         checked={filters.labelIds.has(label.id)}
-                        onChange={() => toggleLabelId(label.id)}
+                        onChange={() => { toggleLabelId(label.id); }}
                         swatch={{ color: label.color }}
                       >
                         {label.name}
@@ -599,25 +597,25 @@ export default function BoardFilterPanel({
         <SectionHeading icon={<BoltIcon className="h-3.5 w-3.5" />}>Activity</SectionHeading>
         <CheckRow
           checked={filters.activity === 'week'}
-          onChange={() => toggleActivity('week')}
+          onChange={() => { toggleActivity('week'); }}
         >
           Active in the last week
         </CheckRow>
         <CheckRow
           checked={filters.activity === 'twoWeeks'}
-          onChange={() => toggleActivity('twoWeeks')}
+          onChange={() => { toggleActivity('twoWeeks'); }}
         >
           Active in the last two weeks
         </CheckRow>
         <CheckRow
           checked={filters.activity === 'fourWeeks'}
-          onChange={() => toggleActivity('fourWeeks')}
+          onChange={() => { toggleActivity('fourWeeks'); }}
         >
           Active in the last four weeks
         </CheckRow>
         <CheckRow
           checked={filters.activity === 'noActivity'}
-          onChange={() => toggleActivity('noActivity')}
+          onChange={() => { toggleActivity('noActivity'); }}
         >
           Without activity in the last four weeks
         </CheckRow>
@@ -630,7 +628,7 @@ export default function BoardFilterPanel({
           type="button"
           role="switch"
           aria-checked={filters.collapseLists}
-          onClick={() => set({ collapseLists: !filters.collapseLists })}
+          onClick={() => { set({ collapseLists: !filters.collapseLists }); }}
           className={`relative h-5 w-9 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary ${
             filters.collapseLists ? 'bg-primary' : 'bg-border'
           }`}


### PR DESCRIPTION
## Scope
- Apply ESLint-safe callback bodies in `src/extensions/Board/components/BoardFilterPanel.tsx`.
- Make the exhaustive due-month and no-activity filter branches explicit without changing their predicates.
- Preserve panel interaction, filter state updates, outside-click/Escape close behaviour, member/label dropdowns and card-filter results.

## Validation
- `bunx eslint src/extensions/Board/components/BoardFilterPanel.tsx`
- UI/E2E coverage: no BoardFilterPanel-specific executable test exists. `tests/e2e/search-filters.spec.ts` targets the separate search surface and was not represented as panel coverage.
- `bun run typecheck` — existing exit 2; no changed-file diagnostic
- `bun test` — existing baseline exit 1
- `bun run build:client` — passed (existing bundle-size warnings)
- `git diff --check`
