### PR TITLE
fix(list): type list read handler boundary

### DIFF
--- a/server/extensions/list/api/list.ts
+++ b/server/extensions/list/api/list.ts
@@ -3,17 +3,28 @@ import { db } from '../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../auth/middlewares/authentication';
 import {
   requireWorkspaceMembership,
-  requireRole,
   type WorkspaceScopedRequest,
 } from '../../../middlewares/permissionManager';
 import { resolveBoardId } from '../../../common/ids/resolveEntityId';
+
+type BoardRow = {
+  id: string;
+  workspace_id: string;
+};
+
+type ListRow = {
+  id: string;
+  board_id: string;
+  archived: boolean;
+  position: string;
+};
 
 export async function handleListLists(req: Request, boardId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
   const resolvedBoardId = await resolveBoardId(boardId);
-  const board = resolvedBoardId ? await db('boards').where({ id: resolvedBoardId }).first() : null;
+  const board = resolvedBoardId ? await db<BoardRow>('boards').where({ id: resolvedBoardId }).first() : null;
   if (!board) {
     return Response.json(
       { error: { code: 'board-not-found', message: 'Board not found' } },
@@ -25,7 +36,7 @@ export async function handleListLists(req: Request, boardId: string): Promise<Re
   const membershipError = await requireWorkspaceMembership(scopedReq, board.workspace_id);
   if (membershipError) return membershipError;
 
-  const lists = await db('lists')
+  const lists = await db<ListRow>('lists')
     .where({ board_id: board.id, archived: false })
     .orderBy('position', 'asc');
 


### PR DESCRIPTION
## Scope
Type the board-list read handler’s board/list query boundaries and remove its unused role import.

## Behaviour preserved
- Authentication, board resolution, workspace membership check, active-list filter, ordering and `{ data: lists }` response shape remain unchanged.

## Verification
- `bunx eslint server/extensions/list/api/list.ts` — pass, 0 findings
- `bun test tests/integration/list/listCRUD.test.ts` — 29 passed
- `bun run typecheck` — existing repository failures (exit 2); no changed-file diagnostic
- `bun test` — existing baseline failure (exit 1): 1,117 passed, 3 skipped, 180 failed, 30 errors
- `bun run build:client` — pass
- `git diff --check` — pass

No UI code changed.