### PR TITLE
test(health): type status dot assertions

### DIFF
--- a/src/extensions/HealthCheck/components/__tests__/HealthCheckStatusDot.test.tsx
+++ b/src/extensions/HealthCheck/components/__tests__/HealthCheckStatusDot.test.tsx
@@ -1,8 +1,14 @@
 // Render smoke tests for HealthCheckStatusDot.
 // Verifies the component renders without throwing for all status values.
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'bun:test';
 import { HealthCheckStatusDot } from '../HealthCheckStatusDot';
+
+declare module 'bun:test' {
+  interface Matchers<T> {
+    toHaveAttribute(attribute: string, value?: string | number | boolean | null | T): void;
+  }
+}
 
 describe('HealthCheckStatusDot', () => {
   it('renders with no status (unknown/gray)', () => {


### PR DESCRIPTION
## Scope
- Resolve lint typing in `src/extensions/HealthCheck/components/__tests__/HealthCheckStatusDot.test.tsx` only.
- Preserve all five render/accessibility assertions.

## Validation
- Focused ESLint
- Focused test is baseline-blocked before assertions: `ReferenceError: document is not defined` from Testing Library render.
- No executable DOM/E2E coverage is available locally for this slice; no UI server is started because implementation/UI behaviour is unchanged.
- `bun run typecheck`, `bun test`, `bun run build:client`, `git diff --check`
