### PR TITLE
fix(ids): type short-id uniqueness lookup

### DIFF
--- a/server/common/ids/shortId.ts
+++ b/server/common/ids/shortId.ts
@@ -8,7 +8,9 @@ export function generateShortId(length = SHORT_ID_LENGTH): string {
   const bytes = randomBytes(length);
   let out = '';
   for (let i = 0; i < length; i += 1) {
-    out += SHORT_ID_ALPHABET[bytes[i] % SHORT_ID_ALPHABET.length];
+    const byte = bytes[i];
+    if (byte === undefined) throw new Error('short-id-random-byte-missing');
+    out += SHORT_ID_ALPHABET.charAt(byte % SHORT_ID_ALPHABET.length);
   }
   return out;
 }
@@ -18,7 +20,7 @@ export async function generateUniqueShortId(
 ): Promise<string> {
   for (let attempt = 0; attempt < 20; attempt += 1) {
     const shortId = generateShortId();
-    const existing = await db(tableName).where({ short_id: shortId }).first();
+    const existing = await db(tableName).where({ short_id: shortId }).first<{ short_id: string } | undefined>();
     if (!existing) return shortId;
   }
   throw new Error(`failed-to-generate-unique-short-id:${tableName}`);


### PR DESCRIPTION
## Scope
Type the optional short-ID uniqueness lookup and make the generated alphabet character explicitly total.

## Behaviour preserved
Short IDs remain eight random base-62 characters by default; uniqueness still retries up to 20 times against the same tables and throws the same exhaustion error.

## Verification
- Focused ESLint: 0 findings
- `bun test tests/integration/trelloCompat/boards.test.ts tests/integration/trelloCompat/lists.test.ts`: 20 passed
- `bun run typecheck`: existing exit 2; no touched-file diagnostic
- `bun test`: existing exit 1 — 1,117 pass, 3 skip, 180 fail, 30 errors
- `bun run build:client`: pass
- `git diff --check`: pass

No UI code changed.