### PR TITLE
fix(crypto): type decrypt output as UTF-8 string

### DIFF
--- a/server/common/crypto.ts
+++ b/server/common/crypto.ts
@@ -51,5 +51,5 @@ export function decryptSecret({ ciphertext, hexKey }: { ciphertext: string; hexK
   const encrypted = buf.subarray(IV_BYTE_LEN, buf.length - TAG_BYTE_LEN);
   const decipher = createDecipheriv(ALGORITHM, key, iv);
   decipher.setAuthTag(tag);
-  return decipher.update(encrypted) + decipher.final('utf8');
+  return decipher.update(encrypted).toString('utf8') + decipher.final('utf8');
 }

--- a/tests/unit/server/common/crypto.test.ts
+++ b/tests/unit/server/common/crypto.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+import { decryptSecret, encryptSecret } from '../../../../server/common/crypto';
+
+const hexKey = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+describe('secret encryption', () => {
+  it('round-trips UTF-8 plaintext', () => {
+    const plaintext = 'Webhook secret: café 🔐';
+
+    expect(decryptSecret({ ciphertext: encryptSecret({ plaintext, hexKey }), hexKey })).toBe(plaintext);
+  });
+
+  it('rejects ciphertext modified after encryption', () => {
+    const ciphertext = encryptSecret({ plaintext: 'secret', hexKey });
+    const bytes = Buffer.from(ciphertext, 'base64');
+    const firstCiphertextByte = 12;
+    bytes[firstCiphertextByte] = (bytes[firstCiphertextByte] ?? 0) ^ 1;
+
+    expect(() => decryptSecret({ ciphertext: bytes.toString('base64'), hexKey })).toThrow();
+  });
+});


### PR DESCRIPTION
## Scope
Explicitly decode the streamed AES-GCM plaintext bytes as UTF-8 before concatenating the final string, and add focused cryptographic contract coverage.

## Behaviour preserved
Cipher format, key validation, AES-256-GCM configuration, encryption, authentication-tag verification, returned plaintext and tamper rejection are unchanged.

## Verification
- Focused ESLint: 0 findings
- `bun test tests/unit/server/common/crypto.test.ts`: 2 passed (UTF-8 round trip and ciphertext tamper rejection)
- `bun run typecheck`: existing exit 2; no touched-file diagnostic
- `bun test`: existing exit 1 — 1,119 pass, 3 skip, 180 fail, 30 errors; two additional passing focused tests
- `bun run build:client`: pass
- `git diff --check`: pass

No UI code changed.