### PR TITLE
refactor(health-check): type single probe database boundary

### DIFF
--- a/server/extensions/healthCheck/api/fixtures/probeContract.ts
+++ b/server/extensions/healthCheck/api/fixtures/probeContract.ts
@@ -1,0 +1,93 @@
+import { expect, mock } from 'bun:test';
+
+const calls: unknown[][] = [];
+let authError: Response | undefined;
+let visibilityError: Response | undefined;
+let row: { id: string; url: string; expected_status: number | null } | undefined;
+let dbError: Error | undefined;
+let probeError: Error | undefined = undefined;
+let allowed = true;
+const result = {
+  id: 'result', healthCheckId: 'check', status: 'healthy', httpStatus: 401,
+  responseTimeMs: 12, errorMessage: null, checkedAt: '2026-01-01T00:00:00.000Z',
+};
+await mock.module('../../../../common/db', () => ({
+  db: (table: string) => {
+    calls.push(['db', table]);
+    return {
+      where: (conditions: unknown) => {
+        calls.push(['where', conditions]);
+        return { first: () => dbError ? Promise.reject(dbError) : Promise.resolve(row) };
+      },
+    };
+  },
+}));
+await mock.module('../../../auth/middlewares/authentication', () => ({
+  authenticate: (req: Request) => {
+    calls.push(['auth', req.url]);
+    return Promise.resolve(authError);
+  },
+}));
+await mock.module('../../../../middlewares/boardVisibility', () => ({
+  applyBoardVisibility: (_req: Request, boardId: string) => {
+    calls.push(['visibility', boardId]);
+    return Promise.resolve(visibilityError);
+  },
+}));
+await mock.module('../../mods/rateLimiter', () => ({
+  checkRateLimit: (key: string) => { calls.push(['limit', key]); return allowed; },
+  retryAfterMs: (key: string) => { calls.push(['retry', key]); return 1501; },
+}));
+await mock.module('../../mods/probe', () => ({
+  probe: (input: unknown) => {
+    calls.push(['probe', input]);
+    return probeError ? Promise.reject(probeError) : Promise.resolve(result);
+  },
+}));
+const { handleProbeHealthCheck } = await import('../probe');
+const request = new Request('http://127.0.0.1/health');
+const invoke = () => handleProbeHealthCheck(request, 'board', 'check');
+const prefix = [['auth', request.url], ['visibility', 'board']];
+const query = [['db', 'board_health_checks'], ['where', { id: 'check', board_id: 'board', is_active: true }]];
+
+authError = new Response('unauthorized', { status: 401 });
+expect(await invoke()).toBe(authError);
+expect(calls.splice(0)).toEqual([['auth', request.url]]);
+authError = undefined;
+visibilityError = new Response('forbidden', { status: 403 });
+expect(await invoke()).toBe(visibilityError);
+expect(calls.splice(0)).toEqual(prefix);
+visibilityError = undefined;
+const missing = await invoke();
+expect(missing.status).toBe(404);
+expect(await missing.json()).toEqual({ name: 'health-check-not-found', data: { message: 'Health check not found' } });
+expect(calls.splice(0)).toEqual([...prefix, ...query]);
+
+for (const expectedStatus of [null, 401, 0]) {
+  row = { id: 'stored-check', url: 'https://example.com/health', expected_status: expectedStatus };
+  const response = await invoke();
+  expect(response.status).toBe(200);
+  expect(await response.json()).toEqual({ data: result });
+  expect(calls.splice(0)).toEqual([...prefix, ...query, ['limit', 'probe:check'], ['probe', {
+    healthCheckId: row.id, url: row.url, expectedStatus,
+  }]]);
+}
+allowed = false;
+const limited = await invoke();
+expect(limited.status).toBe(429);
+expect(limited.headers.get('Retry-After')).toBe('2');
+expect(await limited.json()).toEqual({ name: 'rate-limit-exceeded', data: {
+  message: 'Too many probe requests. Please wait before probing again.', retryAfterSeconds: 2,
+} });
+expect(calls.splice(0)).toEqual([...prefix, ...query, ['limit', 'probe:check'], ['retry', 'probe:check']]);
+allowed = true;
+dbError = new Error('database unavailable');
+expect(await invoke().catch((error: unknown) => error)).toBe(dbError);
+expect(calls.splice(0)).toEqual([...prefix, ...query]);
+dbError = undefined;
+probeError = new Error('probe unavailable');
+expect(await invoke().catch((error: unknown) => error)).toBe(probeError);
+expect(calls.splice(0)).toEqual([...prefix, ...query, ['limit', 'probe:check'], ['probe', {
+  healthCheckId: 'stored-check', url: 'https://example.com/health', expectedStatus: 0,
+}]]);
+console.info('probe handler contract passed');

--- a/server/extensions/healthCheck/api/probe.test.ts
+++ b/server/extensions/healthCheck/api/probe.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'bun:test';
+
+test('real probe handler preserves authorization, scoped lookup, rate limit and response contract', async () => {
+  const child = Bun.spawn([process.execPath, new URL('./fixtures/probeContract.ts', import.meta.url).pathname], {
+    stdout: 'pipe', stderr: 'pipe',
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited, new Response(child.stdout).text(), new Response(child.stderr).text(),
+  ]);
+  expect(stderr).toBe('');
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain('probe handler contract passed');
+});

--- a/server/extensions/healthCheck/api/probe.ts
+++ b/server/extensions/healthCheck/api/probe.ts
@@ -7,6 +7,15 @@ import { applyBoardVisibility } from '../../../middlewares/boardVisibility';
 import { probe } from '../mods/probe';
 import { checkRateLimit, retryAfterMs } from '../mods/rateLimiter';
 
+// Read/filter columns from migrations 0095 and 0097.
+interface ProbeHealthCheckRow {
+  id: string;
+  board_id: string;
+  is_active: boolean;
+  url: string;
+  expected_status: number | null;
+}
+
 export async function handleProbeHealthCheck(
   req: Request,
   boardId: string,
@@ -19,7 +28,7 @@ export async function handleProbeHealthCheck(
   if (visibilityError) return visibilityError;
 
   // Look up the health check and verify it belongs to this board.
-  const check = await db('board_health_checks')
+  const check = await db<ProbeHealthCheckRow>('board_health_checks')
     .where({ id: healthCheckId, board_id: boardId, is_active: true })
     .first();
 


### PR DESCRIPTION
## Scope
One non-payment server lint boundary: type the single-health-check probe DB read using migrations `0095` (non-null id/board_id/is_active/url) and `0097` (nullable integer expected_status). No runtime, auth, API, query, rate-limit or response changes. No UI/config/dependency/deployment/payment changes.

## Verification
Base: `8535f1421ddf409bda6e40e57649dd8b73b52956`, clean main fetched and fast-forward checked before work. Fresh base typecheck/full Bun suite captured before edits.

- Focused ESLint: **0 errors, 0 warnings**, all three touched TypeScript files.
- Full ESLint: **2458 errors / 3 warnings**, down from supplied post-238 baseline **2465 / 3** (seven removed).
- Durable subprocess real-handler contract test: **1 pass**, BASE and HEAD. Exercises authentication/visibility short-circuit order, exact board/id/active query predicates, missing row 404, nullable/401/zero expected status, stored-row probe input, complete success response, rate-limit 429 + rounded Retry-After, DB/probe rejection propagation.
- Mutation RED: temporarily removed `board_id` predicate; test failed on missing predicate, then restored before type edit. This is test sensitivity, not a pre-existing production bug.
- `bun run typecheck`: exit 2 on BASE and HEAD; **147 identical complete multiline diagnostic blocks** (multisets).
- Full `bun test`: exit 1 on both. BASE **1223 pass / 3 skip / 180 fail / 30 errors**; HEAD **1224 pass / 3 skip / 180 fail / 30 errors**. **150 file-qualified named failures + 30 complete file-qualified unhandled error blocks = 180 failures** on each. Multisets unchanged; no added or removed failure/error identities. Comparison stops before repeated failure summary and reconciles totals.
- `bun run build:client`: exit 0 (existing chunk-size warning).
- `git diff --check`: exit 0.
- BASE/HEAD Bun-transpiled production JavaScript **byte-identical**, SHA-256 `30293cc8798b40be3dde269065173b4a2cf94c4be0cd909e245d3f652f6c4022`. No non-erased production changes; only new test/fixture code executes additionally.

## Evidence and limits
Local evidence directory: `/tmp/chimedeck-lint239-2orG37/`.
`base-typecheck.log`, `head-typecheck.log`, `base-test.log`, `head-test.log`, `base-identities.json`, `head-identities.json`, `comparison.json`, `compare.py`, `focused-base.log`, `focused-head.log`, `mutation-red.log`, `focused-eslint.log`, `full-eslint.log`, `build-client.log`, `diff-check.log`, `base-probe.js`, `head-probe.js`, `emitted-sha256.log`.

The durable test imports the real handler in a child Bun process to isolate shared DB mocks. Authentication, visibility, DB, limiter and probe pipeline are fakes: this proves handler delegation/contracts, not live authentication, PostgreSQL filtering/schema acceptance, real limiter timing, external HTTP/SSRF, persistence or router wiring. No UI changes; no UI/E2E claim. Existing health-check pipeline type errors remain in the identical baseline. Separate parent review required; **do not approve or merge in this implementation context**.
