### PR TITLE
fix(activity): type realtime actor display query

### DIFF
--- a/server/extensions/activity/events/publishCardActivityEvent.ts
+++ b/server/extensions/activity/events/publishCardActivityEvent.ts
@@ -12,6 +12,13 @@ import { publisher } from '../../../mods/pubsub/publisher';
 import { buildAvatarProxyUrlsInCollection } from '../../../common/avatar/resolveAvatarUrl';
 import type { WrittenActivity } from '../mods/write';
 
+type ActivityActorRow = {
+  id: string;
+  name: string;
+  email: string;
+  avatar_url: string | null;
+};
+
 export interface PublishCardActivityEventInput {
   activity: WrittenActivity;
   boardId: string;
@@ -22,7 +29,7 @@ export async function publishCardActivityEvent({
   boardId,
 }: PublishCardActivityEventInput): Promise<void> {
   // Resolve actor display info so clients can render the row without a follow-up request.
-  const rawActors = await db('users')
+  const rawActors = await db<ActivityActorRow>('users')
     .where({ id: activity.actor_id })
     .select('id', 'name', 'email', 'avatar_url');
   const actors = buildAvatarProxyUrlsInCollection(rawActors);


### PR DESCRIPTION
## Scope
- Type the four-column `users` projection in `publishCardActivityEvent` with a local `ActivityActorRow` and Knex generic.
- Remove seven unsafe assignment/member-access findings; the row shape matches `db/migrations/0002_auth.ts` (nullable avatar, non-null ID/name/email).
- No runtime branches, query shape, actor lookup, board audience, event payload, failure handling, auth, API, payment, configuration, or dependency changes.
- Base: `16dfec5a6fc3199a52209215518238b43e4da44f` (current fetched `origin/main`, PR #220).

## Verification
Local evidence directory: `/tmp/chimedeck-lint-slice-gcxo4p00/` (local paths, not hosted artifacts).

| Gate | Actual result | Log |
| --- | --- | --- |
| Focused ESLint | Base: seven errors; head: zero errors/warnings | `base-focused-eslint.log`, `head-focused-eslint.log` |
| Full ESLint | 2565 errors, 3 warnings; seven fewer errors than post-#220 inventory | `head-full-eslint.log` |
| Runtime erasure | Base/head Bun-transpiled JavaScript byte-identical | `base-emitted.js`, `head-emitted.js`, `emitted-comparison.log` |
| Direct isolated smoke | 4 pass, 0 fail | `direct-smoke.log`, `publishCardActivityEvent.test.ts` |
| Adjacent activity fan-out tests | 4 pass, 0 fail | `adjacent-tests.log` |
| Typecheck | Both exit 2; all 148 diagnostics byte-identical | `base-typecheck.log`, `head-typecheck.log` |
| Full `bun test` | Both exit 1; 1119 pass, 3 skip, 180 fail, 30 errors | `base-test.log`, `head-test.log` |
| Failure identity comparison | Same 150 file-qualified failing-test identities and 30 file-qualified unhandled-error messages, including multiplicity; no added/removed identities. Bun's 180 fail includes those 30 errors. | `compare.py`, `comparison.json`, `base-failing_tests.json`, `head-failing_tests.json`, `base-unhandled_errors.json`, `head-unhandled_errors.json` |
| Client build | Exit 0 | `head-build-client.log` |
| Diff whitespace | Exit 0 | `diff-check.log` |

Commands executed: `bunx eslint server/extensions/activity/events/publishCardActivityEvent.ts`, `bun run lint`, `bun run typecheck`, `bun test`, `bun run build:client`, `git diff --check`, `bun test server/extensions/activity/mods/__tests__/createActivityEvent.test.ts`, and `bun test /tmp/chimedeck-lint-slice-gcxo4p00/publishCardActivityEvent.test.ts`.

## Coverage limits
- Direct smoke imports the real changed publisher function and real avatar proxy mapper; DB and publisher transports are mocked, as is unused S3 configuration. It checks exact selected columns/filter, room and event shape, avatar proxying, missing actor/null avatar, and swallowed publisher rejection. This is a local isolated smoke artifact, **not a new committed regression suite**.
- Existing fan-out tests mock `publishCardActivityEvent`, so they are **adjacent**, not direct coverage.
- This type-only slice changes no runtime behavior; emitted-code equality is the primary preservation check. No live DB/pubsub integration or browser/E2E run is claimed. No UI files changed.
- Repository-wide typecheck/tests/lint remain red on established baseline debt; no newly introduced failures.

Implementation PR only. Independent parent review required. Do not approve or merge as part of this task.
