### PR TITLE
refactor(automation): type move-to-bottom card queries

### DIFF
--- a/server/extensions/automation/engine/actions/card/moveToBottom.ts
+++ b/server/extensions/automation/engine/actions/card/moveToBottom.ts
@@ -2,6 +2,14 @@ import { z } from 'zod';
 import { between, HIGH_SENTINEL } from '../../../../list/mods/fractional';
 import type { ActionHandler, ActionContext } from '../../../common/types';
 
+// Non-null columns from db/migrations/0006_card.ts used by these queries.
+interface CardPositionRow {
+  id: string;
+  list_id: string;
+  position: string;
+  archived: boolean;
+}
+
 const configSchema = z.object({});
 
 export const cardMoveToBottomAction: ActionHandler = {
@@ -13,10 +21,10 @@ export const cardMoveToBottomAction: ActionHandler = {
     const cardId = evalContext.cardId;
     if (!cardId) throw new Error('card-id-missing');
 
-    const card = await trx('cards').where({ id: cardId }).first();
+    const card = await trx<CardPositionRow>('cards').where({ id: cardId }).first();
     if (!card) throw new Error('card-not-found');
 
-    const lastCard = await trx('cards')
+    const lastCard = await trx<CardPositionRow>('cards')
       .where({ list_id: card.list_id, archived: false })
       .whereNot({ id: cardId })
       .orderBy('position', 'desc')

--- a/tests/integration/automation/moveToBottom.test.ts
+++ b/tests/integration/automation/moveToBottom.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'bun:test';
+import type { ActionContext } from '../../../server/extensions/automation/common/types';
+import { cardMoveToBottomAction } from '../../../server/extensions/automation/engine/actions/card/moveToBottom';
+import { between, HIGH_SENTINEL } from '../../../server/extensions/list/mods/fractional';
+
+// Execute the real handler and fractional indexer; only the transaction is a fake.
+function fixture(rows: (Record<string, unknown> | undefined)[], cardId?: string) {
+  const calls: unknown[][] = [];
+  const updates: { position: string; updated_at: string }[] = [];
+  const query = {
+    where(value: Record<string, unknown>) {
+      calls.push(['where', value]);
+      return query;
+    },
+    whereNot(value: Record<string, unknown>) {
+      calls.push(['whereNot', value]);
+      return query;
+    },
+    orderBy(column: string, direction: string) {
+      calls.push(['orderBy', column, direction]);
+      return query;
+    },
+    first() {
+      calls.push(['first']);
+      return Promise.resolve(rows.shift());
+    },
+    update(value: { position: string; updated_at: string }) {
+      calls.push(['update']);
+      updates.push(value);
+      return Promise.resolve(1);
+    },
+  };
+  const trx = (table: string) => {
+    calls.push(['table', table]);
+    return query;
+  };
+  // Only evalContext and trx are consumed by this action.
+  const context = { evalContext: { actorId: 'actor-1', cardId }, trx } as unknown as ActionContext;
+  return { calls, updates, execute: () => cardMoveToBottomAction.execute(context) };
+}
+
+describe('card.move_to_bottom execution', () => {
+  it('rejects a missing card ID without accessing the transaction', async () => {
+    const f = fixture([]);
+    await expect(f.execute()).rejects.toThrow('card-id-missing');
+    expect(f.calls).toEqual([]);
+  });
+
+  it('rejects an absent card without querying peers or writing', async () => {
+    const f = fixture([undefined], 'card-1');
+    await expect(f.execute()).rejects.toThrow('card-not-found');
+    expect(f.calls).toEqual([
+      ['table', 'cards'], ['where', { id: 'card-1' }], ['first'],
+    ]);
+    expect(f.updates).toEqual([]);
+  });
+
+  it('appends after the last active peer in the same list, excluding itself', async () => {
+    const f = fixture([{ list_id: 'list-1' }, { position: 'M' }], 'card-1');
+    await f.execute();
+    expect(f.calls).toEqual([
+      ['table', 'cards'], ['where', { id: 'card-1' }], ['first'],
+      ['table', 'cards'], ['where', { list_id: 'list-1', archived: false }],
+      ['whereNot', { id: 'card-1' }], ['orderBy', 'position', 'desc'], ['first'],
+      ['table', 'cards'], ['where', { id: 'card-1' }], ['update'],
+    ]);
+    expect(f.updates).toHaveLength(1);
+    expect(f.updates[0]?.position).toBe(between('M', HIGH_SENTINEL));
+    expect(f.updates[0]?.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
+  });
+
+  it('uses the low sentinel when there are no other active cards', async () => {
+    const f = fixture([{ list_id: 'list-1' }, undefined], 'card-1');
+    await f.execute();
+    expect(f.updates).toHaveLength(1);
+    expect(f.updates[0]?.position).toBe(between('', HIGH_SENTINEL));
+  });
+});


### PR DESCRIPTION
## Scope
- Type the two card reads in the move-to-bottom automation action with a local Knex row projection; removes six unsafe-type ESLint errors.
- `id`, `list_id`, `position`, and `archived` nullability comes from `db/migrations/0006_card.ts` (primary key / explicit NOT NULL).
- No runtime logic, SQL, authentication, API responses, UI, payments, dependencies, configuration, deployment, or stable-branch changes.

## Behaviour preservation and coverage
- Base and head Bun-transpiled production JavaScript are byte-identical (866 bytes; SHA256 `648e2e17342d68197a0658f648368d6d5d157e71006d7af020b515a0601d5d3f`).
- Added four durable tests executing the real handler and fractional indexer against a fake transaction: missing ID, missing card, same-list/active/self-excluding descending peer lookup and update, and no-peer sentinel fallback.
- These characterization tests pass on both base production and head. The lint acceptance check was red (six errors) before the type edit and is now green. A temporary descending-to-ascending mutation was rejected by the peer-query test (3 pass / 1 fail); restored code passes all four tests.
- Coverage limits: fake transaction, not live PostgreSQL persistence or full automation orchestration/auth. No module mocks replace the handler. No UI changes; UI/E2E not run.

## Fresh verification
Base: `f53c9d37d550f1bcaaa5346c6f38157a7364cf12` (clean current origin/main). Fresh full typecheck/test baseline captured before any edits.

| Gate | Result |
|---|---|
| Focused ESLint, both changed files | PASS: zero errors/warnings |
| Focused executable tests | PASS: 4 tests / 11 assertions |
| `bun run typecheck` | Existing failure: 148 diagnostics; complete base/head output byte-identical |
| `bun test` | Base 1119 pass / 3 skip / 180 fail / 30 errors; head 1123 pass / 3 skip / 180 fail / 30 errors |
| Failure identity comparison | Identical multisets: 150 file-qualified failing test names and 30 file-qualified complete unhandled-error blocks; zero additions/removals. Bun's 180 fail includes the 30 errors. |
| `bun run build:client` | PASS (Browserslist age / chunk-size warnings) |
| `git diff --check` | PASS |
| Full lint | 2559 errors / 3 warnings, down six from post-221 main (2565 / 3) |

Local reproducible evidence directory: `/tmp/chimedeck-lint-222-DrolyN/`.
- `base-typecheck.txt`, `head-typecheck.txt`, `base-test.txt`, `head-test.txt`
- `compare.py`, `comparison.json`, `base-*-identities.json`, `head-*-identities.json`
- `base-focused-lint.txt`, `head-focused-lint.txt`, `base-focused-test.txt`, `head-focused-test.txt`
- `mutation-ascending-test.txt`, `restored-focused-test.txt`
- `compare-emitted.ts`, `base-emitted.js`, `head-emitted.js`, `emitted-comparison.txt`
- `head-build-client.txt`, `head-full-lint.txt`, `head-diff-check.txt`, command `.exit` files

Implementation-only PR; awaiting separate parent review. Do not approve or merge as part of this implementation task.
