### PR TITLE
fix(label): type list handler workspace boundary

### DIFF
--- a/server/extensions/label/api/list.ts
+++ b/server/extensions/label/api/list.ts
@@ -6,11 +6,13 @@ import {
   type WorkspaceScopedRequest,
 } from '../../../middlewares/permissionManager';
 
+type WorkspaceRow = { id: string };
+
 export async function handleListLabels(req: Request, workspaceId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const workspace = await db('workspaces').where({ id: workspaceId }).first();
+  const workspace = await db<WorkspaceRow>('workspaces').where({ id: workspaceId }).first();
   if (!workspace) {
     return Response.json(
       { error: { code: 'workspace-not-found', message: 'Workspace not found' } },


### PR DESCRIPTION
## Scope
Type the workspace-existence lookup in the label-list endpoint.

## Behaviour preserved
Authentication, workspace-not-found response, workspace membership check, board-scoped label join/filter/order, and `{ data: labels }` response are unchanged.

## Verification
- Focused ESLint: 0 findings
- `bun test tests/integration/cardExtendedFields.test.ts`: 15 passed
- `bun run typecheck`: existing exit 2; no touched-file diagnostic
- `bun test`: existing exit 1 — 1,117 pass, 3 skip, 180 fail, 30 errors
- `bun run build:client`: pass
- `git diff --check`: pass

No UI code changed.