### PR TITLE
fix(list): type sort handler boundary

### DIFF
--- a/server/extensions/list/api/sort.ts
+++ b/server/extensions/list/api/sort.ts
@@ -25,6 +25,11 @@ type CardRow = {
   archived: boolean;
 };
 
+type ListRow = {
+  id: string;
+  board_id: string;
+};
+
 function toTime(value: string | null | undefined, fallback: number): number {
   if (!value) return fallback;
   const parsed = Date.parse(value);
@@ -65,7 +70,7 @@ export async function handleSortListCards(req: Request, listId: string): Promise
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const list = await db('lists').where({ id: listId }).first();
+  const list = await db<ListRow>('lists').where({ id: listId }).first();
   if (!list) {
     return Response.json(
       { error: { code: 'list-not-found', message: 'List not found' } },
@@ -77,7 +82,7 @@ export async function handleSortListCards(req: Request, listId: string): Promise
   const writableError = await requireBoardWritable(boardReq, list.board_id);
   if (writableError) return writableError;
 
-  const board = boardReq.board!;
+  const board = boardReq.board as NonNullable<BoardScopedRequest['board']>;
 
   const scopedReq = req as WorkspaceScopedRequest;
   const membershipError = await requireWorkspaceMembership(scopedReq, board.workspace_id);
@@ -111,14 +116,15 @@ export async function handleSortListCards(req: Request, listId: string): Promise
     return Response.json({ data: cards.map((card) => ({ id: card.id, list_id: card.list_id, position: card.position })) });
   }
 
-  const sortedCards = [...cards].sort((left, right) => compareCards(body.sortBy as SortBy, left, right));
+  const sortBy = body.sortBy;
+  const sortedCards = [...cards].sort((left, right) => compareCards(sortBy, left, right));
   const positions = generatePositions(sortedCards.length);
   const now = new Date().toISOString();
 
   await db.transaction(async (trx) => {
     for (let i = 0; i < sortedCards.length; i += 1) {
       await trx('cards')
-        .where({ id: sortedCards[i]!.id })
+        .where({ id: sortedCards[i]?.id })
         .update({ position: positions[i], updated_at: now });
     }
   });
@@ -126,7 +132,7 @@ export async function handleSortListCards(req: Request, listId: string): Promise
   const payloadCards = sortedCards.map((card, index) => ({
     id: card.id,
     list_id: card.list_id,
-    position: positions[index]!,
+    position: positions[index],
   }));
 
   await writeEvent({


### PR DESCRIPTION
## Scope
Type the list card-sort handler’s list boundary and remove unnecessary assertions after existing input validation.

## Behaviour preserved
Authentication, board writability, workspace membership and `MEMBER` checks, all sort criteria including `card-price`, card ordering, transactional position writes, realtime event payload and response shape remain unchanged.

## Verification
- Focused ESLint: 0 findings
- `bun test tests/integration/list/listCRUD.test.ts`: 29 passed
- `bun run typecheck`: existing exit 2; no touched-file diagnostic
- `bun test`: existing exit 1 — 1,117 pass, 3 skip, 180 fail, 30 errors
- `bun run build:client`: pass
- `git diff --check`: pass

No UI code changed.