### PR TITLE
chore: modernize automation handler schema types

### DIFF
--- a/server/extensions/automation/common/types.ts
+++ b/server/extensions/automation/common/types.ts
@@ -1,4 +1,6 @@
 // Shared types for the automation system.
+import type { Knex } from 'knex';
+import type { ZodType } from 'zod';
 
 export type AutomationType = 'RULE' | 'CARD_BUTTON' | 'BOARD_BUTTON' | 'SCHEDULED' | 'DUE_DATE';
 export type RunStatus = 'SUCCESS' | 'PARTIAL' | 'FAILED';
@@ -64,7 +66,7 @@ export interface TriggerHandler {
   type: string;
   label: string;
   // Zod schema used to validate trigger config at save time.
-  configSchema: import('zod').ZodTypeAny;
+  configSchema: ZodType;
   /** Returns true when this trigger fires for the given event + config. */
   matches(event: AutomationEvent, config: Record<string, unknown>): boolean;
 }
@@ -74,7 +76,7 @@ export interface ActionHandler {
   type: string;
   label?: string;
   category?: string;
-  configSchema: import('zod').ZodTypeAny;
+  configSchema: ZodType;
   /** Execute the action. Throws on unrecoverable failure. */
   execute(context: ActionContext): Promise<void>;
 }
@@ -84,7 +86,7 @@ export interface ActionContext {
   action: AutomationActionRow;
   event: AutomationEvent;
   evalContext: EvaluationContext;
-  trx: import('knex').Knex.Transaction;
+  trx: Knex.Transaction;
   /** Register a side-effect to run after the DB transaction commits (e.g. WS broadcasts). */
   postCommit: (fn: () => void) => void;
 }

--- a/tests/integration/automation/handlerSchemas.test.ts
+++ b/tests/integration/automation/handlerSchemas.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test';
+import type { ActionHandler, TriggerHandler } from '../../../server/extensions/automation/common/types';
+import { cardRemoveLabelAction } from '../../../server/extensions/automation/engine/actions/card/removeLabel';
+import { cardCreatedTrigger } from '../../../server/extensions/automation/engine/triggers/card/created';
+
+// Exercise real schemas through the shared handler interfaces, without DB or registry mocks.
+const action: ActionHandler = cardRemoveLabelAction;
+const trigger: TriggerHandler = cardCreatedTrigger;
+
+describe('Shared automation handler schemas', () => {
+  it('preserves the optional trigger filter and strips unknown config keys', () => {
+    expect(trigger.configSchema.parse({ ignored: true })).toEqual({});
+    expect(trigger.configSchema.parse({ listIds: ['list-1'] })).toEqual({ listIds: ['list-1'] });
+  });
+
+  it('rejects malformed trigger filters through the shared schema boundary', () => {
+    expect(trigger.configSchema.safeParse({ listIds: [42] }).success).toBe(false);
+    expect(trigger.configSchema.safeParse({ listIds: [''] }).success).toBe(false);
+  });
+
+  it('preserves required action config validation and parsed output', () => {
+    expect(action.configSchema.safeParse({}).success).toBe(false);
+    expect(action.configSchema.safeParse({ labelId: '' }).success).toBe(false);
+    expect(action.configSchema.parse({ labelId: 'label-1', ignored: true })).toEqual({ labelId: 'label-1' });
+  });
+});


### PR DESCRIPTION
## Scope
One non-payment server lint slice: modernize shared automation handler schema/transaction type references with named type-only imports. Zod 4 exports deprecated `ZodTypeAny` as an alias of `ZodType`; this preserves its exact contract rather than widening or narrowing configuration validation. No runtime logic, DB row types, auth/API contracts, UI, configuration, dependencies, deployment or stable changes.

Add durable tests of the real card-created trigger and remove-label action schemas through their shared handler interfaces: optional/required fields, malformed values, parsed output and unknown-key stripping. These do not mock the handlers or schemas.

## Verification
Base: `3c271962d134cfb7d829c08b4e4864f418197148` (clean, fetched/fast-forward main before edits).
- Focused ESLint: **0 errors, 0 warnings** for both touched files.
- Full lint: **2534 errors, 3 warnings**, down 5 errors from supplied post-228 baseline (2539/3).
- New schema tests: **3 pass**, on both BASE and HEAD. Temporary required-listIds mutation: **1 expected failure**, restored before the type-only edit (sensitivity evidence, not a production defect).
- Adjacent trigger/action/schema suites: **66 pass, 7 pre-existing failures**; file-qualified failure multisets identical on BASE and HEAD.
- Fresh full `bun test`: BASE **1157 pass / 3 skip / 180 fail / 30 errors**; HEAD **1160 pass / 3 skip / 180 fail / 30 errors**. Compared primary file-qualified full-name failure multisets (150) and complete file-qualified unhandled-error blocks (30), excluding repeated summaries: **no additions or removals**.
- Fresh `bun run typecheck`: exits 2 on both; **148 complete diagnostics identical**, including continuation text, file and position. No additions or removals.
- `bun run build:client`: passes (existing chunk-size warning).
- `git diff --check`: passes.
- BASE/HEAD Bun-transpiled production module: **byte-identical emitted JavaScript**.

## Evidence and limitations
Local evidence directory: `/tmp/chimedeck-lint-slice-M18uhh/` (not committed or available on GitHub).
Key files: `base-typecheck.log`, `head-typecheck.log`, `base-test.log`, `head-test.log`, `comparison.json`, `compare.py`, `*-base.json`, `*-head.json`, `base-focused.log`, `head-new-tests.log`, `mutation-red.log`, `base-adjacent.log`, `head-focused.log`, `adjacent-comparison.log`, `head-eslint.log`, `head-full-lint.log`, `head-build.log`, `diff-check.log`, `emission.log`, `base-emitted.js`, `head-emitted.js`.

Direct real-schema execution is covered; action execution, live PostgreSQL, pubsub and authenticated HTTP flows are not exercised by the new tests. No UI changed; browser/E2E was not run. Full suite remains red from existing failures, including Playwright files collected by Bun. No approval or merge performed; independent review required.
