### PR TITLE
chore(lint): remove unused mentions sync database import

### DIFF
--- a/server/common/mentions/sync.ts
+++ b/server/common/mentions/sync.ts
@@ -1,6 +1,5 @@
 // Syncs the mentions table for a given source (card_description or comment).
 // Diffs old vs new mentions and returns newly added user IDs (for notification dispatch).
-import { db } from '../db';
 import { extractMentions } from './parse';
 import { resolveNicknames } from './resolve';
 import type { Knex } from 'knex';


### PR DESCRIPTION
## Scope
Remove the unused `db` import from `server/common/mentions/sync.ts` (one line, one server file). No function bodies, queries, contracts, dependencies, payment code, deployment configuration, or stable branch changes.

`resolveNicknames` still imports the same shared DB module, so initialization remains reachable; the other dependency, `parse.ts`, has no initialization side effects beyond its regex constant. Bun transpilation confirms only the unused import disappears, not byte-identical output.

Base: `78cf4d302ac8f2934e47b417214f0c2dfa92f13b` (fresh origin/main fetch, ff-only).

## Verification
- Focused ESLint: **0 errors / 0 warnings**, down from one unused-import error.
- Full lint: **2573 errors / 3 warnings**, down from freshly measured **2574 / 3**.
- Related mention webhook helper tests: **12 pass / 0 fail**, both base and head. These do not execute syncMentions and are NOT direct coverage.
- Additional temporary direct smoke: actual syncMentions, parser and resolver with a fake transaction; empty-mention input deletes existing mentions, returns no added IDs, and performs no insert. Passed. No module mocks.
- `bun run typecheck`: exit 2 on both base/head, **148 diagnostics; logs byte-identical**.
- `bun test`: exit 1 on both, **1119 pass / 3 skip / 180 fail / 30 errors**. Compared failing test identities (timing stripped) and error-message multisets: identical, no new or removed failures/errors. Existing issues include Playwright tests collected by Bun, missing DOM, and incomplete DB mocks.
- `bun run build:client`: exit 0; existing large-chunk warning.
- `git diff --check`: exit 0.

## Coverage limitations
No committed direct syncMentions test was found. Temporary smoke covers only the empty-mention path using fake transaction operations, not real PostgreSQL, nonempty resolution, inserts, notification dispatch or rollback. No behavior/public contract change is intended; no permanent tests added for this one-line import cleanup.

Full logs on implementation host: `/tmp/chimedeck-mentions-sync/` (`base-typecheck.log`, `head-typecheck.log`, `base-test.log`, `head-test.log`, `baseline-comparison.json`, `base-lint.log`, `head-lint.log`, `base-focused-lint.log`, `head-focused-lint.log`, `base-focused-test.log`, `head-focused-test.log`, `head-build-client.log`, `head-diff-check.log`, `direct-smoke.ts`, `direct-smoke.log`, `base-sync.js`, `head-sync.js`).

Independent review required. This implementation has not approved or merged the PR.
