### PR TITLE
fix(observability): type metric SDK imports

### DIFF
--- a/server/mods/observability/metrics.ts
+++ b/server/mods/observability/metrics.ts
@@ -48,10 +48,8 @@ export async function initMetrics(): Promise<void> {
   if (!env.OTEL_ENABLED) return;
 
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { MeterProvider, PeriodicExportingMetricReader } = await import('@opentelemetry/sdk-metrics' as any);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { OTLPMetricExporter } = await import('@opentelemetry/exporter-metrics-otlp-http' as any);
+    const { MeterProvider, PeriodicExportingMetricReader } = await import('@opentelemetry/sdk-metrics');
+    const { OTLPMetricExporter } = await import('@opentelemetry/exporter-metrics-otlp-http');
 
     const exporterConfig = getExporterConfig();
     const exporter = new OTLPMetricExporter({ url: exporterConfig.url.replace('/v1/traces', '/v1/metrics') });


### PR DESCRIPTION
## Scope
- Replace the two `as any` OpenTelemetry metric dynamic imports with the installed SDK's typed module imports in `server/mods/observability/metrics.ts`.
- Preserve lazy loading, `OTEL_ENABLED` gating, disabled-mode no-ops, exporter URL mapping, meter names/descriptions and initialization failure handling.

## Validation
- `bunx eslint server/mods/observability/metrics.ts`
- `bun test tests/integration/otel.test.ts` — 5 passing
- `bun run typecheck` — existing exit 2; no changed-file diagnostic
- `bun test` — existing baseline exit 1
- `bun run build:client` — passed (existing bundle-size warnings)
- `git diff --check`
