### PR TITLE
fix(automation): type add-checklist database reads

### DIFF
--- a/server/extensions/automation/engine/actions/card/addChecklist.ts
+++ b/server/extensions/automation/engine/actions/card/addChecklist.ts
@@ -3,6 +3,16 @@ import { z } from 'zod';
 import { between, HIGH_SENTINEL } from '../../../../list/mods/fractional';
 import type { ActionHandler, ActionContext } from '../../../common/types';
 
+// Read projections from migrations 0006_card and 0007_card_extended.
+interface CardLookupRow {
+  id: string;
+}
+
+interface ChecklistItemPositionRow {
+  card_id: string;
+  position: string;
+}
+
 const configSchema = z.object({
   name: z.string().min(1).max(255),
   items: z.array(z.string().min(1).max(512)).optional(),
@@ -22,12 +32,12 @@ export const cardAddChecklistAction: ActionHandler = {
     const cardId = evalContext.cardId;
     if (!cardId) throw new Error('card-id-missing');
 
-    const card = await trx('cards').where({ id: cardId }).first();
+    const card = await trx<CardLookupRow>('cards').where({ id: cardId }).first();
     if (!card) throw new Error('card-not-found');
 
     const titles = config.items && config.items.length > 0 ? config.items : [config.name];
 
-    const lastItem = await trx('checklist_items')
+    const lastItem = await trx<ChecklistItemPositionRow>('checklist_items')
       .where({ card_id: cardId })
       .orderBy('position', 'desc')
       .first();

--- a/tests/integration/automation/addChecklist.test.ts
+++ b/tests/integration/automation/addChecklist.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'bun:test';
+import type { ActionContext } from '../../../server/extensions/automation/common/types';
+import { cardAddChecklistAction } from '../../../server/extensions/automation/engine/actions/card/addChecklist';
+import { between, HIGH_SENTINEL } from '../../../server/extensions/list/mods/fractional';
+
+// Real handler and fractional indexing; fake transaction, not live database coverage.
+function fixture(config: Record<string, unknown>, options: {
+  cardId?: string; missingCard?: boolean; position?: string; readError?: Error; writeError?: Error;
+} = {}) {
+  const calls: unknown[][] = [];
+  const inserts: Record<string, unknown>[] = [];
+  const trx = (table: string) => {
+    calls.push(['table', table]);
+    const query = {
+      where(value: Record<string, unknown>) { calls.push(['where', value]); return query; },
+      orderBy(column: string, direction: string) { calls.push(['orderBy', column, direction]); return query; },
+      first() {
+        calls.push(['first']);
+        if (options.readError) return Promise.reject(options.readError);
+        return Promise.resolve(table === 'cards'
+          ? (options.missingCard ? undefined : { id: 'card-1' })
+          : (options.position === undefined ? undefined : { position: options.position }));
+      },
+      insert(value: Record<string, unknown>) {
+        inserts.push(value);
+        return options.writeError ? Promise.reject(options.writeError) : Promise.resolve(1);
+      },
+    };
+    return query;
+  };
+  const context = { action: { config }, evalContext: { cardId: options.cardId }, trx } as unknown as ActionContext;
+  return { calls, inserts, execute: () => cardAddChecklistAction.execute(context) };
+}
+
+const lookup = [['table', 'cards'], ['where', { id: 'card-1' }], ['first']];
+const lastItemLookup = [['table', 'checklist_items'], ['where', { card_id: 'card-1' }], ['orderBy', 'position', 'desc'], ['first']];
+
+describe('card.add_checklist execution', () => {
+  it('validates config before database access', async () => {
+    const f = fixture({ name: '' }, { cardId: 'card-1' });
+    await expect(f.execute()).rejects.toThrow();
+    expect(f.calls).toEqual([]);
+  });
+  it('rejects missing card ID before database access', async () => {
+    const f = fixture({ name: 'Tasks' });
+    await expect(f.execute()).rejects.toThrow('card-id-missing');
+    expect(f.calls).toEqual([]);
+  });
+  it('rejects missing cards before reading or inserting items', async () => {
+    const f = fixture({ name: 'Tasks' }, { cardId: 'card-1', missingCard: true });
+    await expect(f.execute()).rejects.toThrow('card-not-found');
+    expect(f.calls).toEqual(lookup);
+    expect(f.inserts).toEqual([]);
+  });
+  for (const items of [undefined, []]) {
+    it(`uses the name for ${items === undefined ? 'omitted' : 'empty'} items`, async () => {
+      const f = fixture({ name: 'Tasks', items }, { cardId: 'card-1' });
+      await f.execute();
+      expect(f.calls).toEqual([...lookup, ...lastItemLookup, ['table', 'checklist_items']]);
+      expect(f.inserts).toEqual([{ id: expect.any(String), card_id: 'card-1', title: 'Tasks', checked: false, position: between('', HIGH_SENTINEL) }]);
+    });
+  }
+  it('appends ordered items after the last position without changing titles or payload shape', async () => {
+    const f = fixture({ name: 'Tasks', items: ['First', 'Second'] }, { cardId: 'card-1', position: 'U' });
+    await f.execute();
+    const first = between('U', HIGH_SENTINEL);
+    expect(f.calls).toEqual([...lookup, ...lastItemLookup, ['table', 'checklist_items'], ['table', 'checklist_items']]);
+    expect(f.inserts).toEqual([
+      { id: expect.any(String), card_id: 'card-1', title: 'First', checked: false, position: first },
+      { id: expect.any(String), card_id: 'card-1', title: 'Second', checked: false, position: between(first, HIGH_SENTINEL) },
+    ]);
+    expect(f.inserts[0]?.id).not.toBe(f.inserts[1]?.id);
+  });
+  it('propagates read errors without inserts', async () => {
+    const error = new Error('read-failed');
+    const f = fixture({ name: 'Tasks' }, { cardId: 'card-1', readError: error });
+    await expect(f.execute()).rejects.toBe(error);
+    expect(f.inserts).toEqual([]);
+  });
+  it('stops on an insert error', async () => {
+    const error = new Error('write-failed');
+    const f = fixture({ name: 'Tasks', items: ['First', 'Second'] }, { cardId: 'card-1', writeError: error });
+    await expect(f.execute()).rejects.toBe(error);
+    expect(f.inserts).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Scope
Type only the card-existence and last-checklist-item read boundaries in `card.add_checklist`; no runtime, auth, API, UI, payment, dependency, configuration, or deployment changes.

- Local read projections derive `cards.id` from migration 0006 and non-null `checklist_items.card_id`/`position` from 0007 (0102 preserves position as text).
- Production Bun-transpiled JavaScript is byte-identical to fresh main c3f3fe5df5ee17e99a5fca8d29e99536c1abd998.
- Add eight durable real-handler tests using fake transactions and real fractional indexing: validation, missing IDs/cards, omitted/empty items, ordered append/payload preservation, read/write errors.

## Verification
All local logs: `/tmp/chimedeck-lint228-DbGJPP/`.
- `focused-base.log`: 8 pass against unchanged BASE production.
- `mutation-red.log`: changing descending position lookup to ascending caused 3 failures; mutation restored.
- `focused-head.log`: 8 pass; `focused-lint.log`: zero errors/warnings across both touched files.
- `emitted-js.log`, `base.js`, `head.js`: byte-identical production JavaScript.
- `build-client.log`, `diff-check.log`: pass.
- `base-typecheck.log` / `head-typecheck.log`: both exit 2, identical multiset of 148 diagnostics.
- `base-test.log`: 1149 pass, 3 skip, 180 fail, 30 errors. `head-test.log`: 1157 pass, 3 skip, 180 fail, 30 errors.
- `compare.py` / `comparison.json`: identical file-qualified multisets of 150 failing tests and 30 unhandled errors, excluding repeated failure summary; no added/removed failures or diagnostics.
- `full-lint.log`: 2539 errors, 3 warnings (5 fewer errors than supplied post-227 baseline).

## Coverage limits / existing debt
Tests execute the real handler, not a mock of it; DB transport is fake. No live PostgreSQL, transaction rollback, engine authorization, UI/E2E or pubsub coverage claimed. No UI changed. Existing comment about flat checklist groups is stale after migration 0088: this handler still inserts items without a checklist_id and does not prepend the name to supplied item titles. Migration 0088 makes checklist_id nullable; payload and runtime behavior intentionally remain unchanged, with no claim that this verifies grouped checklist visibility in the live application.

Implementation authored by matthewvryanjh. Separate parent review required; do not auto-approve or merge.
