### PR TITLE
refactor(plugins): type resource board guard queries

### DIFF
--- a/server/extensions/plugins/common/validateResourceBelongsToBoard.fixture.ts
+++ b/server/extensions/plugins/common/validateResourceBelongsToBoard.fixture.ts
@@ -1,0 +1,53 @@
+import { mock } from 'bun:test';
+import assert from 'node:assert/strict';
+
+const scenario = process.argv[2];
+assert.ok(scenario);
+const [scope, outcome] = scenario.split('-');
+assert.ok(scope === 'board' || scope === 'member' || scope === 'list' || scope === 'card');
+const resourceId = scope === 'board' && outcome === 'match' ? 'board-a' : 'resource-a';
+const boardId = 'board-a';
+const calls: unknown[][] = [];
+const failure = new Error('database unavailable');
+// Only the DB transport is fake; every scenario imports the real guard in a child process.
+void mock.module('../../../common/db', () => ({
+  db: (table: string) => {
+    calls.push(['db', table]);
+    const query = {
+      join: (...args: unknown[]) => { calls.push(['join', ...args]); return query; },
+      where: (...args: unknown[]) => { calls.push(['where', ...args]); return query; },
+      select: (...args: unknown[]) => { calls.push(['select', ...args]); return query; },
+      first: () => {
+        calls.push(['first']);
+        if (outcome === 'error') return Promise.reject(failure);
+        return Promise.resolve(outcome === 'missing' ? undefined : { id: resourceId });
+      },
+    };
+    return query;
+  },
+}));
+const { validateResourceBelongsToBoard, ResourceBoardMismatchError } =
+  await import('./validateResourceBelongsToBoard');
+const result = validateResourceBelongsToBoard(scope, resourceId, boardId);
+if (outcome === 'error') {
+  await assert.rejects(result, (error: unknown) => error === failure);
+} else if (outcome === 'missing' || outcome === 'mismatch') {
+  await assert.rejects(result, (error: unknown) => {
+    assert.ok(error instanceof ResourceBoardMismatchError);
+    assert.equal(error.name, 'resource-board-mismatch');
+    assert.equal(error.message, `${scope} '${resourceId}' does not belong to board '${boardId}'`);
+    assert.equal(error.scope, scope);
+    assert.equal(error.resourceId, resourceId);
+    assert.equal(error.boardId, boardId);
+    return true;
+  });
+} else {
+  await result;
+}
+assert.deepEqual(calls, scope === 'list' ? [
+  ['db', 'lists'], ['where', { id: resourceId, board_id: boardId }], ['first'],
+] : scope === 'card' ? [
+  ['db', 'cards'], ['join', 'lists', 'cards.list_id', 'lists.id'],
+  ['where', 'cards.id', resourceId], ['where', 'lists.board_id', boardId],
+  ['select', 'cards.id'], ['first'],
+] : []);

--- a/server/extensions/plugins/common/validateResourceBelongsToBoard.test.ts
+++ b/server/extensions/plugins/common/validateResourceBelongsToBoard.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const fixture = fileURLToPath(new URL('./validateResourceBelongsToBoard.fixture.ts', import.meta.url));
+
+// Subprocesses prevent shared DB mock leakage and adjacent tests replacing the guard.
+// Query assertions do not establish live PostgreSQL filtering or route/auth wiring.
+test.each([
+  'board-match', 'board-mismatch', 'member-match',
+  'list-match', 'list-missing', 'list-error',
+  'card-match', 'card-missing', 'card-error',
+])('plugin resource board boundary: %s', (scenario) => {
+  const result = spawnSync(process.execPath, [fixture, scenario], { encoding: 'utf8' });
+  expect(result.error).toBeUndefined();
+  expect(result.stderr).toBe('');
+  expect(result.status).toBe(0);
+});

--- a/server/extensions/plugins/common/validateResourceBelongsToBoard.ts
+++ b/server/extensions/plugins/common/validateResourceBelongsToBoard.ts
@@ -4,6 +4,17 @@ import { db } from '../../../common/db';
 
 type Scope = 'card' | 'list' | 'board' | 'member';
 
+// Query columns are non-null strings in migrations 0005_list and 0006_card.
+interface ListBoardRow {
+  id: string;
+  board_id: string;
+}
+
+interface CardListRow {
+  id: string;
+  list_id: string;
+}
+
 export class ResourceBoardMismatchError extends Error {
   constructor(public readonly scope: Scope, public readonly resourceId: string, public readonly boardId: string) {
     super(`${scope} '${resourceId}' does not belong to board '${boardId}'`);
@@ -25,19 +36,19 @@ export async function validateResourceBelongsToBoard(
   }
 
   if (scope === 'list') {
-    const list = await db('lists').where({ id: resourceId, board_id: boardId }).first();
+    const list = await db<ListBoardRow>('lists').where({ id: resourceId, board_id: boardId }).first();
     if (!list) throw new ResourceBoardMismatchError(scope, resourceId, boardId);
     return;
   }
 
   if (scope === 'card') {
     // cards don't have a direct board_id — join through lists
-    const card = await db('cards')
+    const card = await db<CardListRow>('cards')
       .join('lists', 'cards.list_id', 'lists.id')
       .where('cards.id', resourceId)
       .where('lists.board_id', boardId)
       .select('cards.id')
-      .first();
+      .first<Pick<CardListRow, 'id'> | undefined>();
     if (!card) throw new ResourceBoardMismatchError(scope, resourceId, boardId);
     return;
   }


### PR DESCRIPTION
## Scope
Type the plugin resource-to-board guard's list lookup and joined card-ID projection using non-null string columns from `0005_list.ts` / `0006_card.ts`. Preserve missing rows as `undefined`. No runtime queries, auth rules, API errors, payments, UI, configuration, dependencies, or deployment changes.

Add subprocess-isolated tests of the real guard: board equality/mismatch, member no-op, list/card found/missing, identical DB rejection propagation, exact table/join/predicates/projection, and structured mismatch error fields. The shared DB module is mocked only inside child Bun processes.

## Verification
Fresh BASE: `1b30269a56fa784909414cb947120f93ee231a8f`; clean main fetched and fast-forward checked before branching.

- Focused ESLint, all three touched files: **0 errors, 0 warnings**.
- Durable guard suite against BASE and HEAD: **9 pass, 0 fail** each.
- Mutation RED: temporarily removed `lists.board_id` predicate; all three card scenarios failed query assertions (6 pass / 3 fail). Restored before typing. This proves test sensitivity, not a pre-existing production defect.
- `bun run typecheck`: BASE/HEAD exit 2 with **147 identical complete multiline diagnostic blocks**.
- Full `bun test`: BASE **1214 pass / 3 skip / 180 fail / 30 errors**; HEAD **1223 pass / 3 skip / 180 fail / 30 errors**. File-qualified named-failure multisets (**150**) and complete file-qualified unhandled-error-block multisets (**30**) are identical. Both reconcile: 150 + 30 = 180 reported failures. No added or removed failure/diagnostic identities.
- `bun run build:client`: exit 0 (existing chunk-size warning).
- `git diff --check`: exit 0.
- Full ESLint: **2465 errors / 3 warnings**, down from supplied post-237 baseline **2467 / 3**.
- Bun-transpiled production BASE/HEAD JavaScript is byte-identical, SHA-256 `5cdf82bbe7095961e163577cec49d23e4f006b0248687b16ebe2c1f7c43e4ec1`. No non-erased production changes; added tests execute new assertions only.

## Evidence and limitations
Local evidence directory: `/tmp/chimedeck-lint-next-KVbJKg/`:
`base-typecheck.log`, `head-typecheck.log`, `base-test.log`, `head-test.log`, `base-identities.json`, `head-identities.json`, `comparison.json`, `compare.py`, `base-focused-test.log`, `head-focused-test.log`, `mutation-red.log`, `head-focused-lint.log`, `head-full-lint.log`, `head-build.log`, `diff-check.log`, `emitted-comparison.json`, `base-emitted.js`, `head-emitted.js`, `compare-emitted.ts`.

The full suite/typecheck remain red with reconciled pre-existing debt. Fake DB transport verifies query construction and guard behavior, not live PostgreSQL filtering/schema acceptance, authenticated HTTP route composition, or end-to-end plugin data access. No UI changes; UI/E2E not run. No live services or deployments changed.

Implementation only. Independent parent review required; do not approve or merge as part of this task.
