### PR TITLE
test(trello): type label compatibility mock

### DIFF
--- a/server/extensions/trelloCompat/tests/labels.test.ts
+++ b/server/extensions/trelloCompat/tests/labels.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { db as database } from '../../../common/db';
 
 type Row = Record<string, unknown>;
 
@@ -27,18 +28,18 @@ class QueryBuilder {
 
   constructor(private readonly store: DataStore, private readonly tableName: keyof DataStore) {}
 
-  where(criteria: Row): QueryBuilder {
+  where(criteria: Row): this {
     this.filters.push((row) => Object.entries(criteria).every(([key, value]) => row[key] === value));
     return this;
   }
 
-  orderBy(field: string, direction: 'asc' | 'desc' = 'asc'): QueryBuilder {
+  orderBy(field: string, direction: 'asc' | 'desc' = 'asc'): this {
     this.orderByField = field;
     this.orderByDirection = direction;
     return this;
   }
 
-  select(...columns: string[]): QueryBuilder {
+  select(...columns: string[]): this {
     this.pickedColumns = columns.length > 0 ? columns : null;
     return this;
   }
@@ -48,25 +49,26 @@ class QueryBuilder {
     return rows[0];
   }
 
-  async insert(payload: Row | Row[]): Promise<void> {
+  insert(payload: Row | Row[]): Promise<void> {
     const rows = Array.isArray(payload) ? payload : [payload];
     for (const row of rows) {
-      (this.store[this.tableName] as Row[]).push({ ...row });
+      this.store[this.tableName].push({ ...row });
     }
+    return Promise.resolve();
   }
 
-  async update(patch: Row): Promise<number> {
+  update(patch: Row): Promise<number> {
     const rows = this.executeSync(false);
     rows.forEach((row) => Object.assign(row, patch));
-    return rows.length;
+    return Promise.resolve(rows.length);
   }
 
-  async delete(): Promise<number> {
-    const rows = this.store[this.tableName] as Row[];
+  delete(): Promise<number> {
+    const rows = this.store[this.tableName];
     const before = rows.length;
     const keep = rows.filter((row) => !this.filters.every((filter) => filter(row)));
     this.store[this.tableName] = keep;
-    return before - keep.length;
+    return Promise.resolve(before - keep.length);
   }
 
   then<TResult1 = Row[], TResult2 = never>(
@@ -77,7 +79,7 @@ class QueryBuilder {
   }
 
   private executeSync(clone = true): Row[] {
-    const source = this.store[this.tableName] as Row[];
+    const source = this.store[this.tableName];
     let rows = source.filter((row) => this.filters.every((filter) => filter(row)));
 
     if (this.orderByField) {
@@ -89,14 +91,15 @@ class QueryBuilder {
         if (left === right) return 0;
         if (left === undefined || left === null) return -1 * factor;
         if (right === undefined || right === null) return 1 * factor;
-        return String(left) > String(right) ? factor : -1 * factor;
+        return String(left as string | number | boolean | bigint | symbol) > String(right as string | number | boolean | bigint | symbol) ? factor : -1 * factor;
       });
     }
 
-    if (this.pickedColumns) {
+    const pickedColumns = this.pickedColumns;
+    if (pickedColumns) {
       rows = rows.map((row) => {
         const next: Row = {};
-        this.pickedColumns!.forEach((column) => {
+        pickedColumns.forEach((column) => {
           next[column] = row[column];
         });
         return next;
@@ -106,8 +109,8 @@ class QueryBuilder {
     return clone ? rows.map((row) => ({ ...row })) : rows;
   }
 
-  private async execute(): Promise<Row[]> {
-    return this.executeSync();
+  private execute(): Promise<Row[]> {
+    return Promise.resolve(this.executeSync());
   }
 }
 
@@ -132,7 +135,12 @@ function createStore(): DataStore {
 
 let dataStore = createStore();
 
-const authenticateMock = mock(async (req: Request & { currentUser?: unknown }) => {
+function requireResponse(response: Response | null | undefined): Response {
+  if (!response) throw new Error('Expected trelloCompatRouter to return a response');
+  return response;
+}
+
+const authenticateMock = mock((req: Request & { currentUser?: unknown }) => {
   const authHeader = req.headers.get('authorization') ?? req.headers.get('Authorization') ?? '';
   const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
 
@@ -144,21 +152,21 @@ const authenticateMock = mock(async (req: Request & { currentUser?: unknown }) =
   return Response.json({ error: { code: 'unauthorized', message: 'Invalid API token' } }, { status: 401 });
 });
 
-mock.module('../../auth/middlewares/authentication', () => ({
+void mock.module('../../auth/middlewares/authentication', () => ({
   authenticate: authenticateMock,
 }));
 
-mock.module('../../../common/db', () => ({
-  db: ((tableName: keyof DataStore) => new QueryBuilder(dataStore, tableName)) as unknown as typeof import('../../../common/db').db,
+void mock.module('../../../common/db', () => ({
+  db: ((tableName: keyof DataStore) => new QueryBuilder(dataStore, tableName)) as unknown as typeof database,
 }));
 
-mock.module('../../../common/ids/resolveEntityId', () => ({
-  resolveBoardId: async (identifier: string) => {
+void mock.module('../../../common/ids/resolveEntityId', () => ({
+  resolveBoardId: (identifier: string) => {
     const found = dataStore.boards.find((row) => row.id === identifier || row.short_id === identifier);
-    return (found?.id as string | undefined) ?? null;
+    return Promise.resolve((found?.id as string | undefined) ?? null);
   },
-  resolveCardId: async () => null,
-  resolveListId: async () => null,
+  resolveCardId: () => Promise.resolve(null),
+  resolveListId: () => Promise.resolve(null),
 }));
 
 const { trelloCompatRouter } = await import('../api/index');
@@ -179,7 +187,7 @@ describe('trelloCompat labels', () => {
 
     const res = await trelloCompatRouter(req, '/trello/1/labels');
     expect(res?.status).toBe(200);
-    const body = await res!.json() as { idBoard: string; name: string; color: string };
+    const body = await requireResponse(res).json() as { idBoard: string; name: string; color: string };
     expect(body.idBoard).toBe('board-1');
     expect(body.name).toBe('Bug');
     expect(body.color).toBe('#FF5733');
@@ -193,7 +201,7 @@ describe('trelloCompat labels', () => {
 
     const res = await trelloCompatRouter(req, '/trello/1/labels/label-1');
     expect(res?.status).toBe(200);
-    const body = await res!.json() as { id: string; name: string };
+    const body = await requireResponse(res).json() as { id: string; name: string };
     expect(body.id).toBe('label-1');
     expect(body.name).toBe('Urgent');
   });
@@ -207,7 +215,7 @@ describe('trelloCompat labels', () => {
 
     const res = await trelloCompatRouter(req, '/trello/1/labels/label-1');
     expect(res?.status).toBe(200);
-    const body = await res!.json() as { name: string };
+    const body = await requireResponse(res).json() as { name: string };
     expect(body.name).toBe('Backend Bug');
     expect(dataStore.labels.find((row) => row.id === 'label-1')?.name).toBe('Backend Bug');
   });
@@ -221,7 +229,7 @@ describe('trelloCompat labels', () => {
 
     const res = await trelloCompatRouter(req, '/trello/1/labels/label-1/color');
     expect(res?.status).toBe(200);
-    const body = await res!.json() as { name: string; color: string };
+    const body = await requireResponse(res).json() as { name: string; color: string };
     expect(body.name).toBe('Urgent');
     expect(body.color).toBe('#123456');
   });
@@ -234,7 +242,7 @@ describe('trelloCompat labels', () => {
 
     const res = await trelloCompatRouter(req, '/trello/1/labels/label-1');
     expect(res?.status).toBe(200);
-    expect(await res!.json()).toEqual({});
+    expect(await requireResponse(res).json()).toEqual({});
     expect(dataStore.labels.find((row) => row.id === 'label-1')).toBeUndefined();
     expect(dataStore.card_labels.find((row) => row.label_id === 'label-1')).toBeUndefined();
   });


### PR DESCRIPTION
## Scope
- Remove focused ESLint debt from the Trello label compatibility test double only.
- Preserve fluent and awaitable query behaviour, cumulative filtering, ordering/projection, cloned reads, source-fixture mutations, mock registration ordering and label/card-reference deletion coverage.

## Expected validation
- `bunx eslint server/extensions/trelloCompat/tests/labels.test.ts`
- `bun test server/extensions/trelloCompat/tests/labels.test.ts`
- `bun run typecheck`
- `bun test`
- `bun run build:client`
- `git diff --check`
