### PR TITLE
fix(label): type update handler boundaries

### DIFF
--- a/server/extensions/label/api/update.ts
+++ b/server/extensions/label/api/update.ts
@@ -7,11 +7,14 @@ import {
   type WorkspaceScopedRequest,
 } from '../../../middlewares/permissionManager';
 
+type LabelRow = { id: string; board_id: string; name: string; color: string };
+type BoardRow = { id: string; workspace_id: string };
+
 export async function handleUpdateLabel(req: Request, labelId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const label = await db('labels').where({ id: labelId }).first();
+  const label = await db<LabelRow>('labels').where({ id: labelId }).first();
   if (!label) {
     return Response.json(
       { error: { code: 'label-not-found', message: 'Label not found' } },
@@ -21,7 +24,7 @@ export async function handleUpdateLabel(req: Request, labelId: string): Promise<
 
   const scopedReq = req as WorkspaceScopedRequest;
   // [why] Labels are now board-scoped; derive workspace_id via the board for permission check.
-  const board = await db('boards').where({ id: label.board_id }).first();
+  const board = await db<BoardRow>('boards').where({ id: label.board_id }).first();
   if (!board) {
     return Response.json(
       { error: { code: 'board-not-found', message: 'Board not found' } },
@@ -70,6 +73,6 @@ export async function handleUpdateLabel(req: Request, labelId: string): Promise<
     await db('labels').where({ id: labelId }).update(updates);
   }
 
-  const updated = await db('labels').where({ id: labelId }).first();
+  const updated = await db<LabelRow>('labels').where({ id: labelId }).first();
   return Response.json({ data: updated });
 }


### PR DESCRIPTION
## Scope
Type the label, board and persisted-label query boundaries in the label-update handler.

## Behaviour preserved
Authentication, workspace membership and `ADMIN` enforcement, board-derived workspace guard, validation, partial update semantics, response and error shapes are unchanged.

## Verification
- Focused ESLint: 0 findings
- `bun test tests/integration/cardExtendedFields.test.ts`: 15 passed
- `bun run typecheck`: existing exit 2; no touched-file diagnostic
- `bun test`: existing exit 1 — 1,117 pass, 3 skip, 180 fail, 30 errors
- `bun run build:client`: pass
- `git diff --check`: pass

No UI code changed.