### PR TITLE
fix(list): type color handler boundary

### DIFF
--- a/server/extensions/list/api/color.ts
+++ b/server/extensions/list/api/color.ts
@@ -9,6 +9,17 @@ import {
 } from '../../../middlewares/permissionManager';
 import { requireBoardWritable, type BoardScopedRequest } from '../../board/middlewares/requireBoardWritable';
 
+type ListRow = {
+  id: string;
+  board_id: string;
+  color: string | null;
+};
+
+type AuthenticatedBoardRequest = AuthenticatedRequest & BoardScopedRequest & {
+  board: NonNullable<BoardScopedRequest['board']>;
+  currentUser: { id: string };
+};
+
 function normalizeColor(value: unknown): string | null | undefined {
   if (value === null) return null;
   if (typeof value !== 'string') return undefined;
@@ -22,7 +33,7 @@ export async function handleUpdateListColor(req: Request, listId: string): Promi
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const list = await db('lists').where({ id: listId }).first();
+  const list = await db<ListRow>('lists').where({ id: listId }).first();
   if (!list) {
     return Response.json(
       { error: { code: 'list-not-found', message: 'List not found' } },
@@ -34,7 +45,7 @@ export async function handleUpdateListColor(req: Request, listId: string): Promi
   const writableError = await requireBoardWritable(boardReq, list.board_id);
   if (writableError) return writableError;
 
-  const board = boardReq.board!;
+  const board = boardReq.board as NonNullable<BoardScopedRequest['board']>;
 
   const scopedReq = req as WorkspaceScopedRequest;
   const membershipError = await requireWorkspaceMembership(scopedReq, board.workspace_id);
@@ -61,15 +72,17 @@ export async function handleUpdateListColor(req: Request, listId: string): Promi
     );
   }
 
-  const [updated] = await db('lists')
+  const updatedRows = await db<ListRow>('lists')
     .where({ id: listId })
-    .update({ color: normalizedColor }, ['*']);
+    .update({ color: normalizedColor }, ['*']) as ListRow[];
+  const updated = updatedRows[0];
 
+  const authenticatedRequest = req as AuthenticatedBoardRequest;
   await writeEvent({
     type: 'list_updated',
     boardId: list.board_id,
     entityId: listId,
-    actorId: (req as AuthenticatedRequest).currentUser?.id ?? 'system',
+    actorId: authenticatedRequest.currentUser.id,
     payload: { list: updated },
   });
 


### PR DESCRIPTION
## Scope
Type the list-colour update handler’s database and authenticated-request boundaries without changing its contract.

## Behaviour preserved
- Authentication, board writability, workspace membership and `MEMBER` role checks remain in their original order.
- Existing hex-colour normalisation and validation, update, `list_updated` event payload and response shape are unchanged.

## Verification
- `bunx eslint server/extensions/list/api/color.ts` — pass, 0 findings
- `bun run typecheck` — existing repository failures (exit 2); no changed-file diagnostic
- `bun test` — existing baseline failure (exit 1): 1,117 passed, 3 skipped, 180 failed, 30 errors
- `bun run build:client` — pass
- `git diff --check` — pass

## Coverage note
No executable test currently targets `PATCH /api/v1/lists/:id/color`; this PR does not claim handler-level coverage. No UI code changed, so UI/E2E coverage does not apply.