### PR TITLE
fix(auth): type verify email user result

### DIFF
--- a/server/extensions/auth/api/verifyEmail.ts
+++ b/server/extensions/auth/api/verifyEmail.ts
@@ -7,6 +7,14 @@ import { issueAccessToken } from '../mods/token/issue';
 import { jwtConfig } from '../common/config/jwt';
 import { buildAvatarProxyUrl } from '../../../common/avatar/resolveAvatarUrl';
 
+type VerifyEmailUserRow = {
+  id: string;
+  email: string;
+  name: string;
+  avatar_url: string | null;
+  verification_token_expires_at: Date | string | null;
+};
+
 export async function handleVerifyEmail(req: Request): Promise<Response> {
   const url = new URL(req.url);
   const token = url.searchParams.get('token');
@@ -18,7 +26,7 @@ export async function handleVerifyEmail(req: Request): Promise<Response> {
     );
   }
 
-  const user = await db('users').where({ verification_token: token }).first();
+  const user = (await db('users').where({ verification_token: token }).first()) as VerifyEmailUserRow | undefined;
 
   if (!user) {
     return Response.json(
@@ -58,7 +66,7 @@ export async function handleVerifyEmail(req: Request): Promise<Response> {
   const responseHeaders = new Headers({ 'Content-Type': 'application/json' });
   responseHeaders.append(
     'Set-Cookie',
-    `refresh_token=${refreshToken}; HttpOnly; Path=/api/v1/auth/refresh; SameSite=Strict; Max-Age=${jwtConfig.refreshTokenTtlDays * 86400}`,
+    `refresh_token=${refreshToken}; HttpOnly; Path=/api/v1/auth/refresh; SameSite=Strict; Max-Age=${String(jwtConfig.refreshTokenTtlDays * 86400)}`,
   );
 
   const avatarUrl = buildAvatarProxyUrl({ userId: user.id, avatarUrl: user.avatar_url ?? null });


### PR DESCRIPTION
## Scope
- Formalise the verified-user persistence boundary in `server/extensions/auth/api/verifyEmail.ts` only.
- Preserve token validation/expiry, verification update, refresh-token persistence, cookie attributes and response JSON exactly.

## Validation
- `bunx eslint server/extensions/auth/api/verifyEmail.ts`
- No dedicated verify-email handler test exists in the repository.
- `bun run typecheck`
- `bun test`
- `bun run build:client`
- `git diff --check`
