### PR TITLE
fix(lint): type automation custom-field action reads

### DIFF
--- a/server/extensions/automation/engine/actions/card/updateCustomFieldValue.test.ts
+++ b/server/extensions/automation/engine/actions/card/updateCustomFieldValue.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from 'bun:test';
+import type { Knex } from 'knex';
+import type { ActionContext } from '../../../common/types';
+import { cardUpdateCustomFieldValueAction as handler } from './updateCustomFieldValue';
+
+// Real action, fake transaction: verifies query/payload contracts, not PostgreSQL acceptance.
+function fixture(config: Record<string, unknown>, rows: Record<string, unknown> = {}) {
+  const calls: unknown[] = [];
+  const data: Record<string, unknown> = {
+    cards: { id: 'card', list_id: 'list' },
+    lists: { id: 'list', board_id: 'board' },
+    custom_fields: { id: 'field', board_id: 'board', field_type: config.fieldType, options: null },
+    ...rows,
+  };
+  const trx = ((table: string) => ({
+    where(filter: unknown) {
+      calls.push({ table, filter });
+      return {
+        first: () => Promise.resolve(data[table]),
+        update: (values: unknown) => {
+          calls.push({ update: values });
+          return Promise.resolve(1);
+        },
+      };
+    },
+    insert(values: unknown) {
+      calls.push({ insert: values });
+      return Promise.resolve([]);
+    },
+  })) as unknown as Knex.Transaction;
+  const context: ActionContext = {
+    automation: {
+      id: 'automation',
+      board_id: 'board',
+      created_by: 'actor',
+      name: 'Test',
+      automation_type: 'RULE',
+      is_enabled: true,
+      icon: null,
+      run_count: 0,
+      last_run_at: null,
+      created_at: new Date(0),
+      updated_at: new Date(0),
+    },
+    action: {
+      id: 'action',
+      automation_id: 'automation',
+      position: 0,
+      action_type: handler.type,
+      config: { fieldId: 'field', ...config },
+    },
+    event: { type: 'test', boardId: 'board', entityId: 'card', actorId: 'actor', payload: {} },
+    evalContext: { cardId: 'card', actorId: 'actor' },
+    trx,
+    postCommit() {
+      throw new Error('unexpected side effect');
+    },
+  };
+  return { calls, context };
+}
+
+const empty = {
+  value_text: null,
+  value_number: null,
+  value_date: null,
+  value_checkbox: null,
+  value_option_id: null,
+};
+
+describe('custom-field action transaction boundary', () => {
+  test('scopes reads and updates the existing value without inserting', async () => {
+    const { calls, context } = fixture(
+      { fieldType: 'NUMBER', valueNumber: 42 },
+      { card_custom_field_values: { id: 'value' } }
+    );
+    await handler.execute(context);
+    expect(calls).toEqual([
+      { table: 'cards', filter: { id: 'card' } },
+      { table: 'lists', filter: { id: 'list' } },
+      { table: 'custom_fields', filter: { id: 'field', board_id: 'board' } },
+      { table: 'card_custom_field_values', filter: { card_id: 'card', custom_field_id: 'field' } },
+      { table: 'card_custom_field_values', filter: { card_id: 'card', custom_field_id: 'field' } },
+      { update: { ...empty, value_number: 42 } },
+    ]);
+  });
+
+  test.each([
+    [
+      { fieldType: 'TEXT', valueText: 'Hello' },
+      { ...empty, value_text: 'Hello' },
+    ],
+    [
+      { fieldType: 'DATE', valueDate: '2026-01-02T03:00:00+03:00' },
+      { ...empty, value_date: '2026-01-02T00:00:00.000Z' },
+    ],
+    [
+      { fieldType: 'CHECKBOX', valueCheckbox: false },
+      { ...empty, value_checkbox: false },
+    ],
+  ])('inserts normalized columns for %j', async (config, columns) => {
+    const { calls, context } = fixture(config);
+    await handler.execute(context);
+    expect(calls.at(-1)).toEqual({
+      insert: {
+        id: expect.any(String) as unknown,
+        card_id: 'card',
+        custom_field_id: 'field',
+        ...columns,
+      },
+    });
+  });
+
+  test.each([[JSON.stringify([{ id: 'option' }])], [[{ id: 'option' }]]])(
+    'accepts dropdown options representation %j',
+    async (options) => {
+      const { calls, context } = fixture(
+        { fieldType: 'DROPDOWN', valueOptionId: 'option' },
+        { custom_fields: { field_type: 'DROPDOWN', options } }
+      );
+      await handler.execute(context);
+      expect(calls.at(-1)).toEqual({
+        insert: {
+          id: expect.any(String) as unknown,
+          card_id: 'card',
+          custom_field_id: 'field',
+          ...empty,
+          value_option_id: 'option',
+        },
+      });
+    }
+  );
+
+  test.each([
+    [{ cards: undefined }, 'card-not-found'],
+    [{ lists: undefined }, 'card-on-different-board'],
+    [{ lists: { board_id: 'other' } }, 'card-on-different-board'],
+    [{ custom_fields: undefined }, 'custom-field-not-found'],
+    [{ custom_fields: { field_type: 'TEXT' } }, 'custom-field-type-mismatch'],
+  ] as const)('rejects invalid scope or missing rows: %j', async (rows, error) => {
+    const { calls, context } = fixture({ fieldType: 'NUMBER', valueNumber: 1 }, rows);
+    expect(await handler.execute(context).catch((error: unknown) => error)).toEqual(
+      new Error(error)
+    );
+    expect(
+      calls.some(
+        (call) =>
+          typeof call === 'object' && call !== null && ('insert' in call || 'update' in call)
+      )
+    ).toBe(false);
+  });
+
+  test.each([[null], ['invalid json'], ['{}'], [[{ id: 'other' }]]])(
+    'rejects absent dropdown option in %j',
+    async (options) => {
+      const { calls, context } = fixture(
+        { fieldType: 'DROPDOWN', valueOptionId: 'option' },
+        { custom_fields: { field_type: 'DROPDOWN', options } }
+      );
+      expect(await handler.execute(context).catch((error: unknown) => error)).toEqual(
+        new Error('custom-field-option-not-found')
+      );
+      expect(calls).toHaveLength(3);
+    }
+  );
+
+  test('rejects missing card ID before querying', async () => {
+    const { calls, context } = fixture({ fieldType: 'NUMBER', valueNumber: 1 });
+    delete context.evalContext.cardId;
+    expect(await handler.execute(context).catch((error: unknown) => error)).toEqual(
+      new Error('card-id-missing')
+    );
+    expect(calls).toEqual([]);
+  });
+});

--- a/server/extensions/automation/engine/actions/card/updateCustomFieldValue.ts
+++ b/server/extensions/automation/engine/actions/card/updateCustomFieldValue.ts
@@ -5,6 +5,29 @@ import type { ActionHandler, ActionContext } from '../../../common/types';
 
 type FieldType = 'TEXT' | 'NUMBER' | 'DATE' | 'CHECKBOX' | 'DROPDOWN';
 
+// Read projections from migrations 0005_list, 0006_card and 0032_custom_fields.
+interface CardRow {
+  id: string;
+  list_id: string;
+}
+
+interface ListRow {
+  id: string;
+  board_id: string;
+}
+
+interface CustomFieldRow {
+  id: string;
+  board_id: string;
+  field_type: FieldType;
+  options: unknown; // Nullable JSONB; parseFieldOptions handles its runtime representation.
+}
+
+interface CustomFieldValueRow {
+  card_id: string;
+  custom_field_id: string;
+}
+
 interface DropdownOption {
   id: string;
   label?: string;
@@ -95,18 +118,18 @@ export const cardUpdateCustomFieldValueAction: ActionHandler = {
     const cardId = evalContext.cardId;
     if (!cardId) throw new Error('card-id-missing');
 
-    const card = await trx('cards').where({ id: cardId }).first();
+    const card = await trx<CardRow>('cards').where({ id: cardId }).first();
     if (!card) throw new Error('card-not-found');
 
-    const list = await trx('lists').where({ id: card.list_id }).first();
+    const list = await trx<ListRow>('lists').where({ id: card.list_id }).first();
     if (list?.board_id !== automation.board_id) throw new Error('card-on-different-board');
 
-    const field = await trx('custom_fields')
+    const field = await trx<CustomFieldRow>('custom_fields')
       .where({ id: config.fieldId, board_id: automation.board_id })
       .first();
     if (!field) throw new Error('custom-field-not-found');
 
-    const dbFieldType = String(field.field_type) as FieldType;
+    const dbFieldType = field.field_type;
     if (dbFieldType !== config.fieldType) throw new Error('custom-field-type-mismatch');
 
     if (config.fieldType === 'DROPDOWN') {
@@ -117,7 +140,7 @@ export const cardUpdateCustomFieldValueAction: ActionHandler = {
 
     const valueColumns = toValueColumns(config);
 
-    const existing = await trx('card_custom_field_values')
+    const existing = await trx<CustomFieldValueRow>('card_custom_field_values')
       .where({ card_id: cardId, custom_field_id: config.fieldId })
       .first();
 


### PR DESCRIPTION
## Scope
One non-payment server lint slice: the automation `card.update_custom_field_value` action's transaction reads.

- Add migration-derived local read projections for cards, lists, custom fields and existing card values (migrations `0005_list`, `0006_card`, `0032_custom_fields`). Include both consumed and filter columns; nullable JSONB options remain `unknown` at the existing parser boundary.
- Remove the now-redundant `String()` conversion of the non-null database field-type enum. Preserve queries, board-scope checks, config validation, error strings and all update/insert payloads.
- Add 16 durable tests calling the real action with a fake transaction. They cover scoped query order, existing-value update, new-value insertion, all five field types, option array/JSON representations, missing rows, cross-board denial and invalid/missing dropdown options.
- No payment, UI, auth/API, configuration, dependency, deployment or stable changes. No suppressions or repo-wide autofix.

## Verification
Started clean on freshly fetched/fast-forwarded main `7ebeb2e697fb6187d26977020f8186e98db726e2`; fresh BASE typecheck and complete `bun test` captured before editing.

| Gate | Result |
| --- | --- |
| Focused ESLint, both touched files | **0 errors, 0 warnings** |
| Real-action focused tests | **16 pass, 0 fail** |
| Full ESLint | **2498 errors / 3 warnings**, down 9 errors from main's 2507 / 3 |
| `bun run typecheck` | Existing failure: **147 complete multiline diagnostic blocks**, identical BASE/HEAD multiset |
| `bun test` | BASE **1175 pass / 3 skip / 180 fail / 30 errors**; HEAD **1191 pass / 3 skip / 180 fail / 30 errors** |
| Full failure comparison | **150 file-qualified named failures + 30 complete file-qualified unhandled-error blocks = 180 aggregate failures**, identical BASE/HEAD multisets; no additions/removals |
| `bun run build:client` | Pass |
| `git diff --check` | Pass |

Tests passed against BASE before production typing. Temporary removal of the custom-field board filter produced a meaningful failing query-contract assertion; the mutation was restored. This is mutation sensitivity evidence, not a pre-existing production defect.

Bun-transpiled BASE/HEAD JavaScript was compared. The **only emitted delta** is `String(field.field_type)` → `field.field_type`, equivalent for the migration's required enum strings. Everything else is byte-identical; this is not a claim that the whole patch is erased-only. Unsupported non-string database values are not part of the migration contract.

## Coverage limitations
Fake transaction tests verify the real handler's control flow, query shapes and payloads, **not** live PostgreSQL schema acceptance, constraints, concurrency, transaction rollback, scheduler/engine composition or pubsub delivery. No UI was changed or UI/E2E run. Existing full-suite and typecheck debt remains; required CI verify does not replace these local comparisons.

## Evidence
Local evidence directory: `/tmp/chimedeck-slice-232-s9WDyT/`

- `base-typecheck.txt`, `head-typecheck.txt`
- `base-test.txt`, `head-test.txt`, `base-parsed.json`, `head-parsed.json`
- `compare.py`, `comparison.json` (complete multiline diagnostic/error blocks; reconciled totals)
- `base-focused.txt`, `mutation-red.txt`, `head-focused.txt`
- `focused-lint.txt`, `head-full-lint.txt`, `build-client.txt`
- `base-emitted.js`, `head-emitted.js`, `emitted-comparison.txt` (diff and SHA-256 hashes)

Implementation author: matthewvryanjh. Ready for separate parent review; **do not approve or merge as part of this implementation task**.
