### PR TITLE
fix: type automation card archive lookup

### DIFF
--- a/server/extensions/automation/engine/actions/card/archive.ts
+++ b/server/extensions/automation/engine/actions/card/archive.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod';
 import type { ActionHandler, ActionContext } from '../../../common/types';
 
+// Existence-check row: id is the string primary key in db/migrations/0006_card.ts.
+interface CardIdentityRow {
+  id: string;
+}
+
 const configSchema = z.object({});
 
 export const cardArchiveAction: ActionHandler = {
@@ -12,7 +17,7 @@ export const cardArchiveAction: ActionHandler = {
     const cardId = evalContext.cardId;
     if (!cardId) throw new Error('card-id-missing');
 
-    const card = await trx('cards').where({ id: cardId }).first();
+    const card = await trx<CardIdentityRow>('cards').where({ id: cardId }).first();
     if (!card) throw new Error('card-not-found');
 
     await trx('cards')

--- a/tests/integration/automation/archive.test.ts
+++ b/tests/integration/automation/archive.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test';
+import type { ActionContext } from '../../../server/extensions/automation/common/types';
+import { cardArchiveAction } from '../../../server/extensions/automation/engine/actions/card/archive';
+
+// Real handler, fake transaction: these tests do not exercise a live database.
+function fixture(card: { id: string } | undefined, cardId?: string, readError?: Error, writeError?: Error) {
+  const calls: unknown[][] = [];
+  const query = {
+    where(value: Record<string, unknown>) {
+      calls.push(['where', value]);
+      return query;
+    },
+    first() {
+      calls.push(['first']);
+      return readError ? Promise.reject(readError) : Promise.resolve(card);
+    },
+    update(value: Record<string, unknown>) {
+      calls.push(['update', value]);
+      return writeError ? Promise.reject(writeError) : Promise.resolve(1);
+    },
+  };
+  const trx = (table: string) => {
+    calls.push(['table', table]);
+    return query;
+  };
+  const context = { evalContext: { cardId }, trx } as unknown as ActionContext;
+  return { calls, execute: () => cardArchiveAction.execute(context) };
+}
+
+const lookup = [['table', 'cards'], ['where', { id: 'card-1' }], ['first']];
+
+describe('card.archive execution', () => {
+  it('rejects missing card ID without database access', async () => {
+    const f = fixture(undefined);
+    await expect(f.execute()).rejects.toThrow('card-id-missing');
+    expect(f.calls).toEqual([]);
+  });
+
+  it('rejects an absent card without updating', async () => {
+    const f = fixture(undefined, 'card-1');
+    await expect(f.execute()).rejects.toThrow('card-not-found');
+    expect(f.calls).toEqual(lookup);
+  });
+
+  it('archives only the requested card with a current ISO timestamp', async () => {
+    const f = fixture({ id: 'card-1' }, 'card-1');
+    const before = Date.now();
+    await f.execute();
+    const after = Date.now();
+    expect(f.calls).toEqual([
+      ...lookup, ['table', 'cards'], ['where', { id: 'card-1' }],
+      ['update', { archived: true, updated_at: expect.any(String) }],
+    ]);
+    const payload = f.calls.at(-1)?.[1] as { updated_at: string };
+    const timestamp = Date.parse(payload.updated_at);
+    expect(new Date(timestamp).toISOString()).toBe(payload.updated_at);
+    expect(timestamp).toBeGreaterThanOrEqual(before);
+    expect(timestamp).toBeLessThanOrEqual(after);
+  });
+
+  it('propagates database read errors without updating', async () => {
+    const error = new Error('read-failed');
+    const f = fixture(undefined, 'card-1', error);
+    await expect(f.execute()).rejects.toBe(error);
+    expect(f.calls).toEqual(lookup);
+  });
+
+  it('propagates database write errors', async () => {
+    const error = new Error('write-failed');
+    const f = fixture({ id: 'card-1' }, 'card-1', undefined, error);
+    await expect(f.execute()).rejects.toBe(error);
+    expect(f.calls.slice(0, -1)).toEqual([...lookup, ['table', 'cards'], ['where', { id: 'card-1' }]]);
+  });
+});


### PR DESCRIPTION
## Scope
- Type the `card.archive` existence lookup with a local `CardIdentityRow`; string primary-key typing comes from `db/migrations/0006_card.ts`.
- Add five durable real-handler tests for missing ID, absent card, requested-card update/ISO timestamp, and read/write error propagation.
- Production change is type-only: BASE/HEAD Bun-transpiled JavaScript is byte-identical. No runtime/auth/API/query/payload changes; no payment, UI, config, dependency, deployment or stable changes.

## Verification
Base: `b06235b98b203c55b6f2375767e4951b2acdba93` (fresh clean origin/main).
- Focused ESLint: zero errors/warnings in both touched files.
- Focused tests: 5 pass on BASE and HEAD. Temporary wrong-card update-filter mutation produced 2 expected failures; restored before final type-only edit (test sensitivity, not a production bug).
- Fresh full `bun test`: BASE 1144 pass / HEAD 1149 pass; both 3 skip, 180 fail, 30 errors. Programmatic multiset comparison finds exactly the same 150 file-qualified failing tests and 30 file/message-qualified unhandled errors (Bun includes the errors in its 180 fail aggregate). No added or removed failures/errors.
- Fresh `bun run typecheck`: exits 2 on both; identical multiset of 148 full diagnostics including continuation text. No added/removed diagnostics.
- `bun run build:client`: passes with existing chunk-size warning.
- `git diff --check`: passes.
- Full lint: 2544 errors / 3 warnings, down one error from supplied post-226 baseline (2545 / 3). Broad lint/typecheck/tests remain red due to existing debt, not claimed green.

Evidence directory: `/tmp/chimedeck-lint-slice-URCBgS/` — `base-typecheck.log`, `head-typecheck.log`, `base-test.log`, `head-test.log`, `compare.py`, `comparison.json`, file-qualified `failures-{base,head}.json`, `unhandled-{base,head}.json`, `diagnostics-{base,head}.json`, `focused-base.log`, `focused-head.log`, `mutation-red.log`, `lint-base.log`, `lint-head.log`, `full-lint-head.log`, `build-client.log`, `diff-check.log`, `emitted-js.log`, `base.js`, `head.js`.

## Coverage limits
Tests execute the actual handler with a fake transaction; they establish query order/filter, preserved payload and error propagation, not live PostgreSQL schema acceptance, transaction/authorization composition or event/pubsub delivery. No UI touched, so UI/E2E not run. No live service or database claims.

Independent parent review required. This implementation PR is not approved or merged by its author.
