### PR TITLE
test(trello): type card member-label mock

### DIFF
--- a/server/extensions/trelloCompat/api/cards/__tests__/members_labels.test.ts
+++ b/server/extensions/trelloCompat/api/cards/__tests__/members_labels.test.ts
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { db as database } from '../../../../../common/db';
 
 type Row = Record<string, unknown>;
+
+function orderValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return value.toString();
+  return JSON.stringify(value);
+}
+
 type DataStore = {
   users: Row[];
   memberships: Row[];
@@ -29,18 +37,18 @@ class QueryBuilder {
 
   constructor(private readonly store: DataStore, private readonly tableName: keyof DataStore) {}
 
-  where(criteria: Row): QueryBuilder {
+  where(criteria: Row): this {
     this.filters.push((row) => Object.entries(criteria).every(([key, value]) => row[key] === value));
     return this;
   }
 
-  orderBy(field: string, direction: 'asc' | 'desc' = 'asc'): QueryBuilder {
+  orderBy(field: string, direction: 'asc' | 'desc' = 'asc'): this {
     this.orderByField = field;
     this.orderByDirection = direction;
     return this;
   }
 
-  select(...columns: string[]): QueryBuilder {
+  select(...columns: string[]): this {
     this.pickedColumns = columns.length > 0 ? columns : null;
     return this;
   }
@@ -50,22 +58,23 @@ class QueryBuilder {
     return rows[0];
   }
 
-  async insert(payload: Row | Row[]): Promise<void> {
+  insert(payload: Row | Row[]): Promise<void> {
     const rows = Array.isArray(payload) ? payload : [payload];
-    for (const row of rows) (this.store[this.tableName] as Row[]).push({ ...row });
+    for (const row of rows) this.store[this.tableName].push({ ...row });
+    return Promise.resolve();
   }
 
-  async update(patch: Row): Promise<number> {
+  update(patch: Row): Promise<number> {
     const rows = this.executeSync(false);
     rows.forEach((row) => Object.assign(row, patch));
-    return rows.length;
+    return Promise.resolve(rows.length);
   }
 
-  async delete(): Promise<number> {
-    const rows = this.store[this.tableName] as Row[];
+  delete(): Promise<number> {
+    const rows = this.store[this.tableName];
     const before = rows.length;
     this.store[this.tableName] = rows.filter((row) => !this.filters.every((filter) => filter(row)));
-    return before - this.store[this.tableName].length;
+    return Promise.resolve(before - this.store[this.tableName].length);
   }
 
   then<TResult1 = Row[], TResult2 = never>(
@@ -76,7 +85,7 @@ class QueryBuilder {
   }
 
   private executeSync(clone = true): Row[] {
-    const source = this.store[this.tableName] as Row[];
+    const source = this.store[this.tableName];
     let rows = source.filter((row) => this.filters.every((filter) => filter(row)));
     if (this.orderByField) {
       const field = this.orderByField;
@@ -87,14 +96,15 @@ class QueryBuilder {
         if (left === right) return 0;
         if (left === undefined || left === null) return -1 * factor;
         if (right === undefined || right === null) return 1 * factor;
-        return String(left) > String(right) ? factor : -1 * factor;
+        return orderValue(left) > orderValue(right) ? factor : -1 * factor;
       });
     }
 
     if (this.pickedColumns) {
+      const pickedColumns = this.pickedColumns;
       rows = rows.map((row) => {
         const next: Row = {};
-        this.pickedColumns!.forEach((column) => {
+        pickedColumns.forEach((column) => {
           next[column] = row[column];
         });
         return next;
@@ -103,8 +113,8 @@ class QueryBuilder {
     return clone ? rows.map((row) => ({ ...row })) : rows;
   }
 
-  private async execute(): Promise<Row[]> {
-    return this.executeSync();
+  private execute(): Promise<Row[]> {
+    return Promise.resolve(this.executeSync());
   }
 }
 
@@ -140,38 +150,38 @@ function createStore(): DataStore {
 let dataStore = createStore();
 let shortIdSeq = 0;
 
-const authenticateMock = mock(async (req: Request & { currentUser?: unknown }) => {
+const authenticateMock = mock((req: Request & { currentUser?: unknown }) => {
   const authHeader = req.headers.get('authorization') ?? req.headers.get('Authorization') ?? '';
   const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
   if (token === 'hf_admin_token') {
     req.currentUser = { id: 'user-admin', email: 'admin@example.com', name: 'Admin User' };
-    return null;
+    return Promise.resolve(null);
   }
-  return Response.json({ error: { code: 'unauthorized', message: 'Invalid API token' } }, { status: 401 });
+  return Promise.resolve(Response.json({ error: { code: 'unauthorized', message: 'Invalid API token' } }, { status: 401 }));
 });
 
-mock.module('../../../../auth/middlewares/authentication', () => ({ authenticate: authenticateMock }));
-mock.module('../../../../../common/db', () => ({
-  db: ((tableName: keyof DataStore) => new QueryBuilder(dataStore, tableName)) as unknown as typeof import('../../../../../common/db').db,
+void mock.module('../../../../auth/middlewares/authentication', () => ({ authenticate: authenticateMock }));
+void mock.module('../../../../../common/db', () => ({
+  db: ((tableName: keyof DataStore) => new QueryBuilder(dataStore, tableName)) as unknown as typeof database,
 }));
-mock.module('../../../../../common/ids/shortId', () => ({
-  generateUniqueShortId: async () => {
+void mock.module('../../../../../common/ids/shortId', () => ({
+  generateUniqueShortId: () => {
     shortIdSeq += 1;
-    return `short${String(shortIdSeq).padStart(4, '0')}`;
+    return Promise.resolve(`short${String(shortIdSeq).padStart(4, '0')}`);
   },
 }));
-mock.module('../../../../../common/ids/resolveEntityId', () => ({
-  resolveCardId: async (identifier: string) => {
+void mock.module('../../../../../common/ids/resolveEntityId', () => ({
+  resolveCardId: (identifier: string) => {
     const found = dataStore.cards.find((row) => row.id === identifier || row.short_id === identifier);
-    return (found?.id as string | undefined) ?? null;
+    return Promise.resolve((found?.id as string | undefined) ?? null);
   },
-  resolveListId: async (identifier: string) => {
+  resolveListId: (identifier: string) => {
     const found = dataStore.lists.find((row) => row.id === identifier || row.short_id === identifier);
-    return (found?.id as string | undefined) ?? null;
+    return Promise.resolve((found?.id as string | undefined) ?? null);
   },
-  resolveBoardId: async (identifier: string) => {
+  resolveBoardId: (identifier: string) => {
     const found = dataStore.boards.find((row) => row.id === identifier || row.short_id === identifier);
-    return (found?.id as string | undefined) ?? null;
+    return Promise.resolve((found?.id as string | undefined) ?? null);
   },
 }));
 
@@ -193,7 +203,8 @@ describe('trelloCompat card member/label endpoints', () => {
     });
     const addRes = await trelloCompatRouter(addReq, '/trello/1/cards/card-1/idMembers');
     expect(addRes?.status).toBe(200);
-    const added = await addRes!.json() as { idMembers: string[] };
+    if (!addRes) throw new Error('Expected member-add response');
+    const added = await addRes.json() as { idMembers: string[] };
     expect(added.idMembers.includes('user-new')).toBe(true);
 
     const deleteReq = new Request('http://localhost/trello/1/cards/card-1/idMembers/user-new', {
@@ -202,7 +213,8 @@ describe('trelloCompat card member/label endpoints', () => {
     });
     const deleteRes = await trelloCompatRouter(deleteReq, '/trello/1/cards/card-1/idMembers/user-new');
     expect(deleteRes?.status).toBe(200);
-    const removed = await deleteRes!.json() as { idMembers: string[] };
+    if (!deleteRes) throw new Error('Expected member-delete response');
+    const removed = await deleteRes.json() as { idMembers: string[] };
     expect(removed.idMembers.includes('user-new')).toBe(false);
   });
 
@@ -214,7 +226,8 @@ describe('trelloCompat card member/label endpoints', () => {
     });
     const addRes = await trelloCompatRouter(addReq, '/trello/1/cards/card-1/idLabels');
     expect(addRes?.status).toBe(200);
-    const added = await addRes!.json() as { idLabels: string[] };
+    if (!addRes) throw new Error('Expected label-add response');
+    const added = await addRes.json() as { idLabels: string[] };
     expect(added.idLabels.includes('label-2')).toBe(true);
 
     const deleteReq = new Request('http://localhost/trello/1/cards/card-1/idLabels/label-2', {
@@ -223,7 +236,8 @@ describe('trelloCompat card member/label endpoints', () => {
     });
     const deleteRes = await trelloCompatRouter(deleteReq, '/trello/1/cards/card-1/idLabels/label-2');
     expect(deleteRes?.status).toBe(200);
-    const removed = await deleteRes!.json() as { idLabels: string[] };
+    if (!deleteRes) throw new Error('Expected label-delete response');
+    const removed = await deleteRes.json() as { idLabels: string[] };
     expect(removed.idLabels.includes('label-2')).toBe(false);
   });
 });


### PR DESCRIPTION
## Scope
- Remove focused ESLint debt from the Trello card member/label compatibility test only.
- Preserve fluent/awaitable query mock semantics, short-ID sequencing, mock registration ordering and member/label lifecycle assertions.

## Validation
- `bunx eslint server/extensions/trelloCompat/api/cards/__tests__/members_labels.test.ts`
- `bun test server/extensions/trelloCompat/api/cards/__tests__/members_labels.test.ts` — 2 passed, 8 assertions
- `bun run typecheck` — existing exit 2; no changed-file diagnostic
- `bun test` — existing baseline exit 1
- `bun run build:client` — passed (existing bundle-size warnings)
- `git diff --check`
