### PR TITLE
refactor(board): type middleware database row boundary

### DIFF
--- a/server/extensions/board/middlewares/boardBoundary.fixture.ts
+++ b/server/extensions/board/middlewares/boardBoundary.fixture.ts
@@ -1,0 +1,68 @@
+// Executed in a child process so Bun module mocks cannot leak into other suites.
+// Real middleware, fake DB: no live PostgreSQL or route/auth-composition coverage.
+import assert from 'node:assert/strict';
+import { mock } from 'bun:test';
+import type { BoardScopedRequest } from './requireBoardWritable';
+
+const [mode, scenario] = process.argv.slice(2);
+assert.ok(mode === 'read' || mode === 'write');
+assert.ok(
+  scenario === 'active' || scenario === 'archived' || scenario === 'missing' || scenario === 'error'
+);
+const board =
+  scenario === 'missing'
+    ? undefined
+    : {
+        id: 'board-1',
+        workspace_id: 'workspace-1',
+        title: 'Board',
+        state: scenario === 'archived' ? 'ARCHIVED' : 'ACTIVE',
+        created_at: null,
+        description: 'Extra fields must survive attachment',
+      };
+const calls: unknown[] = [];
+const failure = new Error('database unavailable');
+await mock.module('../../../common/db', () => ({
+  db: (table: string) => ({
+    where(filter: unknown) {
+      calls.push({ table, filter });
+      return {
+        first() {
+          return scenario === 'error' ? Promise.reject(failure) : Promise.resolve(board);
+        },
+      };
+    },
+  }),
+}));
+const { requireBoardAccess } = await import('./requireBoardAccess');
+const { requireBoardWritable } = await import('./requireBoardWritable');
+const handler = mode === 'read' ? requireBoardAccess : requireBoardWritable;
+const req: BoardScopedRequest = new Request('http://127.0.0.1/boards/board-1');
+if (scenario === 'error') {
+  await assert.rejects(handler(req, 'board-1'), (error: unknown) => error === failure);
+  assert.equal(req.board, undefined);
+} else {
+  const response = await handler(req, 'board-1');
+  if (scenario === 'missing') {
+    assert.ok(response);
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), {
+      error: { code: 'board-not-found', message: 'Board not found' },
+    });
+    assert.equal(req.board, undefined);
+  } else if (mode === 'write' && scenario === 'archived') {
+    assert.ok(response);
+    assert.equal(response.status, 403);
+    assert.deepEqual(await response.json(), {
+      error: {
+        code: 'board-is-archived',
+        message: 'This board is archived and cannot be modified.',
+      },
+    });
+    assert.equal(req.board, undefined);
+  } else {
+    assert.equal(response, null);
+    assert.equal(req.board, board);
+  }
+}
+assert.deepEqual(calls, [{ table: 'boards', filter: { id: 'board-1' } }]);

--- a/server/extensions/board/middlewares/boardBoundary.test.ts
+++ b/server/extensions/board/middlewares/boardBoundary.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const fixture = fileURLToPath(new URL('./boardBoundary.fixture.ts', import.meta.url));
+
+// Child isolation protects both the real middleware imports and other suites' DB mocks.
+for (const mode of ['read', 'write']) {
+  test.each(['active', 'archived', 'missing', 'error'])(
+    `${mode} board boundary: %s`,
+    (scenario) => {
+      const result = spawnSync(process.execPath, [fixture, mode, scenario], { encoding: 'utf8' });
+      expect(result.error).toBeUndefined();
+      expect(result.stderr).toBe('');
+      expect(result.status).toBe(0);
+    }
+  );
+}

--- a/server/extensions/board/middlewares/requireBoardAccess.ts
+++ b/server/extensions/board/middlewares/requireBoardAccess.ts
@@ -4,13 +4,13 @@ import { db } from '../../../common/db';
 
 export type { BoardScopedRequest } from './requireBoardWritable';
 
-import type { BoardScopedRequest } from './requireBoardWritable';
+import type { BoardScopedRequest, ScopedBoardRow } from './requireBoardWritable';
 
 export async function requireBoardAccess(
   req: BoardScopedRequest,
   boardId: string,
 ): Promise<Response | null> {
-  const board = await db('boards').where({ id: boardId }).first();
+  const board = await db<ScopedBoardRow>('boards').where({ id: boardId }).first();
 
   if (!board) {
     return Response.json(

--- a/server/extensions/board/middlewares/requireBoardWritable.ts
+++ b/server/extensions/board/middlewares/requireBoardWritable.ts
@@ -1,8 +1,18 @@
 // Middleware — returns 403 if the target board is ARCHIVED, preventing all mutations.
 import { db } from '../../../common/db';
 
+// Core board columns from db/migrations/0004_board.ts. The timestamp is nullable;
+// PostgreSQL normally returns Date, while serialized fixtures may use strings.
+export interface ScopedBoardRow {
+  id: string;
+  workspace_id: string;
+  title: string;
+  state: 'ACTIVE' | 'ARCHIVED';
+  created_at: Date | string | null;
+}
+
 export interface BoardScopedRequest extends Request {
-  board?: { id: string; workspace_id: string; title: string; state: string; created_at: string };
+  board?: ScopedBoardRow;
 }
 
 // Loads the board by ID and attaches it to the request.
@@ -11,7 +21,7 @@ export async function requireBoardWritable(
   req: BoardScopedRequest,
   boardId: string,
 ): Promise<Response | null> {
-  const board = await db('boards').where({ id: boardId }).first();
+  const board = await db<ScopedBoardRow>('boards').where({ id: boardId }).first();
 
   if (!board) {
     return Response.json(


### PR DESCRIPTION
## Scope
- Type the shared board read/writability middleware Knex boundary with the core columns from `db/migrations/0004_board.ts` (including nullable timestamp), removing five ESLint errors.
- Preserve queries, complete attached row, archived-read access, archived-write rejection, 404/403 bodies, and database-error propagation. Both production files emit byte-identical Bun JavaScript versus base.
- Add eight durable real-middleware cases with fake DB transport in child processes, preventing Bun module-mock leakage. No payment, UI, config, dependency, deployment, or stable changes.

## Verification
Fresh baseline captured before edits at `9ee7ff4d818183f36a121f1b49247e46221270ed` after clean fetch/fast-forward check.

| Gate | Result |
| --- | --- |
| Focused ESLint, all four touched files | 0 errors / 0 warnings |
| Full ESLint | 2498 → 2493 errors; unchanged 3 warnings |
| New boundary tests against BASE | 8 pass |
| Mutation sensitivity | Temporary ARCHIVED → ACTIVE guard inversion: 2 expected failures, then restored |
| HEAD focused tests | 20 pass (8 real middleware + 12 existing adjacent logic tests) |
| `bun run typecheck` | Exit 2 both; 147 complete multiline diagnostics, identical multisets |
| `bun test` | Exit 1 both; 1191 → 1199 pass, 3 skip, 180 aggregate fail |
| Failure reconciliation | 150 file-qualified named failures + 30 complete file-qualified unhandled-error blocks = 180, identical BASE/HEAD multisets |
| `bun run build:client` | Pass |
| `git diff --check` | Pass |
| Bun-transpiled production JS | Byte-identical in both touched production files |

## Local evidence
All paths are on the implementation host under `/tmp/chimedeck-233-`:
- `base-typecheck.txt`, `base-test.txt`, `head-typecheck.txt`, `head-test.txt`
- `compare.py`, `base-parsed.json`, `head-parsed.json`, `comparison.json` (complete diagnostic/error blocks and reconciled counts; no additions/removals)
- `base-focused.txt`, `mutation-red.txt`, `head-focused.txt`
- `focused-lint.txt`, `full-lint.txt`, `build-client.txt`, `diff-check.txt`
- `emitted.ts`, `emitted-comparison.json`, `requireBoardAccess-{base,head}.js`, `requireBoardWritable-{base,head}.js`

## Coverage limits / review
The tests execute real middleware and assert exact DB table/filter, response status/body, same-object row attachment (including extra columns), missing/archived cases and thrown DB errors. DB is fake: no live PostgreSQL, HTTP routing/auth/membership composition, or browser/E2E claim. No UI changed. Existing full-suite/typecheck debt remains; required CI `verify` is a narrower install/build/diff gate. Independent parent review is required; implementation agent will not approve or merge.
