### PR TITLE
refactor(card): type writable middleware database boundary

### DIFF
--- a/server/extensions/card/middlewares/cardWritable.fixture.ts
+++ b/server/extensions/card/middlewares/cardWritable.fixture.ts
@@ -1,0 +1,67 @@
+import { mock } from 'bun:test';
+import assert from 'node:assert/strict';
+import type { CardScopedRequest } from './requireCardWritable';
+
+const scenario = process.argv[2];
+const card = {
+  id: 'card-a', list_id: 'list-a', title: 'Card', description: null,
+  position: 'a', archived: scenario === 'card-archived' || scenario === 'both-archived',
+  due_date: null, created_at: null, updated_at: new Date('2026-01-01'),
+  extra_column: 'preserved',
+};
+const list = { id: 'list-a', board_id: 'board-a', archived: true };
+const board = {
+  id: 'board-a', workspace_id: 'workspace-a', title: 'Board',
+  state: scenario === 'board-archived' || scenario === 'both-archived' ? 'ARCHIVED' : 'ACTIVE',
+  created_at: null, extra_column: 'preserved',
+};
+const calls: { table: string; filter: unknown }[] = [];
+const failure = new Error('database unavailable');
+void mock.module('../../../common/db', () => ({
+  db: (table: string) => ({
+    where: (filter: unknown) => ({
+      first: () => {
+        calls.push({ table, filter });
+        if (scenario === `error-${table}`) return Promise.reject(failure);
+        const rows: Record<string, unknown> = { cards: card, lists: list, boards: board };
+        return Promise.resolve(scenario === `missing-${table}` ? undefined : rows[table]);
+      },
+    }),
+  }),
+}));
+const { requireCardWritable } = await import('./requireCardWritable');
+const req: CardScopedRequest = new Request('http://127.0.0.1/cards/card-a');
+if (scenario?.startsWith('error-')) {
+  await assert.rejects(requireCardWritable(req, 'card-a'), (error: unknown) => error === failure);
+} else {
+  const response = await requireCardWritable(req, 'card-a');
+  const errors: Record<string, [number, string, string]> = {
+    'missing-cards': [404, 'card-not-found', 'Card not found'],
+    'missing-lists': [404, 'card-not-found', 'Card parent list not found'],
+    'missing-boards': [404, 'board-not-found', 'Board not found'],
+    'board-archived': [403, 'board-is-archived', 'This board is archived and cannot be modified.'],
+    'both-archived': [403, 'board-is-archived', 'This board is archived and cannot be modified.'],
+    'card-archived': [403, 'card-archived', 'Card is archived and cannot be modified'],
+  };
+  const expected = errors[scenario ?? ''];
+  if (expected) {
+    assert.ok(response);
+    assert.equal(response.status, expected[0]);
+    assert.deepEqual(await response.json(), { error: { code: expected[1], message: expected[2] } });
+  } else {
+    assert.equal(scenario, 'active');
+    assert.equal(response, null);
+    assert.equal(req.card, card);
+    assert.equal(req.board, board);
+  }
+}
+const count = scenario?.endsWith('-cards') ? 1 : scenario?.endsWith('-lists') ? 2 : 3;
+assert.deepEqual(calls, [
+  { table: 'cards', filter: { id: 'card-a' } },
+  { table: 'lists', filter: { id: 'list-a' } },
+  { table: 'boards', filter: { id: 'board-a' } },
+].slice(0, count));
+if (scenario !== 'active') {
+  assert.equal(req.card, undefined);
+  assert.equal(req.board, undefined);
+}

--- a/server/extensions/card/middlewares/cardWritable.test.ts
+++ b/server/extensions/card/middlewares/cardWritable.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const fixture = fileURLToPath(new URL('./cardWritable.fixture.ts', import.meta.url));
+
+// Keep shared DB mocks out of the suite and import the real middleware in each child.
+test.each([
+  'active', 'missing-cards', 'missing-lists', 'missing-boards',
+  'board-archived', 'card-archived', 'both-archived',
+  'error-cards', 'error-lists', 'error-boards',
+])('card writable boundary: %s', (scenario) => {
+  const result = spawnSync(process.execPath, [fixture, scenario], { encoding: 'utf8' });
+  expect(result.error).toBeUndefined();
+  expect(result.stderr).toBe('');
+  expect(result.status).toBe(0);
+});

--- a/server/extensions/card/middlewares/requireCardWritable.ts
+++ b/server/extensions/card/middlewares/requireCardWritable.ts
@@ -1,19 +1,29 @@
 // Middleware — returns 403 if the target card is archived or the board is ARCHIVED.
 import { db } from '../../../common/db';
-import type { BoardScopedRequest } from '../../board/middlewares/requireBoardWritable';
+import type { BoardScopedRequest, ScopedBoardRow } from '../../board/middlewares/requireBoardWritable';
+
+// Core card columns from 0006_card.ts; timestamps are nullable and PostgreSQL
+// returns Date values, while serialized fixtures may use strings.
+interface ScopedCardRow {
+  id: string;
+  list_id: string;
+  title: string;
+  description: string | null;
+  position: string;
+  archived: boolean;
+  due_date: Date | string | null;
+  created_at: Date | string | null;
+  updated_at: Date | string | null;
+}
+
+// Parent lookup columns from 0005_list.ts.
+interface CardParentListRow {
+  id: string;
+  board_id: string;
+}
 
 export interface CardScopedRequest extends BoardScopedRequest {
-  card?: {
-    id: string;
-    list_id: string;
-    title: string;
-    description: string | null;
-    position: string;
-    archived: boolean;
-    due_date: string | null;
-    created_at: string;
-    updated_at: string;
-  };
+  card?: ScopedCardRow;
 }
 
 // Loads the card by ID, loads its board, and attaches both to the request.
@@ -22,7 +32,7 @@ export async function requireCardWritable(
   req: CardScopedRequest,
   cardId: string,
 ): Promise<Response | null> {
-  const card = await db('cards').where({ id: cardId }).first();
+  const card = await db<ScopedCardRow>('cards').where({ id: cardId }).first();
 
   if (!card) {
     return Response.json(
@@ -31,7 +41,7 @@ export async function requireCardWritable(
     );
   }
 
-  const list = await db('lists').where({ id: card.list_id }).first();
+  const list = await db<CardParentListRow>('lists').where({ id: card.list_id }).first();
   if (!list) {
     return Response.json(
       { error: { code: 'card-not-found', message: 'Card parent list not found' } },
@@ -39,7 +49,7 @@ export async function requireCardWritable(
     );
   }
 
-  const board = await db('boards').where({ id: list.board_id }).first();
+  const board = await db<ScopedBoardRow>('boards').where({ id: list.board_id }).first();
   if (!board) {
     return Response.json(
       { error: { code: 'board-not-found', message: 'Board not found' } },


### PR DESCRIPTION
## Scope
Type the card-writability middleware's card → list → board reads using migrations `0006_card.ts`, `0005_list.ts` and the existing migration-derived `ScopedBoardRow` (`0004_board.ts`). Correct the request's card timestamp typing to nullable `Date | string`; preserve complete row attachment, all queries, response bodies/statuses and guard order.

Production Bun-transpiled JavaScript is byte-identical to BASE. No non-erased production changes. No payment/monetisation, UI, configuration, dependency, deployment or stable changes.

## Executable evidence
BASE: `67e448142c5fe3fdd2131c4cbc0888a95e302c1e`, clean fetch/fast-forward main before branching. Fresh typecheck and full tests captured before edits.

- Focused ESLint: **0 errors, 0 warnings** across all three touched files.
- Full ESLint: **2482 errors / 3 warnings**, down 11 errors from 2493 / 3.
- Durable real-middleware subprocess tests: **10 pass** against BASE; final card + adjacent board boundaries **18 pass**.
- Temporary wrong-parent-filter mutation failed with the expected `card-a` versus `list-a` query assertion; restored before the typing change. This is mutation sensitivity, not a production bug fix.
- `bun run typecheck`: exit 2 on both; **147 complete multiline diagnostic blocks identical**.
- `bun test`: BASE **1199 pass / 3 skip / 180 fail / 30 errors**; HEAD **1209 pass / 3 skip / 180 fail / 30 errors**. File-qualified named-failure multiset **150 identical**, complete file-qualified unhandled-error-block multiset **30 identical**. Both reconcile `150 + 30 = 180`; no added or removed failures/errors.
- `bun run build:client`: exit 0 (existing chunk-size warnings).
- `git diff --check`: pass.

Local evidence directory: `/tmp/chimedeck-slice234.oLzmMV/` (`base-typecheck.log`, `base-test.log`, `head-typecheck.log`, `head-test.log`, `base-identities.json`, `head-identities.json`, `comparison.json`, `compare.py`, `focused-base.log`, `mutation-red.log`, `focused-head.log`, `focused-lint.log`, `full-lint.log`, `build.log`, `base-emitted.js`, `head-emitted.js`, `emitted-comparison.log`).

## Coverage limits
Tests import the real middleware with a child-process-isolated fake DB. Cover missing card/list/board, archived card/board and precedence when both are archived, active acceptance even with an archived parent list (existing behavior), query order/filter/early exit, unchanged full object identity including additional columns and nullable/Date timestamps, and errors from each DB lookup with no request attachment. They do **not** prove live PostgreSQL execution, router/auth composition or UI/E2E. No UI changed. Typings do not add runtime validation. Baseline repository tests/typecheck remain red as detailed above.

Implementation authored by `matthewvryanjh`; independent parent review required. **Do not approve or merge as part of this task.**
