### PR TITLE
chore: type automation move-to-list reads

### DIFF
--- a/server/extensions/automation/engine/actions/card/moveToList.ts
+++ b/server/extensions/automation/engine/actions/card/moveToList.ts
@@ -3,6 +3,20 @@ import { between, HIGH_SENTINEL } from '../../../../list/mods/fractional';
 import { broadcast } from '../../../../realtime/mods/rooms/broadcast';
 import type { ActionHandler, ActionContext } from '../../../common/types';
 
+// Consumed/filter columns from migrations 0006_card and 0005_list.
+// The full card is still read and spread into the existing broadcast payload.
+interface MoveCardRow {
+  id: string;
+  list_id: string;
+  position: string;
+  archived: boolean;
+}
+
+interface TargetListRow {
+  id: string;
+  board_id: string;
+}
+
 const configSchema = z.object({
   listId: z.string().min(1),
   position: z.enum(['top', 'bottom']).optional(),
@@ -24,17 +38,17 @@ export const cardMoveToListAction: ActionHandler = {
     const cardId = evalContext.cardId;
     if (!cardId) throw new Error('card-id-missing');
 
-    const card = await trx('cards').where({ id: cardId }).first();
+    const card = await trx<MoveCardRow>('cards').where({ id: cardId }).first();
     if (!card) throw new Error('card-not-found');
 
-    const targetList = await trx('lists').where({ id: config.listId }).first();
+    const targetList = await trx<TargetListRow>('lists').where({ id: config.listId }).first();
     if (!targetList) throw new Error('target-list-not-found');
 
     // Guard: the target list must belong to the same board as the automation.
     if (targetList.board_id !== automation.board_id)
       throw new Error('target-list-on-different-board');
 
-    const targetCards = await trx('cards')
+    const targetCards = await trx<MoveCardRow>('cards')
       .where({ list_id: config.listId, archived: false })
       .whereNot({ id: cardId })
       .orderBy('position', 'asc');

--- a/tests/integration/automation/moveToList.test.ts
+++ b/tests/integration/automation/moveToList.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'bun:test';
+import type { ServerWebSocket } from 'bun';
+import type { ActionContext } from '../../../server/extensions/automation/common/types';
+import { cardMoveToListAction } from '../../../server/extensions/automation/engine/actions/card/moveToList';
+import { between, HIGH_SENTINEL } from '../../../server/extensions/list/mods/fractional';
+import { rooms, type WsData } from '../../../server/extensions/realtime/mods/rooms';
+
+// Real action, fractional indexer and broadcaster; fake transaction and socket only.
+function fixture({
+  cardId = 'card-1',
+  card = { id: 'card-1', list_id: 'source', title: 'Keep me', extra: { preserved: true } },
+  list = { id: 'target', board_id: 'move-to-list-test-board' },
+  peers = [{ position: 'B' }, { position: 'M' }],
+  config = { listId: 'target' },
+}: {
+  cardId?: string;
+  card?: Record<string, unknown> | null;
+  list?: Record<string, unknown> | null;
+  peers?: { position: string }[];
+  config?: Record<string, unknown>;
+} = {}) {
+  const calls: unknown[][] = [];
+  const updates: { list_id: string; position: string; updated_at: string }[] = [];
+  const callbacks: (() => void)[] = [];
+  const rows = [card, list];
+  const query = {
+    where(value: Record<string, unknown>) {
+      calls.push(['where', value]);
+      return query;
+    },
+    whereNot(value: Record<string, unknown>) {
+      calls.push(['whereNot', value]);
+      return query;
+    },
+    orderBy(column: string, direction: string) {
+      calls.push(['orderBy', column, direction]);
+      return Promise.resolve(peers);
+    },
+    first() {
+      calls.push(['first']);
+      return Promise.resolve(rows.shift());
+    },
+    update(value: { list_id: string; position: string; updated_at: string }) {
+      calls.push(['update']);
+      updates.push(value);
+      return Promise.resolve(1);
+    },
+  };
+  const trx = (table: string) => {
+    calls.push(['table', table]);
+    return query;
+  };
+  // The fake supplies exactly the context fields consumed by this action.
+  const context = {
+    evalContext: { actorId: 'actor-1', cardId },
+    automation: { board_id: 'move-to-list-test-board' },
+    action: { config },
+    trx,
+    postCommit(fn: () => void) { callbacks.push(fn); },
+  } as unknown as ActionContext;
+  return { calls, updates, callbacks, card, execute: () => cardMoveToListAction.execute(context) };
+}
+
+describe('card.move_to_list execution', () => {
+  for (const [name, options, error, queries] of [
+    ['invalid config', { config: { listId: '' } }, 'Too small', 0],
+    ['missing card ID', { cardId: '' }, 'card-id-missing', 0],
+    ['absent card', { card: null }, 'card-not-found', 1],
+    ['absent target list', { list: null }, 'target-list-not-found', 2],
+    ['foreign board', { list: { id: 'target', board_id: 'other' } }, 'target-list-on-different-board', 2],
+  ] as const) {
+    it(`rejects ${name} before peer queries, writes or callbacks`, async () => {
+      const f = fixture(options);
+      await expect(f.execute()).rejects.toThrow(error);
+      expect(f.calls.filter(([kind]) => kind === 'table')).toHaveLength(queries);
+      expect(f.calls.some(([kind]) => kind === 'orderBy')).toBe(false);
+      expect(f.updates).toEqual([]);
+      expect(f.callbacks).toEqual([]);
+    });
+  }
+
+  for (const position of ['top', 'bottom', undefined] as const) {
+    it(`moves to ${position ?? 'default bottom'} with exact filters and a deferred full-card broadcast`, async () => {
+      const f = fixture({ config: { listId: 'target', position } });
+      const messages: string[] = [];
+      const socket = { send(message: string) { messages.push(message); return 1; } } as unknown as ServerWebSocket<WsData>;
+      const boardId = 'move-to-list-test-board';
+      rooms.set(boardId, new Set([socket]));
+      try {
+        await f.execute();
+        expect(f.calls).toEqual([
+          ['table', 'cards'], ['where', { id: 'card-1' }], ['first'],
+          ['table', 'lists'], ['where', { id: 'target' }], ['first'],
+          ['table', 'cards'], ['where', { list_id: 'target', archived: false }],
+          ['whereNot', { id: 'card-1' }], ['orderBy', 'position', 'asc'],
+          ['table', 'cards'], ['where', { id: 'card-1' }], ['update'],
+        ]);
+        const expected = position === 'top' ? between('', 'B') : between('M', HIGH_SENTINEL);
+        expect(f.updates).toHaveLength(1);
+        expect(f.updates[0]).toEqual({ list_id: 'target', position: expected, updated_at: expect.any(String) });
+        expect(f.updates[0]?.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
+        expect(messages).toEqual([]);
+        expect(f.callbacks).toHaveLength(1);
+        for (const callback of f.callbacks) callback();
+        expect(messages).toEqual([JSON.stringify({
+          type: 'card_moved',
+          payload: { card: { ...f.card, list_id: 'target', position: expected }, fromListId: 'source' },
+        })]);
+      } finally {
+        rooms.delete(boardId);
+      }
+    });
+  }
+
+  for (const position of ['top', 'bottom'] as const) {
+    it(`uses both sentinels for an empty target at ${position}`, async () => {
+      const f = fixture({ peers: [], config: { listId: 'target', position } });
+      await f.execute();
+      expect(f.updates[0]?.position).toBe(between('', HIGH_SENTINEL));
+    });
+  }
+});


### PR DESCRIPTION
## Scope
- Type the three database reads in `card.move_to_list` using consumed/filter columns derived from migrations `0006_card.ts` and `0005_list.ts`.
- Preserve queries, validation, same-board guard, full-card payload, ordering, update and post-commit broadcast. Bun-transpiled production JavaScript is byte-identical (1,954 bytes BASE/HEAD).
- Add 10 durable real-action tests: invalid config, missing card ID/card/list, foreign board, top/bottom/default placement, empty target, exact filter/order/write calls and deferred full-card broadcast including extra fields.
- No payment/monetisation, UI, configuration, dependencies, deployment or stable changes.

## Verification
Fresh BASE: `221a156560edae4611202349fa3cd27a2e1b0a1f`, clean and fast-forwarded before edits.

| Gate | Result |
| --- | --- |
| Focused ESLint, both changed files | 0 errors / 0 warnings (14 production errors removed) |
| New handler tests on BASE | 10 pass |
| Temporary descending-order mutation on BASE | Fails as expected; mutation restored before type-only edit |
| HEAD moveToList + moveToTop + moveToBottom | 18 pass |
| `bun run typecheck` | BASE/HEAD exit 2: exact same 148 complete diagnostic blocks |
| `bun test` | BASE 1160 pass / HEAD 1170 pass; both 3 skip, 180 fail, 30 errors |
| File-qualified failure comparison | Identical multisets: 150 named failures + 30 unhandled-error blocks; no added or removed identities |
| `bun run build:client` | Pass |
| `git diff --check` | Pass |
| Full `bun run lint` | 2520 errors / 3 warnings, down from post-229 2534 / 3 |

## Local evidence
All logs use `/tmp/chimedeck-slice-1788941793825240000-`:
- `base-typecheck.log`, `base-test.log` (captured before any edit)
- `base-focused.log`, `base-focused-lint.log`, `mutation-red.log`
- `head-focused-lint.log`, `head-focused.log`, `head-typecheck.log`, `head-test.log`, `head-build.log`, `head-full-lint.log`, `diff-check.log`
- `comparison.json`, `diagnostics-multisets.json`, `failing_tests-multisets.json`, `unhandled_errors-multisets.json`, `compare.py`
- `emission.json`, `base-emitted.js`, `head-emitted.js`, `results.json`

## Coverage limits
Tests run the actual action, fractional indexer, in-process broadcaster and room registry. Only the Knex transaction/query and WebSocket send endpoint are fakes; tests verify call contracts and payload preservation, not live PostgreSQL execution, real transaction commit scheduling or network WebSocket delivery. No live DB/pubsub or UI/E2E validation claimed. Existing global test/typecheck/lint debt remains; no newly introduced failures found.

Implementation authored by matthewvryanjh. Independent parent review required; this task does not approve or merge.
