### PR TITLE
fix(activity): mark webhook dispatch as intentional async

### DIFF
--- a/server/extensions/activity/mods/createActivityEvent.ts
+++ b/server/extensions/activity/mods/createActivityEvent.ts
@@ -28,7 +28,7 @@ async function fireCardMemberWebhook({
   if (!env.WEBHOOKS_ENABLED) return;
   const webhooks = await getActiveWebhooksForEvent({ knex: db, eventType });
   for (const wh of webhooks) {
-    dispatchWebhook({
+    void dispatchWebhook({
       endpoint: wh.endpoint_url,
       signingSecret: wh.signing_secret,
       eventType,


### PR DESCRIPTION
## Scope
Explicitly mark member-webhook delivery as intentional fire-and-forget work.

## Behaviour preserved
Webhook delivery remains non-blocking: activity/event callers do not await it, and webhook dispatch payload/selection are unchanged.

## Verification
- Focused ESLint: 0 findings
- `bun test server/extensions/activity/mods/__tests__/createActivityEvent.test.ts`: 4 passed
- `bun run typecheck`: existing exit 2; no touched-file diagnostic
- `bun test`: existing exit 1 — 1,117 pass, 3 skip, 180 fail, 30 errors
- `bun run build:client`: pass
- `git diff --check`: pass

No UI code changed.