### PR TITLE
fix(workspace): type invite validation lookup

### DIFF
--- a/server/extensions/workspace/mods/invite/validate.ts
+++ b/server/extensions/workspace/mods/invite/validate.ts
@@ -1,8 +1,6 @@
-// Encapsulates invite validation: check cache first, fall back to DB.
+// Encapsulates invite validation against the authoritative database record.
 // Returns the invite record or an error descriptor.
 import { db } from '../../../../common/db';
-import { memCache } from '../../../../mods/cache/index';
-import { inviteConfig } from '../../common/config/invite';
 
 export type InviteRecord = {
   id: string;
@@ -18,11 +16,8 @@ export type ValidateInviteResult =
   | { ok: false; reason: 'not-found' | 'invite-expired' | 'invite-already-used' };
 
 export async function validateInvite({ token }: { token: string }): Promise<ValidateInviteResult> {
-  // Fast path — cache miss falls through to DB.
-  const cached = memCache.get(`${inviteConfig.cacheKeyPrefix}${token}`);
-
   // DB is authoritative for accepted_at and final expiry.
-  const invite: InviteRecord | undefined = await db('invites').where({ token }).first();
+  const invite = await db('invites').where({ token }).first<InviteRecord | undefined>();
 
   if (!invite) {
     return { ok: false, reason: 'not-found' };


### PR DESCRIPTION
## Scope
Type invite validation’s authoritative DB lookup and remove the existing no-op cache read with its stale comment/imports.

## Behaviour preserved
Validation still reads the database, returning the same not-found, expired, already-used, or valid invite results. The removed cache value was never inspected or returned.

## Verification
- Focused ESLint: 0 findings
- `bun test tests/integration/trelloCompat/organizations.test.ts`: 6 passed
- `bun run typecheck`: existing exit 2; no touched-file diagnostic
- `bun test`: existing exit 1 — 1,117 pass, 3 skip, 180 fail, 30 errors
- `bun run build:client`: pass
- `git diff --check`: pass

No UI code changed.