### PR TITLE
fix(list): type creation handler boundary

### DIFF
--- a/server/extensions/list/api/create.ts
+++ b/server/extensions/list/api/create.ts
@@ -14,6 +14,20 @@ import { between, HIGH_SENTINEL } from '../mods/fractional';
 import { sanitizeText } from '../../../common/sanitize';
 import { generateUniqueShortId } from '../../../common/ids/shortId';
 
+type ListRow = {
+  id: string;
+  short_id: string;
+  board_id: string;
+  title: string;
+  position: string;
+  archived: boolean;
+};
+
+type AuthenticatedBoardRequest = AuthenticatedRequest & BoardScopedRequest & {
+  board: NonNullable<BoardScopedRequest['board']>;
+  currentUser: { id: string };
+};
+
 export async function handleCreateList(req: Request, boardId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
@@ -22,7 +36,7 @@ export async function handleCreateList(req: Request, boardId: string): Promise<R
   const writableError = await requireBoardWritable(boardReq, boardId);
   if (writableError) return writableError;
 
-  const board = boardReq.board!;
+  const board = boardReq.board as NonNullable<BoardScopedRequest['board']>;
   const canonicalBoardId = board.id;
 
   const scopedReq = req as WorkspaceScopedRequest;
@@ -50,7 +64,7 @@ export async function handleCreateList(req: Request, boardId: string): Promise<R
   }
 
   // Resolve position: insert after the specified list (or at the end)
-  const activeLists = await db('lists')
+  const activeLists = await db<ListRow>('lists')
     .where({ board_id: canonicalBoardId, archived: false })
     .orderBy('position', 'asc');
 
@@ -67,7 +81,7 @@ export async function handleCreateList(req: Request, boardId: string): Promise<R
         { status: 404 },
       );
     }
-    const after = activeLists[afterIndex]!;
+    const after = activeLists[afterIndex] as ListRow;
     const next = activeLists[afterIndex + 1];
     position = between(after.position, next ? next.position : HIGH_SENTINEL);
   }
@@ -83,10 +97,11 @@ export async function handleCreateList(req: Request, boardId: string): Promise<R
     archived: false,
   });
 
-  const list = await db('lists').where({ id }).first();
+  const list = await db<ListRow>('lists').where({ id }).first();
 
   // Broadcast full list object so clients can update their local state
-  await writeEvent({ type: 'list_created', boardId: canonicalBoardId, entityId: id, actorId: (req as AuthenticatedRequest).currentUser?.id ?? 'system', payload: { list } });
+  const authenticatedRequest = req as AuthenticatedBoardRequest;
+  await writeEvent({ type: 'list_created', boardId: canonicalBoardId, entityId: id, actorId: authenticatedRequest.currentUser.id, payload: { list } });
 
   return Response.json({ data: list }, { status: 201 });
 }


### PR DESCRIPTION
## Scope
Type the authenticated list-creation handler’s database and request boundaries without changing its API contract.

## Behaviour preserved
- Existing authentication, board writability, workspace membership and member/guest-role checks remain in the same order.
- List ordering, sanitisation, insert payload, `list_created` event and `201 { data: list }` response shape are unchanged.

## Verification
- `bunx eslint server/extensions/list/api/create.ts` — pass, 0 findings
- `bun test server/extensions/mcp/tools/createList.test.ts` — 2 passed
- `bun run typecheck` — existing repository failures (exit 2); no diagnostic in the changed file
- `bun test` — existing baseline failures (exit 1): 1,117 passed, 3 skipped, 180 failed, 30 errors; no focused-list regression identified
- `bun run build:client` — pass
- `git diff --check` — pass

## Coverage note
There is no existing executable server-handler test for `POST /api/v1/boards/:boardId/lists`. The focused MCP client contract test covers its request/response boundary; this PR does not claim handler-level integration coverage.