### PR TITLE
refactor(notifications): type preference guard database reads

### DIFF
--- a/server/extensions/notifications/mods/__tests__/fixtures/preferenceGuards.ts
+++ b/server/extensions/notifications/mods/__tests__/fixtures/preferenceGuards.ts
@@ -1,0 +1,48 @@
+import { strict as assert } from 'node:assert';
+import { mock } from 'bun:test';
+
+let result: Record<string, boolean> | undefined;
+const state: { failure?: Error } = {};
+const calls: unknown[] = [];
+void mock.module('../../../../../common/db', () => ({
+  db(table: string) {
+    calls.push(table);
+    return {
+      where(filter: Record<string, string>) {
+        calls.push(filter);
+        return this;
+      },
+      select(...columns: string[]) {
+        calls.push(columns);
+        return this;
+      },
+      first() {
+        calls.push('first');
+        return state.failure ? Promise.reject(state.failure) : Promise.resolve(result);
+      },
+    };
+  },
+}));
+
+const { globalPreferenceGuard } = await import('../../globalPreferenceGuard');
+const { preferenceGuard, NOTIFICATION_TYPES } = await import('../../preferenceGuard');
+
+for (const enabled of [undefined, true, false]) {
+  result = enabled === undefined ? undefined : { global_notifications_enabled: enabled };
+  calls.length = 0;
+  assert.equal(await globalPreferenceGuard({ userId: 'user-a' }), enabled ?? true);
+  assert.deepEqual(calls, ['user_notification_settings', { user_id: 'user-a' }, ['global_notifications_enabled'], 'first']);
+}
+for (const type of NOTIFICATION_TYPES) {
+  for (const row of [undefined, { in_app_enabled: false, email_enabled: false }, { in_app_enabled: true, email_enabled: false }, { in_app_enabled: false, email_enabled: true }, { in_app_enabled: true, email_enabled: true }]) {
+    result = row;
+    calls.length = 0;
+    assert.deepEqual(await preferenceGuard({ userId: 'user-b', type }), row ?? { in_app_enabled: true, email_enabled: true });
+    assert.deepEqual(calls, ['notification_preferences', { user_id: 'user-b', type }, ['in_app_enabled', 'email_enabled'], 'first']);
+  }
+}
+const failure = new Error('preference read failed');
+state.failure = failure;
+await assert.rejects(globalPreferenceGuard({ userId: 'user-a' }), failure);
+await assert.rejects(preferenceGuard({ userId: 'user-b', type: 'mention' }), failure);
+console.info('real preference guards: defaults, channel combinations, all types, scoped queries, rejection propagation verified');

--- a/server/extensions/notifications/mods/__tests__/preferenceGuards.test.ts
+++ b/server/extensions/notifications/mods/__tests__/preferenceGuards.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'bun:test';
+
+// Shared DB mocks stay in a child process; these imports exercise the real guards.
+test('real preference guards preserve opt-out defaults and user/type query scope', async () => {
+  const child = Bun.spawn([process.execPath, new URL('./fixtures/preferenceGuards.ts', import.meta.url).pathname], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  expect(stderr).toBe('');
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain('rejection propagation verified');
+});

--- a/server/extensions/notifications/mods/globalPreferenceGuard.ts
+++ b/server/extensions/notifications/mods/globalPreferenceGuard.ts
@@ -2,8 +2,14 @@
 // Missing row means notifications are enabled (opt-out model per Sprint 95).
 import { db } from '../../../common/db';
 
+// Migration 0087: primary user key and non-null boolean toggle.
+interface GlobalPreferenceRow {
+  user_id: string;
+  global_notifications_enabled: boolean;
+}
+
 export async function globalPreferenceGuard({ userId }: { userId: string }): Promise<boolean> {
-  const row = await db('user_notification_settings')
+  const row = await db<GlobalPreferenceRow>('user_notification_settings')
     .where({ user_id: userId })
     .select('global_notifications_enabled')
     .first();

--- a/server/extensions/notifications/mods/preferenceGuard.ts
+++ b/server/extensions/notifications/mods/preferenceGuard.ts
@@ -24,6 +24,12 @@ export interface NotificationPreference {
   email_enabled: boolean;
 }
 
+// Migration 0037: non-null user/type keys and non-null channel booleans.
+interface PreferenceRow extends NotificationPreference {
+  user_id: string;
+  type: string;
+}
+
 // When NOTIFICATION_PREFERENCES_ENABLED flag is off callers should skip the guard entirely
 // and treat all channels as enabled. This helper is used when the flag is on.
 export async function preferenceGuard({
@@ -33,7 +39,7 @@ export async function preferenceGuard({
   userId: string;
   type: NotificationType;
 }): Promise<NotificationPreference> {
-  const row = await db('notification_preferences')
+  const row = await db<PreferenceRow>('notification_preferences')
     .where({ user_id: userId, type })
     .select('in_app_enabled', 'email_enabled')
     .first();


### PR DESCRIPTION
## Scope
- Type the global and per-notification-type preference guard Knex reads using local row interfaces derived from migrations `0087_user_notification_settings` and `0037_notification_preferences` (non-null booleans; user/type filter keys included).
- Preserve missing-row opt-out defaults, false toggles, user/type filters, projections, and rejection propagation. No API/auth changes, payment work, UI, configuration, dependencies, deployment, or stable changes.
- Add a durable subprocess-isolated test of both real guards; shared DB mock never enters the parent full-suite process.

## Verification
BASE: `342634915e2db21404b687f52f3289b1155b2dde`, clean main fetched and fast-forward checked before branching. Fresh BASE typecheck and full Bun tests captured before edits.

| Gate | Actual result |
| --- | --- |
| Focused ESLint, all four touched files | exit 0, zero errors/warnings |
| Durable real-guard test on BASE and HEAD | 1 pass each |
| Mutation sensitivity | Removing the type filter failed the durable test; restored before typing (not a pre-existing defect) |
| `bun run typecheck` | exit 2 on both; identical multiset of 147 complete multiline diagnostic blocks |
| `bun test` BASE | 1213 pass, 3 skip, 180 fail, 30 errors |
| `bun test` HEAD | 1214 pass, 3 skip, 180 fail, 30 errors |
| Failure identity comparison | Identical 150 file-qualified named failures plus 30 complete file-qualified unhandled-error blocks; 150 + 30 reconciles to 180 fail. No added/removed diagnostic, failure, or unhandled-error entries |
| `bun run build:client` | exit 0; existing large-chunk warning |
| `git diff --check` | exit 0 |
| Full ESLint | 2467 errors, 3 warnings (previous main report 2475 errors, 3 warnings: 8 errors removed) |
| Bun-transpiled production JavaScript | Both files byte-identical BASE/HEAD; no non-erased production changes |

## Coverage limits
The child imports the real production guards with only their Knex DB seam mocked. It asserts exact tables, user/type predicates, selected columns, `.first()`, missing-row defaults, global true/false, every notification type with all four channel combinations, and error propagation. This does **not** exercise live PostgreSQL/schema enforcement, router/auth composition, notification transport/delivery, or browser E2E. No UI change; UI/E2E not run. Existing full-suite failures include unsuitable/infrastructure-dependent suites and are not claimed green.

## Local evidence
`/tmp/chimedeck-lint-slice-n9peBL/`:
- `base-typecheck.txt`, `head-typecheck.txt`, `base-test.txt`, `head-test.txt`
- `compare.py`, `base-parsed.json`, `head-parsed.json`, `comparison.json` (complete blocks and multisets, totals asserted)
- `focused-base.txt`, `mutation-red.txt`, `focused-head.txt`, `focused-lint.txt`, `full-lint.txt`, `build.txt`
- `compare-js.ts`, `emitted-js.txt`, `globalPreferenceGuard-{base,head}.js`, `preferenceGuard-{base,head}.js`

Implementation only. Independent parent review required; do not approve or merge from this context.
