### PR TITLE
fix(lint): type automation move-to-top card queries

### DIFF
--- a/server/extensions/automation/engine/actions/card/moveToTop.ts
+++ b/server/extensions/automation/engine/actions/card/moveToTop.ts
@@ -2,6 +2,14 @@ import { z } from 'zod';
 import { between, HIGH_SENTINEL } from '../../../../list/mods/fractional';
 import type { ActionHandler, ActionContext } from '../../../common/types';
 
+// Non-null columns from db/migrations/0006_card.ts used by these queries.
+interface CardPositionRow {
+  id: string;
+  list_id: string;
+  position: string;
+  archived: boolean;
+}
+
 const configSchema = z.object({});
 
 export const cardMoveToTopAction: ActionHandler = {
@@ -13,10 +21,10 @@ export const cardMoveToTopAction: ActionHandler = {
     const cardId = evalContext.cardId;
     if (!cardId) throw new Error('card-id-missing');
 
-    const card = await trx('cards').where({ id: cardId }).first();
+    const card = await trx<CardPositionRow>('cards').where({ id: cardId }).first();
     if (!card) throw new Error('card-not-found');
 
-    const firstCard = await trx('cards')
+    const firstCard = await trx<CardPositionRow>('cards')
       .where({ list_id: card.list_id, archived: false })
       .whereNot({ id: cardId })
       .orderBy('position', 'asc')

--- a/tests/integration/automation/moveToTop.test.ts
+++ b/tests/integration/automation/moveToTop.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'bun:test';
+import type { ActionContext } from '../../../server/extensions/automation/common/types';
+import { cardMoveToTopAction } from '../../../server/extensions/automation/engine/actions/card/moveToTop';
+import { between, HIGH_SENTINEL } from '../../../server/extensions/list/mods/fractional';
+
+// Execute the real handler and fractional indexer; only the transaction is a fake.
+function fixture(rows: (Record<string, unknown> | undefined)[], cardId?: string) {
+  const calls: unknown[][] = [];
+  const updates: { position: string; updated_at: string }[] = [];
+  const query = {
+    where(value: Record<string, unknown>) {
+      calls.push(['where', value]);
+      return query;
+    },
+    whereNot(value: Record<string, unknown>) {
+      calls.push(['whereNot', value]);
+      return query;
+    },
+    orderBy(column: string, direction: string) {
+      calls.push(['orderBy', column, direction]);
+      return query;
+    },
+    first() {
+      calls.push(['first']);
+      return Promise.resolve(rows.shift());
+    },
+    update(value: { position: string; updated_at: string }) {
+      calls.push(['update']);
+      updates.push(value);
+      return Promise.resolve(1);
+    },
+  };
+  const trx = (table: string) => {
+    calls.push(['table', table]);
+    return query;
+  };
+  // Only evalContext and trx are consumed by this action.
+  const context = { evalContext: { actorId: 'actor-1', cardId }, trx } as unknown as ActionContext;
+  return { calls, updates, execute: () => cardMoveToTopAction.execute(context) };
+}
+
+describe('card.move_to_top execution', () => {
+  it('rejects a missing card ID without accessing the transaction', async () => {
+    const f = fixture([]);
+    await expect(f.execute()).rejects.toThrow('card-id-missing');
+    expect(f.calls).toEqual([]);
+  });
+
+  it('rejects an absent card without querying peers or writing', async () => {
+    const f = fixture([undefined], 'card-1');
+    await expect(f.execute()).rejects.toThrow('card-not-found');
+    expect(f.calls).toEqual([
+      ['table', 'cards'], ['where', { id: 'card-1' }], ['first'],
+    ]);
+    expect(f.updates).toEqual([]);
+  });
+
+  it('prepends before the first active peer in the same list, excluding itself', async () => {
+    const f = fixture([{ list_id: 'list-1' }, { position: 'M' }], 'card-1');
+    await f.execute();
+    expect(f.calls).toEqual([
+      ['table', 'cards'], ['where', { id: 'card-1' }], ['first'],
+      ['table', 'cards'], ['where', { list_id: 'list-1', archived: false }],
+      ['whereNot', { id: 'card-1' }], ['orderBy', 'position', 'asc'], ['first'],
+      ['table', 'cards'], ['where', { id: 'card-1' }], ['update'],
+    ]);
+    expect(f.updates).toHaveLength(1);
+    expect(f.updates[0]?.position).toBe(between('', 'M'));
+    expect(f.updates[0]?.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
+  });
+
+  it('uses the high sentinel when there are no other active cards', async () => {
+    const f = fixture([{ list_id: 'list-1' }, undefined], 'card-1');
+    await f.execute();
+    expect(f.updates).toHaveLength(1);
+    expect(f.updates[0]?.position).toBe(between('', HIGH_SENTINEL));
+  });
+});


### PR DESCRIPTION
## Summary
- Type the two card read queries in `card.move_to_top` using the non-null id/list_id/position/archived columns from `db/migrations/0006_card.ts`, including filter/order columns.
- Preserve all runtime queries, guards, fractional positioning, update fields and action contracts. Bun-transpiled BASE/HEAD production JavaScript is byte-identical.
- Add four durable tests executing the real handler and fractional indexer with a fake transaction: missing ID, absent card, first active same-list peer excluding self, and empty-list high-sentinel fallback.

## Verification
Base: `da44e02f20446dbb284633a00b3673e54b09b320`, clean fetched/fast-forward main before edits.
- Focused ESLint: 6 errors → 0; both touched files lint clean.
- Fresh full lint: 2553 errors / 3 warnings (previous main log: 2559 / 3).
- Focused real-handler tests: 8 pass / 0 fail including adjacent move-to-bottom tests. New four tests also passed against BASE; temporary descending-order mutation produced the expected peer-order assertion failure, then was restored.
- `bun run typecheck`: existing failure, 148 diagnostics at BASE and HEAD; complete diagnostic logs byte-identical.
- `bun test`: BASE 1123 pass / 3 skip / 180 fail / 30 errors; HEAD 1127 pass / 3 skip / 180 fail / 30 errors. Compared file-qualified full failure names before Bun's repeated summary and file/message unhandled-error identities: identical multisets (150 named failures + 30 unhandled errors), no additions/removals. All identities have nonempty file and message/name.
- `bun run build:client`: pass, existing large-chunk warning.
- `git diff --check`: pass.

## Coverage limits / boundaries
Fake-transaction tests verify query calls and resulting update values, not live PostgreSQL ordering/transactions or orchestration/auth/pubsub. No UI changed, so UI/E2E not applicable. No payment, billing, monetisation, dependency, configuration, suppression or deployment changes. Broad test/typecheck debt remains; required CI does not replace these local checks. Independent parent review required; do not approve or merge in this implementation context.

## Local evidence
All logs/artifacts under `/tmp/chimedeck-move-top-20260909-135245/`:
`base-typecheck.log`, `head-typecheck.log`, `base-test.log`, `head-test.log`, `comparison.json`, `base-identities.json`, `head-identities.json`, `compare.py`, `base-focused-lint.log`, `head-focused-lint.log`, `head-full-lint.log`, `base-focused-test.log`, `mutation-red.log`, `head-focused-test.log`, `head-build.log`, `erasure.log`, `base-emitted.js`, `head-emitted.js`.
