### PR TITLE
refactor: type plugin CSP origin database projection

### DIFF
--- a/server/extensions/plugins/mods/fixtures/pluginCspOrigins.ts
+++ b/server/extensions/plugins/mods/fixtures/pluginCspOrigins.ts
@@ -1,0 +1,45 @@
+import { mock } from 'bun:test';
+import assert from 'node:assert/strict';
+
+const scenario = process.argv[2];
+const rows = [
+  { connector_url: 'https://plugin.example/path?q=1', whitelisted_domains: ['https://api.example/a', 'https://api.example/b', 'http://localhost:8080/path', 'invalid', 'data:text/plain,hello'] },
+  { connector_url: 'https://plugin.example/other', whitelisted_domains: null },
+  { connector_url: null, whitelisted_domains: { url: 'https://ignored.example' } },
+  { connector_url: 'not a URL', whitelisted_domains: '["https://ignored.example"]' },
+  { connector_url: 'data:text/plain,hello', whitelisted_domains: [] },
+  { connector_url: 'http://localhost:3000/plugin', whitelisted_domains: ['https://second.example/path'] },
+];
+let queries = 0;
+const failure = new Error('database unavailable');
+await mock.module('../../../../common/db', () => ({
+  db: (table: string) => {
+    assert.equal(table, 'plugins');
+    queries += 1;
+    return {
+      where(filter: unknown) {
+        assert.deepEqual(filter, { is_active: true });
+        return {
+          select(...columns: string[]) {
+            assert.deepEqual(columns, ['connector_url', 'whitelisted_domains']);
+            return scenario === 'failure'
+              ? Promise.reject(failure)
+              : Promise.resolve(scenario === 'empty' ? [] : rows);
+          },
+        };
+      },
+    };
+  },
+}));
+const { getPluginCspOrigins } = await import('../getPluginCspOrigins');
+if (scenario === 'failure') {
+  await assert.rejects(getPluginCspOrigins(), (error: unknown) => error === failure);
+} else {
+  assert.deepEqual(await getPluginCspOrigins(), scenario === 'empty'
+    ? { frameSrc: [], connectSrc: [] }
+    : {
+      frameSrc: ['https://plugin.example', 'http://localhost:3000'],
+      connectSrc: ['https://api.example', 'http://localhost:8080', 'https://second.example'],
+    });
+}
+assert.equal(queries, 1);

--- a/server/extensions/plugins/mods/getPluginCspOrigins.test.ts
+++ b/server/extensions/plugins/mods/getPluginCspOrigins.test.ts
@@ -1,0 +1,13 @@
+import { test, expect } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const fixture = fileURLToPath(new URL('./fixtures/pluginCspOrigins.ts', import.meta.url));
+
+for (const scenario of ['origins', 'empty', 'failure']) {
+  test(`getPluginCspOrigins preserves ${scenario} contract in an isolated process`, () => {
+    const result = spawnSync(process.execPath, [fixture, scenario], { encoding: 'utf8' });
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+  });
+}

--- a/server/extensions/plugins/mods/getPluginCspOrigins.ts
+++ b/server/extensions/plugins/mods/getPluginCspOrigins.ts
@@ -6,6 +6,14 @@
 // connect-src so scripts inside the plugin iframe can reach their declared APIs.
 import { db } from '../../../common/db';
 
+// Migrations 0021/0023: nullable connector text, required active flag,
+// and unconstrained nullable JSONB (not necessarily an array of strings).
+interface PluginCspRow {
+  connector_url: string | null;
+  is_active: boolean;
+  whitelisted_domains: unknown;
+}
+
 export interface PluginCspOrigins {
   /** Origins to add to frame-src (connector_url of each active plugin). */
   frameSrc: string[];
@@ -30,7 +38,7 @@ function toOrigin(url: string): string | null {
  * if performance becomes a concern.
  */
 export async function getPluginCspOrigins(): Promise<PluginCspOrigins> {
-  const plugins = await db('plugins')
+  const plugins = await db<PluginCspRow>('plugins')
     .where({ is_active: true })
     .select('connector_url', 'whitelisted_domains');
 
@@ -40,7 +48,7 @@ export async function getPluginCspOrigins(): Promise<PluginCspOrigins> {
   for (const plugin of plugins) {
     // connector_url → frame-src so the iframe can be loaded.
     if (plugin.connector_url) {
-      const origin = toOrigin(plugin.connector_url as string);
+      const origin = toOrigin(plugin.connector_url);
       if (origin) frameSrcSet.add(origin);
     }
 


### PR DESCRIPTION
## Scope
Type the plugin CSP-origin database projection from migrations 0021/0023: nullable connector text, non-null active flag, and unconstrained nullable JSONB. Preserve active-only filtering, selected columns, URL parsing, deduplication/insertion order, and rejection propagation. No UI, payments, configuration, dependency or deployment changes.

Add durable real-function tests with a child-process DB fixture, so shared Bun mocks cannot leak into the suite. Tests cover duplicate/path normalization, invalid/opaque URLs, nullable connectors, null/object/string/array JSONB, explicit ports, empty results, and DB rejection. Active filter and projection are asserted. Tests passed on BASE; a temporary active-filter mutation failed and was restored before implementation.

## Verification
BASE: f01373c691528a30acaf3d591ab6f6e4de81288f (fresh clean main, fetched/fast-forward checked).
- All three touched TypeScript files: focused ESLint **0 errors / 0 warnings**.
- Full lint: **2482 → 2479 errors**, 3 warnings unchanged.
- Focused tests: **3 pass / 0 fail**, BASE and HEAD.
- `bun run typecheck`: exit 2, **147 → 147** complete multiline diagnostic blocks, identical multisets.
- `bun test`: exit 1, **1209 → 1212 pass**, 3 skip, 180 fail, 30 errors unchanged. Parsed **150 file-qualified named failures + 30 file-qualified complete unhandled-error blocks = 180**, identical BASE/HEAD multisets. No new failures.
- `bun run build:client`: exit 0.
- `git diff --check`: exit 0.
- BASE/HEAD Bun-transpiled production JavaScript: **byte-identical**. No non-erased production changes.

## Evidence and limits
Local evidence directory: `/tmp/chimedeck-slice-20260909-161358/`.
`base-{typecheck,test,focused}.log`, `mutation-red.log`, `head-{eslint,focused,typecheck,test,build,full-lint}.log`, `comparison.json`, `compare.py`, `{base,head}-{diagnostics,failures,unhandled}.json`, `{base,head}-emitted.js`, `emission.log`.

These are real-function tests with fake DB transport, not live PostgreSQL, authenticated HTTP, cache/helmet composition, or browser CSP enforcement. Existing registry writes describe JSONB as text[]; this slice does not change or validate those writes. Existing broad-suite failures remain. No UI changed, so UI/E2E was not run.

Implementation author: matthewvryanjh. Independent review required; no approval or merge performed.
