### PR TITLE
fix(automation): type archive-all-cards action boundary

### DIFF
--- a/server/extensions/automation/engine/actions/list/archiveAllCards.ts
+++ b/server/extensions/automation/engine/actions/list/archiveAllCards.ts
@@ -1,7 +1,10 @@
 // list.archive_all_cards — archives every non-archived card in a list atomically.
 
 import { z } from 'zod';
-import type { ActionHandler, ActionContext } from '../../../../common/types';
+import type { ActionHandler, ActionContext } from '../../../common/types';
+
+// Read projection from db/migrations/0005_list.ts (primary key).
+type ListRow = { id: string };
 
 const configSchema = z.object({
   listId: z.string().min(1),
@@ -15,7 +18,7 @@ export const listArchiveAllCardsAction: ActionHandler = {
   async execute({ action, trx }: ActionContext): Promise<void> {
     const config = configSchema.parse(action.config);
 
-    const list = await trx('lists').where({ id: config.listId }).first();
+    const list = await trx<ListRow>('lists').where({ id: config.listId }).first();
     if (!list) throw new Error('list-not-found');
 
     await trx('cards')

--- a/tests/integration/automation/archiveAllCards.test.ts
+++ b/tests/integration/automation/archiveAllCards.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test';
+import type { Knex } from 'knex';
+import type { ActionContext } from '../../../server/extensions/automation/common/types';
+import { listArchiveAllCardsAction } from '../../../server/extensions/automation/engine/actions/list/archiveAllCards';
+
+// Exercise the real handler; this transaction fake verifies query/payload contracts,
+// not PostgreSQL execution, transaction atomicity, or engine authorization.
+function fixture(listExists = true, config: Record<string, unknown> = { listId: 'list-1' }) {
+  const calls: unknown[][] = [];
+  const trx = ((table: string) => {
+    calls.push(['table', table]);
+    return {
+      where(filter: Record<string, unknown>) {
+        calls.push(['where', table, filter]);
+        return {
+          first() {
+            calls.push(['first', table]);
+            return Promise.resolve(listExists ? { id: 'list-1' } : undefined);
+          },
+          update(payload: Record<string, unknown>) {
+            calls.push(['update', table, payload]);
+            return Promise.resolve(2);
+          },
+        };
+      },
+    };
+  }) as unknown as Knex.Transaction;
+  const context = {
+    action: { id: 'action-1', automation_id: 'automation-1', position: 0, action_type: 'list.archive_all_cards', config },
+    trx,
+  } as ActionContext;
+  return { calls, context };
+}
+
+describe('list.archive_all_cards real handler', () => {
+  it('checks the configured list and archives only its non-archived cards', async () => {
+    const { calls, context } = fixture();
+    const before = Date.now();
+    await listArchiveAllCardsAction.execute(context);
+    const after = Date.now();
+    expect(calls).toEqual([
+      ['table', 'lists'],
+      ['where', 'lists', { id: 'list-1' }],
+      ['first', 'lists'],
+      ['table', 'cards'],
+      ['where', 'cards', { list_id: 'list-1', archived: false }],
+      ['update', 'cards', { archived: true, updated_at: expect.any(String) }],
+    ]);
+    const payload = calls[5]?.[2] as { updated_at: string };
+    const timestamp = new Date(payload.updated_at);
+    expect(timestamp.toISOString()).toBe(payload.updated_at);
+    expect(timestamp.getTime()).toBeGreaterThanOrEqual(before);
+    expect(timestamp.getTime()).toBeLessThanOrEqual(after);
+  });
+
+  it('rejects a missing list before touching cards', async () => {
+    const { calls, context } = fixture(false);
+    await expect(listArchiveAllCardsAction.execute(context)).rejects.toThrow('list-not-found');
+    expect(calls).toEqual([
+      ['table', 'lists'], ['where', 'lists', { id: 'list-1' }], ['first', 'lists'],
+    ]);
+  });
+
+  it.each([{}, { listId: '' }, { listId: 42 }])('rejects invalid config %j before querying', async (config) => {
+    const { calls, context } = fixture(true, config);
+    await expect(listArchiveAllCardsAction.execute(context)).rejects.toThrow();
+    expect(calls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Repair the archive-all-cards action's **type-only** `ActionHandler`/`ActionContext` import and type its list-existence read with the primary key from `db/migrations/0005_list.ts`.
- Preserve all runtime code, validation, query filters/order, update payload, missing-list error and auth/API contracts. BASE/HEAD Bun-transpiled JavaScript is byte-identical (574 bytes).
- Add five durable tests of the real action executor covering the configured-list lookup, non-archived-card filter, timestamp/update payload, missing-list rejection and invalid configs before DB access.

No payment, UI, config, suppression, dependency, deployment, stable or protection changes. **Independent review required; do not auto-approve or merge.**

## Verification
Fresh BASE `efdd42746ad048c35bf16666a063dc02d147c001` typecheck and full Bun tests were captured before edits.

| Gate | Result |
| --- | --- |
| ESLint both touched files | 0 errors, 0 warnings |
| Full ESLint | 2507 errors / 3 warnings, down from supplied post-230 2520 / 3; 12 action findings and 1 downstream registry finding removed |
| Real-handler tests | 5 pass on BASE and HEAD |
| Mutation sensitivity | Temporarily changing the archive filter from false to true produced the expected assertion failure (4 pass / 1 fail); restored before implementation. Not a pre-existing production defect. |
| `bun run typecheck` | BASE 148 → HEAD 147 complete multiline diagnostics; no added diagnostic blocks; only the broken import diagnostic removed |
| `bun test` | BASE 1170 pass / 3 skip / 180 fail / 30 errors → HEAD 1175 pass / 3 skip / 180 fail / 30 errors |
| Failure reconciliation | Identical file-qualified multisets: 150 named failures + 30 complete unhandled-error blocks = 180 aggregate failures; no additions/removals |
| Automation directory tests | 181 pass / 10 fail on both BASE production + new tests and HEAD; exact file-qualified failure multisets unchanged |
| `bun run build:client` | Pass |
| `git diff --check` | Pass |

## Coverage limits
The tests import and execute the real handler, using an explicit transaction fake at the DB boundary. They verify queries and payloads, not live PostgreSQL acceptance/atomicity, transaction rollback, engine authorization/registration, or pubsub. No UI changes; no browser/E2E claim. Existing full-suite and automation-suite failures remain unresolved and are not reported as green.

## Local evidence
All evidence: `/tmp/chimedeck-slice-20260909-152648/`
- `base-typecheck.log`, `base-test.log`, `head-typecheck.log`, `head-test.log`
- `baseline-comparison.json`, `compare.py`, `diagnostics-{base,head}.json`, `named_failures-{base,head}.json`, `unhandled_errors-{base,head}.json`
- `base-focused.log`, `mutation-red.log`, `head-focused.log`, `head-lint.log`, `head-full-lint.log`
- `base-automation-tests-with-new-tests.log`, `head-automation-tests.log`, `automation-comparison.json`
- `base-emitted.js`, `head-emitted.js`, `emitted-comparison.log`, `head-build.log`, `diff-check.log`, `gates.json`
These paths are local reviewer evidence, not remotely hosted artifacts.
