### PR TITLE
test(board-view): type preference slice state

### DIFF
--- a/src/extensions/BoardViewSwitcher/__tests__/viewPreference.slice.spec.ts
+++ b/src/extensions/BoardViewSwitcher/__tests__/viewPreference.slice.spec.ts
@@ -1,7 +1,8 @@
 // Unit tests for viewPreference.slice (Sprint 52).
 // Tests the Redux slice in isolation — no real API calls.
-import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 import { configureStore } from '@reduxjs/toolkit';
+import type { RootState } from '~/store';
 import viewPreferenceReducer, {
   setActiveView,
   fetchViewPreference,
@@ -12,6 +13,12 @@ import viewPreferenceReducer, {
 import type { ViewPreferenceState } from '../types';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
+
+type ViewPreferenceTestState = Pick<RootState, 'viewPreference'>;
+
+function asRootState(state: ViewPreferenceTestState): RootState {
+  return state as RootState;
+}
 
 function makeStore(preloaded?: Partial<ViewPreferenceState>) {
   return configureStore({
@@ -25,20 +32,20 @@ function makeStore(preloaded?: Partial<ViewPreferenceState>) {
 describe('viewPreference slice — setActiveView', () => {
   it('defaults to KANBAN', () => {
     const store = makeStore();
-    expect(selectActiveView(store.getState() as any)).toBe('KANBAN');
+    expect(selectActiveView(asRootState(store.getState()))).toBe('KANBAN');
   });
 
   it('updates activeView optimistically', () => {
     const store = makeStore();
     store.dispatch(setActiveView('TABLE'));
-    expect(selectActiveView(store.getState() as any)).toBe('TABLE');
+    expect(selectActiveView(asRootState(store.getState()))).toBe('TABLE');
   });
 
   it('cycles through all view types', () => {
     const store = makeStore();
     for (const view of ['KANBAN', 'TABLE', 'CALENDAR', 'TIMELINE'] as const) {
       store.dispatch(setActiveView(view));
-      expect(selectActiveView(store.getState() as any)).toBe(view);
+      expect(selectActiveView(asRootState(store.getState()))).toBe(view);
     }
   });
 });
@@ -47,26 +54,26 @@ describe('viewPreference slice — fetchViewPreference thunk', () => {
   it('sets status to loading on pending', () => {
     const store = makeStore();
     store.dispatch({ type: fetchViewPreference.pending.type, meta: { requestId: 'r1', arg: { boardId: 'b1' } } });
-    expect(selectViewPreferenceStatus(store.getState() as any)).toBe('loading');
+    expect(selectViewPreferenceStatus(asRootState(store.getState()))).toBe('loading');
   });
 
   it('sets activeView on fulfilled', () => {
     const store = makeStore();
     store.dispatch({ type: fetchViewPreference.fulfilled.type, payload: 'CALENDAR', meta: { requestId: 'r1', arg: { boardId: 'b1' } } });
-    expect(selectActiveView(store.getState() as any)).toBe('CALENDAR');
-    expect(selectViewPreferenceStatus(store.getState() as any)).toBe('idle');
+    expect(selectActiveView(asRootState(store.getState()))).toBe('CALENDAR');
+    expect(selectViewPreferenceStatus(asRootState(store.getState()))).toBe('idle');
   });
 
   it('falls back to KANBAN if payload is undefined', () => {
     const store = makeStore({ activeView: 'TABLE' });
     store.dispatch({ type: fetchViewPreference.fulfilled.type, payload: undefined, meta: { requestId: 'r1', arg: { boardId: 'b1' } } });
-    expect(selectActiveView(store.getState() as any)).toBe('KANBAN');
+    expect(selectActiveView(asRootState(store.getState()))).toBe('KANBAN');
   });
 
   it('resets status to idle on rejected', () => {
     const store = makeStore();
     store.dispatch({ type: fetchViewPreference.rejected.type, meta: { requestId: 'r1', arg: { boardId: 'b1' } } });
-    expect(selectViewPreferenceStatus(store.getState() as any)).toBe('idle');
+    expect(selectViewPreferenceStatus(asRootState(store.getState()))).toBe('idle');
   });
 });
 
@@ -74,19 +81,19 @@ describe('viewPreference slice — saveViewPreference thunk', () => {
   it('sets status to loading on pending', () => {
     const store = makeStore();
     store.dispatch({ type: saveViewPreference.pending.type, meta: { requestId: 'r2', arg: { boardId: 'b1', viewType: 'TABLE' } } });
-    expect(selectViewPreferenceStatus(store.getState() as any)).toBe('loading');
+    expect(selectViewPreferenceStatus(asRootState(store.getState()))).toBe('loading');
   });
 
   it('confirms activeView on fulfilled', () => {
     const store = makeStore({ activeView: 'TABLE' });
     store.dispatch({ type: saveViewPreference.fulfilled.type, payload: 'TABLE', meta: { requestId: 'r2', arg: { boardId: 'b1', viewType: 'TABLE' } } });
-    expect(selectActiveView(store.getState() as any)).toBe('TABLE');
-    expect(selectViewPreferenceStatus(store.getState() as any)).toBe('idle');
+    expect(selectActiveView(asRootState(store.getState()))).toBe('TABLE');
+    expect(selectViewPreferenceStatus(asRootState(store.getState()))).toBe('idle');
   });
 
   it('keeps current view if payload is undefined on fulfilled', () => {
     const store = makeStore({ activeView: 'CALENDAR' });
     store.dispatch({ type: saveViewPreference.fulfilled.type, payload: undefined, meta: { requestId: 'r2', arg: { boardId: 'b1', viewType: 'CALENDAR' } } });
-    expect(selectActiveView(store.getState() as any)).toBe('CALENDAR');
+    expect(selectActiveView(asRootState(store.getState()))).toBe('CALENDAR');
   });
 });


### PR DESCRIPTION
## Scope

Makes `src/extensions/BoardViewSwitcher/__tests__/viewPreference.slice.spec.ts` lint-clean without changing its Redux slice assertions.

## Behaviour preserved

- KANBAN default and optimistic active-view updates.
- All supported view types.
- Fetch thunk pending, fulfilled, undefined-payload fallback, and rejected states.
- Save thunk pending, fulfilled, and undefined-payload behaviour.

## Validation

- `bunx eslint src/extensions/BoardViewSwitcher/__tests__/viewPreference.slice.spec.ts` — passed, 0 findings
- `bun test src/extensions/BoardViewSwitcher/__tests__/viewPreference.slice.spec.ts` — 10 passed, 0 failed, 15 expectations
- `git diff --check` — passed
- `bun run typecheck` — existing exit 2; no touched-file diagnostic
- `bun test` — existing exit 1
- `bun run build:client` — passed
