### PR TITLE
fix(activity): type persisted activity rows

### DIFF
--- a/server/extensions/activity/mods/write.ts
+++ b/server/extensions/activity/mods/write.ts
@@ -29,7 +29,7 @@ export interface WrittenActivity {
 
 export async function writeActivity(input: WriteActivityInput): Promise<WrittenActivity> {
   const id = randomUUID();
-  const [activity] = await db('activities').insert({
+  const activities = await db('activities').insert({
     id,
     entity_type: input.entityType,
     entity_id: input.entityId,
@@ -40,7 +40,8 @@ export async function writeActivity(input: WriteActivityInput): Promise<WrittenA
     ip_address: input.ipAddress ?? null,
     user_agent: input.userAgent ?? null,
     created_at: new Date().toISOString(),
-  }, ['*']);
+  }, ['*']) as WrittenActivity[];
+  const activity = activities[0];
 
   return activity as WrittenActivity;
 }


### PR DESCRIPTION
## Scope
Type the returned activity rows from the append-only activity insert.

## Behaviour preserved
Insert fields, append-only semantics, returned record shape, and callers are unchanged.

## Verification
- Focused ESLint: 0 findings
- `bun test tests/integration/commentsActivity.test.ts`: 16 passed
- `bun run typecheck`: existing exit 2; no touched-file diagnostic
- `bun test`: existing exit 1 — 1,117 pass, 3 skip, 180 fail, 30 errors
- `bun run build:client`: pass
- `git diff --check`: pass

No UI code changed.