### PR TITLE
refactor(automation): type mark-due-complete card read

### DIFF
--- a/server/extensions/automation/engine/actions/card/markDueComplete.ts
+++ b/server/extensions/automation/engine/actions/card/markDueComplete.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import type { ActionHandler, ActionContext } from '../../../common/types';
 
+// Read projection from db/migrations/0006_card.ts (due_date is nullable).
+interface CardDueDateRow {
+  id: string;
+  due_date: Date | null;
+}
+
 const configSchema = z.object({});
 
 export const cardMarkDueCompleteAction: ActionHandler = {
@@ -12,7 +18,7 @@ export const cardMarkDueCompleteAction: ActionHandler = {
     const cardId = evalContext.cardId;
     if (!cardId) throw new Error('card-id-missing');
 
-    const card = await trx('cards').where({ id: cardId }).first();
+    const card = await trx<CardDueDateRow>('cards').where({ id: cardId }).first();
     if (!card) throw new Error('card-not-found');
     if (!card.due_date) throw new Error('card-has-no-due-date');
 

--- a/tests/integration/automation/markDueComplete.test.ts
+++ b/tests/integration/automation/markDueComplete.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test';
+import type { ActionContext } from '../../../server/extensions/automation/common/types';
+import { cardMarkDueCompleteAction } from '../../../server/extensions/automation/engine/actions/card/markDueComplete';
+
+// Execute the real handler with a fake transaction; no live database is exercised.
+function fixture(card: { due_date: Date | null } | undefined, cardId?: string, writeError?: Error) {
+  const calls: unknown[][] = [];
+  const query = {
+    where(value: Record<string, unknown>) {
+      calls.push(['where', value]);
+      return query;
+    },
+    first() {
+      calls.push(['first']);
+      return Promise.resolve(card);
+    },
+    update(value: Record<string, unknown>) {
+      calls.push(['update', value]);
+      return writeError ? Promise.reject(writeError) : Promise.resolve(1);
+    },
+  };
+  const trx = (table: string) => {
+    calls.push(['table', table]);
+    return query;
+  };
+  const context = { evalContext: { cardId }, trx } as unknown as ActionContext;
+  return { calls, execute: () => cardMarkDueCompleteAction.execute(context) };
+}
+
+const lookup = [['table', 'cards'], ['where', { id: 'card-1' }], ['first']];
+
+describe('card.mark_due_complete execution', () => {
+  it('rejects missing card ID without database access', async () => {
+    const f = fixture(undefined);
+    await expect(f.execute()).rejects.toThrow('card-id-missing');
+    expect(f.calls).toEqual([]);
+  });
+
+  it('rejects an absent card without updating', async () => {
+    const f = fixture(undefined, 'card-1');
+    await expect(f.execute()).rejects.toThrow('card-not-found');
+    expect(f.calls).toEqual(lookup);
+  });
+
+  it('rejects a null due date without updating', async () => {
+    const f = fixture({ due_date: null }, 'card-1');
+    await expect(f.execute()).rejects.toThrow('card-has-no-due-date');
+    expect(f.calls).toEqual(lookup);
+  });
+
+  it('updates only the requested card with completion and a current ISO timestamp', async () => {
+    const f = fixture({ due_date: new Date('2026-01-01T00:00:00Z') }, 'card-1');
+    const before = Date.now();
+    await f.execute();
+    const after = Date.now();
+    expect(f.calls).toEqual([
+      ...lookup, ['table', 'cards'], ['where', { id: 'card-1' }],
+      ['update', { due_complete: true, updated_at: expect.any(String) }],
+    ]);
+    const payload = f.calls.at(-1)?.[1] as { updated_at: string };
+    const timestamp = Date.parse(payload.updated_at);
+    expect(new Date(timestamp).toISOString()).toBe(payload.updated_at);
+    expect(timestamp).toBeGreaterThanOrEqual(before);
+    expect(timestamp).toBeLessThanOrEqual(after);
+  });
+
+  it('propagates database write errors', async () => {
+    const error = new Error('write-failed');
+    const f = fixture({ due_date: new Date() }, 'card-1', error);
+    await expect(f.execute()).rejects.toBe(error);
+    expect(f.calls.slice(0, -1)).toEqual([...lookup, ['table', 'cards'], ['where', { id: 'card-1' }]]);
+  });
+});


### PR DESCRIPTION
## Summary
- Type the `card.mark_due_complete` card read with the `id` / nullable `due_date` projection from migration `0006_card.ts`.
- Add five durable real-handler tests for missing ID/card/due date, card-scoped completion with ISO timestamp, and write-error propagation.
- Production change is type-only: BASE/HEAD Bun-transpiled JavaScript is byte-identical. No API/auth/query/payload changes; no payments, UI, dependencies, configuration, or deployment changes.

## Verification
Fresh BASE `4fb7dd636972931f725e9527389ce8c592c173c6` captured before edits. Local evidence directory: `/tmp/chimedeck-lint-slice-I3H8fj/`.

| Gate | Result | Log |
|---|---|---|
| Focused ESLint, both touched files | zero errors/warnings, exit 0 | `focused-lint.log` |
| Real-handler tests against BASE | 5 pass | `base-focused.log` |
| Temporary completion=false mutation | expected 1 failure, restored | `mutation-red.log` |
| Real-handler tests against HEAD | 5 pass | `head-focused.log` |
| `bun run typecheck` | BASE/HEAD exit 2; 148 identical diagnostics; complete logs byte-identical | `base-typecheck.log`, `head-typecheck.log` |
| `bun test` | BASE 1139 pass / HEAD 1144 pass; both 3 skip, 180 fail, 30 errors | `base-test.log`, `head-test.log` |
| Exact multiset comparison | unchanged 150 file-qualified test failures and 30 file-qualified unhandled-error messages; no added/removed diagnostic/failure/error identities | `compare.py`, `comparison.json` |
| `bun run build:client` | exit 0; existing large-chunk warning | `build-client.log` |
| Emitted JavaScript | byte-identical | `emitted-comparison.log`, `base-emitted.js`, `head-emitted.js` |
| `bun run lint` | 2545 errors / 3 warnings, down 2 errors from supplied post-225 baseline | `head-full-lint.log` |
| `git diff --check` | exit 0 | local command |

Bun's aggregate 180 failures includes the 30 unhandled errors; the comparison excludes its repeated end-of-run failure summary and separately compares actual file-qualified failures and unhandled errors, not just totals.

## Coverage limits
Tests invoke the real handler with a fake Knex transaction. They prove query filters/order, guard behavior, exact update payload shape and timestamp, and error propagation; not live PostgreSQL schema acceptance, transaction rollback, engine authorization, or dispatch integration. No UI changed, so no UI/E2E run. Existing repository-wide test/typecheck/lint failures remain, with no new failures. No approval or merge requested from the implementation worker.
