### PR TITLE
fix(automation): type sort-by-name action

### DIFF
--- a/server/extensions/automation/engine/actions/list/sortByName.ts
+++ b/server/extensions/automation/engine/actions/list/sortByName.ts
@@ -2,11 +2,16 @@
 
 import { z } from 'zod';
 import { between, HIGH_SENTINEL } from '../../../../list/mods/fractional';
-import type { ActionHandler, ActionContext } from '../../../../common/types';
+import type { ActionHandler, ActionContext } from '../../../common/types';
 
 const configSchema = z.object({
   listId: z.string().min(1),
 });
+
+type SortableCardRow = {
+  id: string;
+  title: string | null;
+};
 
 export const listSortByNameAction: ActionHandler = {
   type: 'list.sort_by_name',
@@ -16,12 +21,12 @@ export const listSortByNameAction: ActionHandler = {
   async execute({ action, trx }: ActionContext): Promise<void> {
     const config = configSchema.parse(action.config);
 
-    const list = await trx('lists').where({ id: config.listId }).first();
+    const list = (await trx('lists').where({ id: config.listId }).first()) as unknown;
     if (!list) throw new Error('list-not-found');
 
-    const cards = await trx('cards')
+    const cards = (await trx('cards')
       .where({ list_id: config.listId, archived: false })
-      .orderBy('position', 'asc');
+      .orderBy('position', 'asc')) as SortableCardRow[];
 
     if (cards.length < 2) return;
 


### PR DESCRIPTION
## Scope
- Correct the stale automation `ActionContext` type import and formalise sortable-card query results in `sortByName.ts`.
- Preserve non-archived list selection, case-insensitive title ordering and fractional-position update sequence.

## Validation
- `bunx eslint server/extensions/automation/engine/actions/list/sortByName.ts`
- `bun test tests/integration/automation/actions.test.ts` — baseline-blocked before tests: empty `DATABASE_URL` (`ERR_INVALID_URL`).
- `bun run typecheck` — existing exit 2; no changed-file diagnostic
- `bun test` — existing baseline exit 1
- `bun run build:client` — passed (existing bundle-size warnings)
- `git diff --check`
