### PR TITLE
test(state-transitions): type broadcast mock

### DIFF
--- a/server/extensions/stateTransitions/api/__tests__/wsBroadcast.test.ts
+++ b/server/extensions/stateTransitions/api/__tests__/wsBroadcast.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { db as dbFunction } from '../../../../common/db';
 
 type Row = Record<string, unknown>;
 type DataStore = {
@@ -16,18 +17,18 @@ class QueryBuilder {
 
   constructor(private readonly store: DataStore, private readonly tableName: keyof DataStore) {}
 
-  where(criteria: Row): QueryBuilder {
+  where(criteria: Row): this {
     this.filters.push((row) => Object.entries(criteria).every(([key, value]) => row[key] === value));
     return this;
   }
 
-  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): QueryBuilder {
+  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): this {
     this.orderedBy = column;
     this.orderDirection = direction;
     return this;
   }
 
-  select(...columns: string[]): QueryBuilder {
+  select(...columns: string[]): this {
     this.selectedColumns = columns.length > 0 ? columns : null;
     return this;
   }
@@ -41,20 +42,20 @@ class QueryBuilder {
     const rows = Array.isArray(payload) ? payload : [payload];
     const inserted = rows.map((row) => ({ ...row }));
     for (const row of inserted) {
-      (this.store[this.tableName] as Row[]).push(row);
+      this.store[this.tableName].push(row);
     }
     return {
-      returning: async () => inserted.map((row) => ({ ...row })),
+      returning: () => Promise.resolve(inserted.map((row) => ({ ...row }))),
     };
   }
 
-  async update(patch: Row, returning?: string[]): Promise<Row[] | number> {
+  update(patch: Row, returning?: string[]): Promise<Row[] | number> {
     const rows = this.executeSync(false);
     for (const row of rows) Object.assign(row, patch);
     if (returning && returning.length > 0) {
-      return rows.map((row) => ({ ...row }));
+      return Promise.resolve(rows.map((row) => ({ ...row })));
     }
-    return rows.length;
+    return Promise.resolve(rows.length);
   }
 
   then<TResult1 = Row[], TResult2 = never>(
@@ -65,7 +66,7 @@ class QueryBuilder {
   }
 
   private executeSync(clone = true): Row[] {
-    let rows = (this.store[this.tableName] as Row[]).filter((row) =>
+    let rows = this.store[this.tableName].filter((row) =>
       this.filters.every((predicate) => predicate(row)),
     );
 
@@ -80,10 +81,11 @@ class QueryBuilder {
       });
     }
 
-    if (this.selectedColumns) {
+    const selectedColumns = this.selectedColumns;
+    if (selectedColumns) {
       rows = rows.map((row) => {
         const next: Row = {};
-        for (const key of this.selectedColumns!) next[key] = row[key];
+        for (const key of selectedColumns) next[key] = row[key];
         return next;
       });
     }
@@ -91,8 +93,8 @@ class QueryBuilder {
     return clone ? rows.map((row) => ({ ...row })) : rows;
   }
 
-  private async execute(): Promise<Row[]> {
-    return this.executeSync();
+  private execute(): Promise<Row[]> {
+    return Promise.resolve(this.executeSync());
   }
 }
 
@@ -111,49 +113,50 @@ function resetStore(): DataStore {
   };
 }
 
-mock.module('../../../../config/featureFlags', () => ({
+void mock.module('../../../../config/featureFlags', () => ({
   featureFlags: {
     STATE_TRANSITIONS_ENABLED: true,
   },
 }));
 
-mock.module('../../../../common/db', () => ({
-  db: ((tableName: keyof DataStore) => new QueryBuilder(dataStore, tableName)) as unknown as typeof import('../../../../common/db').db,
+void mock.module('../../../../common/db', () => ({
+  db: ((tableName: keyof DataStore) => new QueryBuilder(dataStore, tableName)) as unknown as typeof dbFunction,
 }));
 
-mock.module('../../../auth/middlewares/authentication', () => ({
-  authenticate: async (req: Request & { currentUser?: { id: string; email: string } }) => {
+void mock.module('../../../auth/middlewares/authentication', () => ({
+  authenticate: (req: Request & { currentUser?: { id: string; email: string } }) => {
     req.currentUser = { id: 'user-admin', email: 'admin@example.com' };
-    return null;
+    return Promise.resolve(null);
   },
 }));
 
-mock.module('../../../board/middlewares/requireBoardWritable', () => ({
-  requireBoardWritable: async (
+void mock.module('../../../board/middlewares/requireBoardWritable', () => ({
+  requireBoardWritable: (
     req: Request & { board?: { id: string; workspace_id: string } },
     boardId: string,
   ) => {
     req.board = { id: boardId, workspace_id: 'ws-1' };
-    return null;
+    return Promise.resolve(null);
   },
 }));
 
-mock.module('../../../../middlewares/permissionManager', () => ({
-  requireWorkspaceMembership: async () => null,
+void mock.module('../../../../middlewares/permissionManager', () => ({
+  requireWorkspaceMembership: () => Promise.resolve(null),
   requireRole: () => null,
 }));
 
-mock.module('../../../../common/uuid', () => ({
+void mock.module('../../../../common/uuid', () => ({
   generateId: () => 'state-transition-generated',
 }));
 
-mock.module('../../common/ws', () => ({
-  broadcastStateTransitionUpdated: async (input: {
+void mock.module('../../common/ws', () => ({
+  broadcastStateTransitionUpdated: (input: {
     boardId: string;
     actorId: string;
     enabled: boolean;
   }) => {
     broadcasts.push({ boardId: input.boardId, actorId: input.actorId, enabled: input.enabled });
+    return Promise.resolve();
   },
 }));
 


### PR DESCRIPTION
## Scope
- Remove lint-invalid mock/test-double patterns in `server/extensions/stateTransitions/api/__tests__/wsBroadcast.test.ts` only.
- Preserve query and insert-returning mock behaviour, dynamic mock ordering, UUID fixture, access setup and broadcast assertion.

## Validation
- `bunx eslint server/extensions/stateTransitions/api/__tests__/wsBroadcast.test.ts`
- `bun test server/extensions/stateTransitions/api/__tests__/wsBroadcast.test.ts`
- `bun run typecheck`
- `bun test`
- `bun run build:client`
- `git diff --check`
