### PR TITLE
refactor(automation): type add-member existence queries

### DIFF
--- a/server/extensions/automation/engine/actions/card/addMember.ts
+++ b/server/extensions/automation/engine/actions/card/addMember.ts
@@ -1,6 +1,16 @@
 import { z } from 'zod';
 import type { ActionHandler, ActionContext } from '../../../common/types';
 
+// Existence-query columns from 0002_auth, 0006_card and 0007_card_extended.
+interface EntityIdRow {
+  id: string;
+}
+
+interface CardMemberRow {
+  card_id: string;
+  user_id: string;
+}
+
 const configSchema = z.object({
   memberId: z.string().min(1),
 });
@@ -15,14 +25,14 @@ export const cardAddMemberAction: ActionHandler = {
     const cardId = evalContext.cardId;
     if (!cardId) throw new Error('card-id-missing');
 
-    const card = await trx('cards').where({ id: cardId }).first();
+    const card = await trx<EntityIdRow>('cards').where({ id: cardId }).first();
     if (!card) throw new Error('card-not-found');
 
-    const user = await trx('users').where({ id: config.memberId }).first();
+    const user = await trx<EntityIdRow>('users').where({ id: config.memberId }).first();
     if (!user) throw new Error('member-not-found');
 
     // Idempotent: skip if already assigned
-    const existing = await trx('card_members')
+    const existing = await trx<CardMemberRow>('card_members')
       .where({ card_id: cardId, user_id: config.memberId })
       .first();
     if (!existing) {

--- a/tests/integration/automation/addMember.test.ts
+++ b/tests/integration/automation/addMember.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'bun:test';
+import type { ActionContext } from '../../../server/extensions/automation/common/types';
+import { cardAddMemberAction } from '../../../server/extensions/automation/engine/actions/card/addMember';
+
+// Real handler and Zod validation; only the transaction is faked (no live DB).
+function fixture(rows: (Record<string, unknown> | undefined)[], cardId?: string, memberId: unknown = 'member-1') {
+  const calls: unknown[][] = [];
+  const query = {
+    where(value: Record<string, unknown>) {
+      calls.push(['where', value]);
+      return query;
+    },
+    first() {
+      calls.push(['first']);
+      return Promise.resolve(rows.shift());
+    },
+    insert(value: Record<string, unknown>) {
+      calls.push(['insert', value]);
+      return Promise.resolve([]);
+    },
+  };
+  const trx = (table: string) => {
+    calls.push(['table', table]);
+    return query;
+  };
+  const context = {
+    action: { config: { memberId } }, evalContext: { cardId }, trx,
+  } as unknown as ActionContext;
+  return { calls, execute: () => cardAddMemberAction.execute(context) };
+}
+
+const cardLookup = [['table', 'cards'], ['where', { id: 'card-1' }], ['first']];
+const memberLookup = [['table', 'users'], ['where', { id: 'member-1' }], ['first']];
+const relationLookup = [
+  ['table', 'card_members'], ['where', { card_id: 'card-1', user_id: 'member-1' }], ['first'],
+];
+
+describe('card.add_member execution', () => {
+  it('validates config before accessing the transaction', async () => {
+    for (const memberId of ['', 42, null]) {
+      const f = fixture([], 'card-1', memberId);
+      await expect(f.execute()).rejects.toThrow();
+      expect(f.calls).toEqual([]);
+    }
+  });
+
+  it('rejects missing card ID before querying', async () => {
+    const f = fixture([]);
+    await expect(f.execute()).rejects.toThrow('card-id-missing');
+    expect(f.calls).toEqual([]);
+  });
+
+  it('rejects absent card before querying users', async () => {
+    const f = fixture([undefined], 'card-1');
+    await expect(f.execute()).rejects.toThrow('card-not-found');
+    expect(f.calls).toEqual(cardLookup);
+  });
+
+  it('rejects absent member before querying associations', async () => {
+    const f = fixture([{ id: 'card-1' }, undefined], 'card-1');
+    await expect(f.execute()).rejects.toThrow('member-not-found');
+    expect(f.calls).toEqual([...cardLookup, ...memberLookup]);
+  });
+
+  it('does not insert an existing association', async () => {
+    const f = fixture([{ id: 'card-1' }, { id: 'member-1' }, { card_id: 'card-1', user_id: 'member-1' }], 'card-1');
+    await f.execute();
+    expect(f.calls).toEqual([...cardLookup, ...memberLookup, ...relationLookup]);
+  });
+
+  it('inserts exactly the requested association with a current ISO timestamp when absent', async () => {
+    const f = fixture([{ id: 'card-1' }, { id: 'member-1' }, undefined], 'card-1');
+    const before = Date.now();
+    await f.execute();
+    const after = Date.now();
+    expect(f.calls).toEqual([
+      ...cardLookup, ...memberLookup, ...relationLookup,
+      ['table', 'card_members'],
+      ['insert', { card_id: 'card-1', user_id: 'member-1', created_at: expect.any(String) }],
+    ]);
+    const payload = f.calls.at(-1)?.[1] as { created_at: string };
+    const timestamp = Date.parse(payload.created_at);
+    expect(new Date(timestamp).toISOString()).toBe(payload.created_at);
+    expect(timestamp).toBeGreaterThanOrEqual(before);
+    expect(timestamp).toBeLessThanOrEqual(after);
+  });
+});


### PR DESCRIPTION
## Scope
- Type only the `card.add_member` existence-query results using migration-derived ID and relation columns (`0002_auth`, `0006_card`, `0007_card_extended`).
- Add six durable tests invoking the real action handler and real Zod parser, with a fake transaction seam.
- No runtime/auth/API changes, UI, payments, dependencies, configuration, deployment or stable changes. Production Bun-transpiled JavaScript is byte-identical to BASE (SHA-256 `17a4a01524d953997c971a02dad48852b55d76f72680d9aab9b8efbd8e1dcba0`).

## Validation
Fresh BASE: `b421278e19eb92e321f13e1e65fe567e3756cc30` (clean main, fetched and ff-checked before changes).

| Gate | Result |
| --- | --- |
| Focused ESLint, both touched files | PASS, zero errors/warnings; removes 3 production errors |
| Full ESLint | Existing debt: 2547 errors / 3 warnings, down from supplied post-224 2550 / 3 |
| Focused real-handler tests (addMember + addLabel) | PASS: 12 tests |
| Added tests against unmodified BASE handler | PASS: 6 tests |
| Temporary wrong-member relation-filter mutation | Expected RED: 2 failures; mutation restored before type-only implementation |
| `bun run typecheck` | Existing failure: 148 diagnostics; complete BASE/HEAD output byte-identical |
| `bun test` | BASE 1133 pass, HEAD 1139 pass; both 3 skip, 180 fail, 30 errors |
| File-qualified named failures / unhandled errors | Exact multisets unchanged: 150 named failures + 30 unhandled errors; no added/removed identities (ignores repeated final failure summary) |
| `bun run build:client` | PASS with chunk-size warning |
| `git diff --check` | PASS |

## Coverage limitations / pre-existing observation
Tests exercise configuration rejection, missing card/member short-circuit order, exact ID filters, idempotency, and existing insertion payload/current ISO timestamp. They do not exercise live DB, transaction concurrency, auth routing, or pubsub; the transaction transport is fake. No UI changed, so UI/E2E was not run.

The existing insert includes `created_at`, but migration `0007_card_extended` declares only `card_id` and `user_id` for `card_members`, and the migration search found no later timestamp addition. This potential pre-existing live-schema mismatch is deliberately preserved, not fixed or claimed covered by fake-transaction tests. Only existence reads receive row typing.

## Local evidence
Unique directory: `/tmp/chimedeck-next-20260909-141303/`
- `base-typecheck.log`, `base-test.log`, `head-typecheck.log`, `head-test.log`
- `base-focused.log`, `base-focused-eslint.log`, `mutation-red.log`
- `head-focused.log`, `head-eslint.log`, `head-full-eslint.log`, `head-build.log`, `head-diff-check.log`, `head-exits.json`
- `comparison.json`, `compare.py`, `base-identities.json`, `head-identities.json`
- `emitted-js.json`, `base-addMember.js`, `head-addMember.js`

Implementation author: matthewvryanjh. Independent review required; this worker will not approve or merge.
