### PR TITLE
test(health): type countdown assertions

### DIFF
--- a/src/extensions/HealthCheck/components/__tests__/HealthCheckCountdown.test.tsx
+++ b/src/extensions/HealthCheck/components/__tests__/HealthCheckCountdown.test.tsx
@@ -1,7 +1,13 @@
 // Render smoke tests for HealthCheckCountdown.
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'bun:test';
 import { HealthCheckCountdown } from '../HealthCheckCountdown';
+
+declare module 'bun:test' {
+  interface Matchers<T> {
+    toBeTruthy(): T;
+  }
+}
 
 describe('HealthCheckCountdown', () => {
   it('renders seconds remaining', () => {


### PR DESCRIPTION
## Scope
- Resolve lint typing in `src/extensions/HealthCheck/components/__tests__/HealthCheckCountdown.test.tsx` only.
- Preserve all five render and aria-live assertions.

## Validation
- Focused lint.
- Focused test baseline-blocked before assertions: `ReferenceError: document is not defined` from Testing Library render.
- No DOM/E2E coverage is available locally; no UI implementation change.
- `bun run typecheck`, `bun test`, `bun run build:client`, `git diff --check`.
