### PR TITLE
chore(lint): remove unused board background TTL constant

### DIFF
--- a/server/extensions/board/common/resolveBackgroundUrl.ts
+++ b/server/extensions/board/common/resolveBackgroundUrl.ts
@@ -1,8 +1,6 @@
 // Returns a stable proxy path for a board background, or the raw value for non-S3 backgrounds.
 import { s3Config } from '../../attachment/common/config/s3';
 
-const BACKGROUND_URL_TTL_SECONDS = 15 * 60; // 15 minutes — kept for reference, no longer used here
-
 export function extractS3KeyFromBackgroundUrl(url: string): string | null {
   try {
     const parsed = new URL(url);


### PR DESCRIPTION
## Scope
Remove the unused `BACKGROUND_URL_TTL_SECONDS` constant and its stale reference comment from `server/extensions/board/common/resolveBackgroundUrl.ts` (two deleted lines). No imports, executable function bodies, authorization, response contracts, payment code, UI, configuration, or deployment changes.

Base: `dea5f121363a7beed7f823504a9ffd8ccb4da2f9`, freshly fetched and fast-forward checked with a clean worktree.

## Verification
- Focused ESLint: base 1 unused-variable error; head 0 errors / 0 warnings, exit 0.
- Full ESLint: 2573 → 2572 errors; 3 warnings unchanged (exit 1, existing debt).
- Direct executable smoke: 10 passing tests / 17 assertions before and after. Imports the real module and real S3 config, with no mocks; covers null/undefined/empty backgrounds, colors/external/invalid URLs, path-style and both virtual-host S3 formats, percent decoding, malformed encoding, and stable proxy paths.
- `bun run typecheck`: exit 2 on both; identical 148 diagnostic identities.
- `bun test`: exit 1 on both; 1119 pass / 3 skip / 180 fail / 30 errors. File-qualified comparison finds identical 150 named failures and 30 unhandled errors (the latter contribute to Bun's fail total); no added or removed failure/error identities. Repeated summary lines excluded.
- `bun run build:client`: exit 0; existing large-chunk warning.
- `git diff --check`: exit 0.

## Coverage limitations
The focused smoke is an ad hoc `/tmp` harness, not a committed regression suite: no behavior changed and the removed constant is a pure unused numeric initializer. This directly exercises the resolver, not live S3, background proxy HTTP authorization, database integration, or UI/E2E. No UI files changed. Broad typecheck and tests remain red on verified pre-existing identities, not claimed green.

## Evidence
Local logs and executable comparison/harness: `/tmp/chimedeck-lint-slice-_4rtgxv1/`
- `base-{typecheck,test,lint,focused-lint,focused-test}.log`
- `head-{typecheck,test,lint,focused-lint,focused-test,build-client}.log`
- `identity-comparison.json`, `base-identities.json`, `head-identities.json`, `compare.py`, `background.test.ts`, `diff-check.log`

Authored as `matthewvryanjh`. Independent parent review required; this implementation agent will not approve or merge.
