### PR TITLE
fix(cards): narrow resolved cover guard

### DIFF
--- a/server/common/cards/cover.ts
+++ b/server/common/cards/cover.ts
@@ -46,7 +46,7 @@ export async function resolveCoverImageUrls<T extends CardCoverFields>(cards: T[
       if (!attachmentId) return { ...card, cover_image_url: null, cover_aspect_ratio: null, cover_is_gif: false };
 
       const attachment = attachmentById.get(attachmentId);
-      if (attachment?.card_id !== card.id || attachment?.status !== 'READY') {
+      if (attachment?.card_id !== card.id || attachment.status !== 'READY') {
         return { ...card, cover_image_url: null, cover_aspect_ratio: null, cover_is_gif: false };
       }
 


### PR DESCRIPTION
## Scope
Remove a redundant optional chain after the existing attachment lookup guard in card-cover resolution.

## Behaviour preserved
Missing, mismatched, non-ready and keyless attachments still resolve to no cover; valid ready attachments retain the same proxy URL, GIF handling and aspect-ratio logic.

## Verification
- Focused ESLint: 0 findings
- No executable direct test for `resolveCoverImageUrls` exists; no UI code changed
- `bun run typecheck`: existing exit 2; no touched-file diagnostic
- `bun test`: existing exit 1 — 1,119 pass, 3 skip, 180 fail, 30 errors
- `bun run build:client`: pass
- `git diff --check`: pass
