### PR TITLE
fix(mentions): type board scope lookup

### DIFF
--- a/server/common/mentions/resolve.ts
+++ b/server/common/mentions/resolve.ts
@@ -14,6 +14,11 @@ interface User {
   avatar_url: string | null;
 }
 
+interface BoardMentionScope {
+  workspace_id: string;
+  visibility: string;
+}
+
 export async function resolveNicknames({
   nicknames,
   boardId,
@@ -26,7 +31,7 @@ export async function resolveNicknames({
   const board = await db('boards')
     .where({ id: boardId })
     .select('workspace_id', 'visibility')
-    .first();
+    .first<BoardMentionScope | undefined>();
 
   if (!board) return [];
 


### PR DESCRIPTION
## Scope
Type the board workspace/visibility lookup used to scope @mention resolution.

## Behaviour preserved
Missing boards still return no users. Private boards remain restricted to board members/guests; workspace/public boards remain restricted to non-guest workspace members plus board guests; nickname and UUID-token matching are unchanged.

## Verification
- Focused ESLint: 0 findings
- No executable direct test for `resolveNicknames` exists; no UI code changed
- `bun run typecheck`: existing exit 2; no touched-file diagnostic
- `bun test`: existing exit 1 — 1,119 pass, 3 skip, 180 fail, 30 errors
- `bun run build:client`: pass
- `git diff --check`: pass
