### PR TITLE
fix(ids): type entity ID lookup boundary

### DIFF
--- a/server/common/ids/resolveEntityId.ts
+++ b/server/common/ids/resolveEntityId.ts
@@ -4,13 +4,13 @@ async function resolveEntityId(
   tableName: 'boards' | 'cards' | 'lists' | 'comments' | 'attachments',
   identifier: string,
 ): Promise<string | null> {
-  const row = await db(tableName)
+  const row = await db<{ id: string }>(tableName)
     .where('id', identifier)
     .orWhere('short_id', identifier)
     .select('id')
-    .first();
+    .first<{ id: string } | undefined>();
 
-  return (row?.id as string | undefined) ?? null;
+  return row?.id ?? null;
 }
 
 export async function resolveBoardId(identifier: string): Promise<string | null> {


### PR DESCRIPTION
## Scope
Type the shared entity-ID lookup row and remove its assertion.

## Behaviour preserved
Board, card, list, comment and attachment resolution still checks canonical ID or short ID and returns either the canonical ID or `null`.

## Verification
- Focused ESLint: 0 findings
- `bun test tests/integration/trelloCompat/actions.test.ts tests/integration/trelloCompat/boards.test.ts tests/integration/trelloCompat/lists.test.ts`: 26 passed
- `bun run typecheck`: existing exit 2; no touched-file diagnostic
- `bun test`: existing exit 1 — 1,119 pass, 3 skip, 180 fail, 30 errors
- `bun run build:client`: pass
- `git diff --check`: pass

No UI code changed.