### PR TITLE
fix(workspace): type invite membership lookup

### DIFF
--- a/server/extensions/workspace/mods/invite/consume.ts
+++ b/server/extensions/workspace/mods/invite/consume.ts
@@ -19,7 +19,7 @@ export async function consumeInvite({ invite, userId }: ConsumeInviteParams): Pr
     // Upsert membership — idempotent if user somehow already a member.
     const existing = await trx('memberships')
       .where({ user_id: userId, workspace_id: invite.workspace_id })
-      .first();
+      .first<{ user_id: string } | undefined>();
 
     if (!existing) {
       await trx('memberships').insert({


### PR DESCRIPTION
## Scope
Type the optional existing-membership lookup in invite consumption.

## Behaviour preserved
Invite acceptance timestamp, idempotent membership insertion, transaction boundary and cache eviction are unchanged.

## Verification
- Focused ESLint: 0 findings
- `bun test tests/integration/trelloCompat/organizations.test.ts`: 6 passed
- `bun run typecheck`: existing exit 2; no touched-file diagnostic
- `bun test`: existing exit 1 — 1,117 pass, 3 skip, 180 fail, 30 errors
- `bun run build:client`: pass
- `git diff --check`: pass

No UI code changed.