### PR TITLE
fix(list): type delete handler boundary

### DIFF
--- a/server/extensions/list/api/delete.ts
+++ b/server/extensions/list/api/delete.ts
@@ -12,11 +12,21 @@ import { requireBoardWritable, type BoardScopedRequest } from '../../board/middl
 import { featureFlags } from '../../../config/featureFlags';
 import { syncStateTransitionsOnListDelete } from '../../stateTransitions/hooks/listSync';
 
+type ListRow = {
+  id: string;
+  board_id: string;
+};
+
+type AuthenticatedBoardRequest = AuthenticatedRequest & BoardScopedRequest & {
+  board: NonNullable<BoardScopedRequest['board']>;
+  currentUser: { id: string };
+};
+
 export async function handleDeleteList(req: Request, listId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const list = await db('lists').where({ id: listId }).first();
+  const list = await db<ListRow>('lists').where({ id: listId }).first();
   if (!list) {
     return Response.json(
       { error: { code: 'list-not-found', message: 'List not found' } },
@@ -28,7 +38,7 @@ export async function handleDeleteList(req: Request, listId: string): Promise<Re
   const writableError = await requireBoardWritable(boardReq, list.board_id);
   if (writableError) return writableError;
 
-  const board = boardReq.board!;
+  const board = boardReq.board as NonNullable<BoardScopedRequest['board']>;
 
   const scopedReq = req as WorkspaceScopedRequest;
   const membershipError = await requireWorkspaceMembership(scopedReq, board.workspace_id);
@@ -66,7 +76,8 @@ export async function handleDeleteList(req: Request, listId: string): Promise<Re
   }
 
   // Stub event emission.
-  await writeEvent({ type: 'list_deleted', boardId: list.board_id, entityId: listId, actorId: (req as AuthenticatedRequest).currentUser?.id ?? 'system', payload: {} });
+  const authenticatedRequest = req as AuthenticatedBoardRequest;
+  await writeEvent({ type: 'list_deleted', boardId: list.board_id, entityId: listId, actorId: authenticatedRequest.currentUser.id, payload: {} });
 
   return new Response(null, { status: 204 });
 }


### PR DESCRIPTION
## Scope
Type the list-delete handler’s database and authenticated-request boundaries without changing its public contract.

## Behaviour preserved
- Authentication, board writability, workspace membership and `ADMIN` authorisation checks remain ordered as before.
- Card-count confirmation, hard delete, state-transition synchronisation, `list_deleted` event and `204` response remain unchanged.

## Verification
- `bunx eslint server/extensions/list/api/delete.ts` — pass, 0 findings
- `bun test server/extensions/stateTransitions/common/__tests__/integration_list_sync.test.ts` — 2 passed
- `bun run typecheck` — existing repository failures (exit 2); no changed-file diagnostic
- `bun test` — existing baseline failure (exit 1): 1,117 passed, 3 skipped, 180 failed, 30 errors
- `bun run build:client` — pass
- `git diff --check` — pass

## Coverage
The focused executable route test verifies list deletion removes the corresponding state-transition node and connected edges. No UI code changed.