### PR TITLE
test(health-check): type row render fixtures

### DIFF
--- a/src/extensions/HealthCheck/components/__tests__/HealthCheckRow.test.tsx
+++ b/src/extensions/HealthCheck/components/__tests__/HealthCheckRow.test.tsx
@@ -1,6 +1,6 @@
 // Render smoke tests for HealthCheckRow.
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, mock } from 'bun:test';
 import { HealthCheckRow } from '../HealthCheckRow';
 import type { HealthCheck } from '../../api';
 
@@ -12,19 +12,20 @@ const baseEntry: HealthCheck = {
   type: 'preset',
   presetKey: 'stripe',
   isActive: true,
+  expectedStatus: 200,
   createdAt: new Date().toISOString(),
   latestResult: null,
 };
 
 describe('HealthCheckRow', () => {
   it('renders service name and URL', () => {
-    render(<HealthCheckRow entry={baseEntry} isProbing={false} onRemove={vi.fn()} />);
+    render(<HealthCheckRow entry={baseEntry} isProbing={false} onRemove={mock()} />);
     expect(screen.getByText('Stripe API')).toBeTruthy();
     expect(screen.getByText('https://api.stripe.com/')).toBeTruthy();
   });
 
   it('shows spinner when probing', () => {
-    render(<HealthCheckRow entry={baseEntry} isProbing={true} onRemove={vi.fn()} />);
+    render(<HealthCheckRow entry={baseEntry} isProbing={true} onRemove={mock()} />);
     expect(screen.getByRole('status')).toBeTruthy();
   });
 
@@ -39,7 +40,7 @@ describe('HealthCheckRow', () => {
         checkedAt: new Date().toISOString(),
       },
     };
-    render(<HealthCheckRow entry={entry} isProbing={false} onRemove={vi.fn()} />);
+    render(<HealthCheckRow entry={entry} isProbing={false} onRemove={mock()} />);
     expect(screen.getByText('120 ms')).toBeTruthy();
   });
 
@@ -54,7 +55,7 @@ describe('HealthCheckRow', () => {
         checkedAt: new Date().toISOString(),
       },
     };
-    render(<HealthCheckRow entry={entry} isProbing={false} onRemove={vi.fn()} />);
+    render(<HealthCheckRow entry={entry} isProbing={false} onRemove={mock()} />);
     expect(screen.getByText('Timeout')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Scope
- Move `HealthCheckRow` render smoke tests to the repository’s Bun test API.
- Align the fixture with the current required `HealthCheck.expectedStatus` field.
- Preserve all four rendered-output assertions: service/URL, probing spinner, response time and timeout label.

## Validation
- `bunx eslint src/extensions/HealthCheck/components/__tests__/HealthCheckRow.test.tsx`
- `bun test src/extensions/HealthCheck/components/__tests__/HealthCheckRow.test.tsx` — baseline-blocked: all four cases fail before assertions with `ReferenceError: document is not defined`. Reproduced on current `main` before this test-only change.
- `bun run typecheck` — existing exit 2; no changed-file diagnostic
- `bun test` — existing baseline exit 1
- `bun run build:client` — passed (existing bundle-size warnings)
- `git diff --check`
