### PR TITLE
refactor(users): type avatar proxy database boundary

### DIFF
--- a/server/extensions/users/api/avatar/proxy.fixture.ts
+++ b/server/extensions/users/api/avatar/proxy.fixture.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { mock } from 'bun:test';
+
+let authError: Response | undefined;
+let row: { id: string; avatar_url: string | null } | undefined;
+const calls: unknown[] = [];
+let signError: Error | undefined;
+void mock.module('../../../auth/middlewares/authentication', () => ({
+  authenticate: (req: Request) => {
+    calls.push(['authenticate', req.url]);
+    return Promise.resolve(authError);
+  },
+}));
+void mock.module('../../../../common/db', () => ({
+  db: (table: string) => {
+    calls.push(['db', table]);
+    return {
+      where: (condition: unknown) => {
+        calls.push(['where', condition]);
+        return {
+          select: (...columns: string[]) => {
+            calls.push(['select', columns]);
+            return { first: () => Promise.resolve(row) };
+          },
+        };
+      },
+    };
+  },
+}));
+void mock.module('../../../attachment/common/presign', () => ({
+  presignGetUrl: (input: { s3Key: string; ttlSeconds: number }) => {
+    calls.push(['presign', input]);
+    return signError
+      ? Promise.reject(signError)
+      : Promise.resolve({ url: 'https://signed.example/avatar?token=secret' });
+  },
+}));
+// Keep the real key extractor; only replace its S3 configuration dependency.
+void mock.module('../../../attachment/common/config/s3', () => ({
+  s3Config: { bucket: 'avatars-bucket' },
+  s3Client: {},
+}));
+const { handleAvatarProxy } = await import('./proxy');
+const req = new Request('http://127.0.0.1/api/v1/users/target/avatar');
+function reset(avatar: string | null | undefined) {
+  calls.length = 0;
+  authError = undefined;
+  signError = undefined;
+  row = avatar === undefined ? undefined : { id: 'target', avatar_url: avatar };
+}
+reset('avatars/target.png');
+authError = Response.json({ error: 'unauthorized' }, { status: 401 });
+assert.equal(await handleAvatarProxy(req, 'target'), authError);
+assert.deepEqual(calls, [['authenticate', req.url]]);
+
+for (const avatar of [undefined, null, '']) {
+  reset(avatar);
+  const response = await handleAvatarProxy(req, 'target');
+  assert.equal(response.status, 404);
+  assert.deepEqual(await response.json(), avatar === undefined
+    ? { name: 'user-not-found', data: { message: 'User not found' } }
+    : { name: 'avatar-not-set', data: { message: 'User has no avatar' } });
+  assert.deepEqual(calls, [
+    ['authenticate', req.url], ['db', 'users'], ['where', { id: 'target' }],
+    ['select', ['id', 'avatar_url']],
+  ]);
+}
+reset('https://github.example/avatar.png');
+const external = await handleAvatarProxy(req, 'target');
+assert.equal(external.status, 302);
+assert.equal(external.headers.get('location'), 'https://github.example/avatar.png');
+assert.equal(calls.length, 4);
+
+for (const avatar of ['avatars/target.png', 'https://s3.example/avatars-bucket/avatars/target.png']) {
+  reset(avatar);
+  const response = await handleAvatarProxy(req, 'target');
+  assert.equal(response.status, 302);
+  assert.equal(response.headers.get('location'), 'https://signed.example/avatar?token=secret');
+  assert.equal(await response.text(), '');
+  assert.deepEqual(calls, [
+    ['authenticate', req.url], ['db', 'users'], ['where', { id: 'target' }],
+    ['select', ['id', 'avatar_url']],
+    ['presign', { s3Key: 'avatars/target.png', ttlSeconds: 60 }],
+  ]);
+}
+reset('avatars/target.png');
+signError = new Error('signing failed');
+await assert.rejects(handleAvatarProxy(req, 'target'), signError);

--- a/server/extensions/users/api/avatar/proxy.test.ts
+++ b/server/extensions/users/api/avatar/proxy.test.ts
@@ -1,0 +1,14 @@
+import { test, expect } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+test('real avatar proxy preserves authentication, lookup, redirects and signing failures', () => {
+  // Shared DB/auth mocks must not leak into the full Bun suite.
+  const result = spawnSync(process.execPath, [fileURLToPath(new URL('./proxy.fixture.ts', import.meta.url))], {
+    encoding: 'utf8',
+    timeout: 20_000,
+  });
+  expect(result.error).toBeUndefined();
+  expect(result.stderr).toBe('');
+  expect(result.status).toBe(0);
+});

--- a/server/extensions/users/api/avatar/proxy.ts
+++ b/server/extensions/users/api/avatar/proxy.ts
@@ -11,11 +11,17 @@ import { presignGetUrl } from '../../../attachment/common/presign';
 
 const PROXY_TTL_SECONDS = 60;
 
+// db/migrations/0002_auth.ts: primary string ID and nullable avatar URL.
+interface AvatarUserRow {
+  id: string;
+  avatar_url: string | null;
+}
+
 export async function handleAvatarProxy(req: Request, userId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const user = await db('users').where({ id: userId }).select('id', 'avatar_url').first();
+  const user = await db<AvatarUserRow>('users').where({ id: userId }).select('id', 'avatar_url').first();
   if (!user) {
     return Response.json(
       { name: 'user-not-found', data: { message: 'User not found' } },
@@ -30,11 +36,11 @@ export async function handleAvatarProxy(req: Request, userId: string): Promise<R
     );
   }
 
-  const s3Key = extractS3KeyFromAvatarUrl({ avatarUrl: user.avatar_url as string });
+  const s3Key = extractS3KeyFromAvatarUrl({ avatarUrl: user.avatar_url });
 
   if (!s3Key) {
     // External avatar URL (e.g. GitHub OAuth) — proxy as a direct redirect
-    return Response.redirect(user.avatar_url as string, 302);
+    return Response.redirect(user.avatar_url, 302);
   }
 
   const { url } = await presignGetUrl({ s3Key, ttlSeconds: PROXY_TTL_SECONDS });


### PR DESCRIPTION
## Scope
- Type the avatar proxy's users read using `id: string` / `avatar_url: string | null`, derived from `db/migrations/0002_auth.ts`; remove two now-redundant string assertions.
- Production BASE/HEAD Bun-transpiled JavaScript is byte-identical: no non-erased production changes, authentication/API/redirect/signing behavior unchanged.
- Add a durable real-handler regression executed in a child Bun process to isolate shared DB/auth/S3 mocks. It checks denial before DB access, exact user filter/projection, missing user/null/empty avatar responses, external redirect, raw/path-style S3 key extraction, 60-second signing, empty redirect body and signing-error propagation.
- No payments, UI, configuration, dependencies, deployment or stable changes.

## Executed validation
Fresh BASE `2d2f5d3802216a1ba25faa08d1319cf16da925a4` typecheck/full suite were captured before edits.
- Focused ESLint: all 3 touched files zero errors/warnings.
- Regression: BASE 1 pass; temporary wrong-user query-filter mutation failed on the exact filter assertion (sensitivity RED, not a pre-existing defect); restored HEAD 1 pass.
- `bun run typecheck`: BASE and HEAD exit 2, exactly the same 147 complete multiline diagnostic blocks.
- `bun test`: BASE 1212 pass / 3 skip / 180 fail / 30 errors; HEAD 1213 pass / 3 skip / 180 fail / 30 errors. File-qualified named-failure multisets identical (150); file-qualified complete unhandled-error blocks identical (30). 150 + 30 reconciles to 180 aggregate failures in both runs. No added/removed diagnostic or failure identities.
- `bun run build:client`: exit 0.
- `git diff --check`: exit 0.
- Full lint: 2475 errors / 3 warnings, down four errors from supplied post-235 baseline 2479 / 3; still fails on unrelated debt.

## Evidence and limitations
Local artifact directory: `/tmp/chimedeck-slice-20260909-162403/`.
`base-typecheck.txt`, `head-typecheck.txt`, `base-test.txt`, `head-test.txt`, `base-parsed.json`, `head-parsed.json`, `comparison.json`, `compare.py`, `focused-base.txt`, `mutation-red.txt`, `focused-head.txt`, `focused-lint.txt`, `full-lint.txt`, `build-client.txt`, `emitted-js.txt`, `base.js`, `head.js`.

Tests run the real proxy and real key extractor, with fake authentication result, DB query chain, signer and S3 configuration. They do not establish live PostgreSQL acceptance, live credential verification, real S3 signing/network redirects or router/browser composition. No UI changes; UI/E2E not run. Existing global suite failures remain, not represented as green. Independent parent review required; this implementation context will not approve or merge.
