### PR TITLE
refactor(automation): type add-label existence queries

### DIFF
--- a/server/extensions/automation/engine/actions/card/addLabel.ts
+++ b/server/extensions/automation/engine/actions/card/addLabel.ts
@@ -1,6 +1,16 @@
 import { z } from 'zod';
 import type { ActionHandler, ActionContext } from '../../../common/types';
 
+// Existence-query columns from 0006_card and 0007_card_extended.
+interface EntityIdRow {
+  id: string;
+}
+
+interface CardLabelRow {
+  card_id: string;
+  label_id: string;
+}
+
 const configSchema = z.object({
   labelId: z.string().min(1),
 });
@@ -15,14 +25,14 @@ export const cardAddLabelAction: ActionHandler = {
     const cardId = evalContext.cardId;
     if (!cardId) throw new Error('card-id-missing');
 
-    const card = await trx('cards').where({ id: cardId }).first();
+    const card = await trx<EntityIdRow>('cards').where({ id: cardId }).first();
     if (!card) throw new Error('card-not-found');
 
-    const label = await trx('labels').where({ id: config.labelId }).first();
+    const label = await trx<EntityIdRow>('labels').where({ id: config.labelId }).first();
     if (!label) throw new Error('label-not-found');
 
     // Idempotent: skip if already attached
-    const existing = await trx('card_labels')
+    const existing = await trx<CardLabelRow>('card_labels')
       .where({ card_id: cardId, label_id: config.labelId })
       .first();
     if (!existing) {

--- a/tests/integration/automation/addLabel.test.ts
+++ b/tests/integration/automation/addLabel.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'bun:test';
+import type { ActionContext } from '../../../server/extensions/automation/common/types';
+import { cardAddLabelAction } from '../../../server/extensions/automation/engine/actions/card/addLabel';
+
+// Real handler and Zod validation; only the transaction is faked (no live DB).
+function fixture(rows: (Record<string, unknown> | undefined)[], cardId?: string, labelId: unknown = 'label-1') {
+  const calls: unknown[][] = [];
+  const query = {
+    where(value: Record<string, unknown>) {
+      calls.push(['where', value]);
+      return query;
+    },
+    first() {
+      calls.push(['first']);
+      return Promise.resolve(rows.shift());
+    },
+    insert(value: Record<string, unknown>) {
+      calls.push(['insert', value]);
+      return Promise.resolve([]);
+    },
+  };
+  const trx = (table: string) => {
+    calls.push(['table', table]);
+    return query;
+  };
+  const context = {
+    action: { config: { labelId } }, evalContext: { cardId }, trx,
+  } as unknown as ActionContext;
+  return { calls, execute: () => cardAddLabelAction.execute(context) };
+}
+
+const cardLookup = [['table', 'cards'], ['where', { id: 'card-1' }], ['first']];
+const labelLookup = [['table', 'labels'], ['where', { id: 'label-1' }], ['first']];
+const relationLookup = [
+  ['table', 'card_labels'], ['where', { card_id: 'card-1', label_id: 'label-1' }], ['first'],
+];
+
+describe('card.add_label execution', () => {
+  it('validates config before accessing the transaction', async () => {
+    for (const labelId of ['', 42, null]) {
+      const f = fixture([], 'card-1', labelId);
+      await expect(f.execute()).rejects.toThrow();
+      expect(f.calls).toEqual([]);
+    }
+  });
+
+  it('rejects missing card ID before querying', async () => {
+    const f = fixture([]);
+    await expect(f.execute()).rejects.toThrow('card-id-missing');
+    expect(f.calls).toEqual([]);
+  });
+
+  it('rejects absent card before querying labels', async () => {
+    const f = fixture([undefined], 'card-1');
+    await expect(f.execute()).rejects.toThrow('card-not-found');
+    expect(f.calls).toEqual(cardLookup);
+  });
+
+  it('rejects absent label before querying associations', async () => {
+    const f = fixture([{ id: 'card-1' }, undefined], 'card-1');
+    await expect(f.execute()).rejects.toThrow('label-not-found');
+    expect(f.calls).toEqual([...cardLookup, ...labelLookup]);
+  });
+
+  it('does not insert an existing association', async () => {
+    const f = fixture([{ id: 'card-1' }, { id: 'label-1' }, { card_id: 'card-1', label_id: 'label-1' }], 'card-1');
+    await f.execute();
+    expect(f.calls).toEqual([...cardLookup, ...labelLookup, ...relationLookup]);
+  });
+
+  it('inserts exactly the requested association when absent', async () => {
+    const f = fixture([{ id: 'card-1' }, { id: 'label-1' }, undefined], 'card-1');
+    await f.execute();
+    expect(f.calls).toEqual([
+      ...cardLookup, ...labelLookup, ...relationLookup,
+      ['table', 'card_labels'], ['insert', { card_id: 'card-1', label_id: 'label-1' }],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Type the three existence queries in `card.add_label` using migration-derived ID/relation columns (0006_card, 0007_card_extended).
- Preserve query/filter/insert/error order and all runtime/auth/API contracts; Bun-transpiled BASE/HEAD handler JavaScript is byte-identical.
- Add six durable real-handler tests for config validation, missing card ID/card/label, existing relation, and exact insertion. No payment, UI, config, dependency, deployment, or stable changes.

## Verification
BASE: `eaa90f928eaa419ad3ebb713f9728517d3615403` (fresh clean main, fetch + ff checked).
- Focused ESLint: both touched files zero errors/warnings. Full lint now **2550 errors / 3 warnings**, down three errors from supplied latest main lint.
- New handler tests: **6 pass**, tested against original production implementation before edits and HEAD. Temporary wrong-label association-filter mutation produced RED (restored).
- Automation suite: HEAD **139 pass / 10 fail**; BASE with new tests has identical file-qualified failing-test/unhandled-error identities.
- Fresh full `bun test`: BASE **1127 pass / 3 skip / 180 fail / 30 errors**; HEAD **1133 pass / 3 skip / 180 fail / 30 errors**. Parsed before repeated failure summary: identical **150 file-qualified failing-test identities + 30 file/message-qualified unhandled errors**, no additions/removals.
- Fresh `bun run typecheck`: BASE and HEAD exit 2, identical **148 file/line/column/code/message diagnostic identities**, no additions/removals.
- `bun run build:client`: PASS. `git diff --check`: PASS.
- BASE/HEAD emitted JS: byte-identical.

## Coverage limitations
Tests execute the real handler and Zod validation with a fake transaction. They verify query/guard/write contracts, not live PostgreSQL constraints, concurrency, engine authorization, or live pubsub. No browser/UI changes; no UI/E2E claim. Existing broad test/typecheck failures remain, not green gates.

## Evidence
Local evidence directory: `/tmp/chimedeck-lint-next-pOx15p/`.
`base-typecheck.log`, `head-typecheck.log`, `base-test.log`, `head-test.log`, `comparison.json`, `*-failures.json`, `*-errors.json`, `*-diagnostics.json`, `compare.py`, `focused-base.log`, `focused-action-head.log`, `mutation-red.log`, `focused-automation-base.log`, `focused-head.log`, `focused-comparison.log`, `focused-eslint.log`, `full-lint-head.log`, `build-client.log`, `diff-check.log`, `emitted-comparison.log`, `base-emitted.js`, `head-emitted.js`.

Independent parent review required. Do not approve or merge as part of this implementation task.
