### PR TITLE
refactor(notifications): type board preference reads

### DIFF
--- a/server/extensions/notifications/mods/__tests__/boardPreferenceReads.test.ts
+++ b/server/extensions/notifications/mods/__tests__/boardPreferenceReads.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'bun:test';
+
+// Exercise the real guards with fake DB reads isolated from other suites.
+test('real board preference guard preserves scope, participant defaults and channel precedence', async () => {
+  const child = Bun.spawn([process.execPath, new URL('./fixtures/boardPreferenceGuard.ts', import.meta.url).pathname], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  expect(stderr).toBe('');
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain('rejection propagation verified');
+});

--- a/server/extensions/notifications/mods/__tests__/fixtures/boardPreferenceGuard.ts
+++ b/server/extensions/notifications/mods/__tests__/fixtures/boardPreferenceGuard.ts
@@ -1,0 +1,81 @@
+import { strict as assert } from 'node:assert';
+import { mock } from 'bun:test';
+
+const rows = new Map<string, Record<string, boolean> | undefined>();
+const calls: unknown[] = [];
+let failingTable = '';
+const failure = new Error('board preference read failed');
+void mock.module('../../../../../common/db', () => ({
+  db(table: string) {
+    calls.push(table);
+    return {
+      where(filter: Record<string, string>) {
+        calls.push(filter);
+        return this;
+      },
+      select(...columns: string[]) {
+        calls.push(columns);
+        return this;
+      },
+      first() {
+        calls.push('first');
+        return table === failingTable ? Promise.reject(failure) : Promise.resolve(rows.get(table));
+      },
+    };
+  },
+}));
+const { resolveBoardNotificationPreference, boardPreferenceGuard, resolveNotificationChannels } = await import('../../boardPreferenceGuard');
+const { NOTIFICATION_TYPES } = await import('../../preferenceGuard');
+const scope = { userId: 'user-a', boardId: 'board-b' };
+const filter = { user_id: scope.userId, board_id: scope.boardId };
+const boardLookup = ['board_notification_preferences', filter, ['notifications_enabled', 'only_related_to_me'], 'first'];
+for (const enabled of [false, true]) {
+  for (const related of [false, true]) {
+    rows.set('board_notification_preferences', { notifications_enabled: enabled, only_related_to_me: related });
+    calls.length = 0;
+    assert.deepEqual(await resolveBoardNotificationPreference(scope), { notificationsEnabled: enabled, onlyRelatedToMe: related });
+    assert.deepEqual(calls, boardLookup);
+    calls.length = 0;
+    assert.equal(await boardPreferenceGuard(scope), enabled);
+    assert.deepEqual(calls, boardLookup);
+  }
+}
+rows.clear();
+for (const member of [false, true]) {
+  for (const guest of [false, true]) {
+    rows.set('board_members', member ? {} : undefined);
+    rows.set('board_guest_access', guest ? {} : undefined);
+    calls.length = 0;
+    assert.deepEqual(await resolveBoardNotificationPreference(scope), { notificationsEnabled: member || guest, onlyRelatedToMe: false });
+    assert.deepEqual(calls, [...boardLookup, 'board_members', filter, 'first', 'board_guest_access', filter, 'first']);
+    assert.equal(await boardPreferenceGuard(scope), member || guest);
+  }
+}
+rows.clear();
+const channelRows = [undefined, { in_app_enabled: false, email_enabled: false }, { in_app_enabled: false, email_enabled: true }, { in_app_enabled: true, email_enabled: false }, { in_app_enabled: true, email_enabled: true }];
+for (const type of [...NOTIFICATION_TYPES, 'future-type']) {
+  for (const board of channelRows) {
+    for (const user of channelRows) {
+      rows.set('board_notification_type_preferences', board);
+      rows.set('notification_preferences', user);
+      calls.length = 0;
+      const effective = board ?? user;
+      assert.deepEqual(await resolveNotificationChannels({ ...scope, type }), { inApp: effective?.in_app_enabled ?? true, email: effective?.email_enabled ?? true });
+      assert.deepEqual(calls, [
+        'board_notification_type_preferences', { ...filter, type }, ['in_app_enabled', 'email_enabled'], 'first',
+        ...(board ? [] : ['notification_preferences', { user_id: scope.userId, type }, ['in_app_enabled', 'email_enabled'], 'first']),
+      ]);
+    }
+  }
+}
+rows.clear();
+for (const table of ['board_notification_preferences', 'board_members', 'board_guest_access']) {
+  failingTable = table;
+  await assert.rejects(resolveBoardNotificationPreference(scope), failure);
+  await assert.rejects(boardPreferenceGuard(scope), failure);
+}
+for (const table of ['board_notification_type_preferences', 'notification_preferences']) {
+  failingTable = table;
+  await assert.rejects(resolveNotificationChannels({ ...scope, type: 'mention' }), failure);
+}
+console.info('real board preference guard: scope, defaults, precedence, channel combinations and rejection propagation verified');

--- a/server/extensions/notifications/mods/boardPreferenceGuard.ts
+++ b/server/extensions/notifications/mods/boardPreferenceGuard.ts
@@ -2,6 +2,28 @@
 // Missing row means notifications are enabled (opt-out model per Sprint 95).
 import { db } from '../../../common/db';
 
+// Migrations 0030/0040: non-null participant user/board keys.
+interface BoardScopeRow {
+  user_id: string;
+  board_id: string;
+}
+
+// Migrations 0086/0117: non-null board preference flags.
+interface BoardPreferenceRow extends BoardScopeRow {
+  notifications_enabled: boolean;
+  only_related_to_me: boolean;
+}
+
+// Migrations 0037/0092: non-null user/type keys and channel flags.
+interface ChannelPreferenceRow {
+  user_id: string;
+  type: string;
+  in_app_enabled: boolean;
+  email_enabled: boolean;
+}
+
+interface BoardChannelPreferenceRow extends ChannelPreferenceRow, BoardScopeRow {}
+
 export interface BoardNotificationPreferenceSettings {
   notificationsEnabled: boolean;
   onlyRelatedToMe: boolean;
@@ -14,7 +36,7 @@ export async function resolveBoardNotificationPreference({
   userId: string;
   boardId: string;
 }): Promise<BoardNotificationPreferenceSettings> {
-  const row = await db('board_notification_preferences')
+  const row = await db<BoardPreferenceRow>('board_notification_preferences')
     .where({ user_id: userId, board_id: boardId })
     .select('notifications_enabled', 'only_related_to_me')
     .first();
@@ -30,8 +52,8 @@ export async function resolveBoardNotificationPreference({
   // Default ON for board participants (joined members OR board guests), but keep
   // default OFF for workspace/admin users who can view a board without joining it.
   const [isMember, hasGuestAccess] = await Promise.all([
-    db('board_members').where({ user_id: userId, board_id: boardId }).first(),
-    db('board_guest_access').where({ user_id: userId, board_id: boardId }).first(),
+    db<BoardScopeRow>('board_members').where({ user_id: userId, board_id: boardId }).first(),
+    db<BoardScopeRow>('board_guest_access').where({ user_id: userId, board_id: boardId }).first(),
   ]);
 
   return {
@@ -83,7 +105,7 @@ export async function resolveNotificationChannels({
   type: string;
 }): Promise<{ inApp: boolean; email: boolean }> {
   // 1. Board-type-pref takes highest precedence.
-  const boardRow = await db('board_notification_type_preferences')
+  const boardRow = await db<BoardChannelPreferenceRow>('board_notification_type_preferences')
     .where({ user_id: userId, board_id: boardId, type })
     .select('in_app_enabled', 'email_enabled')
     .first();
@@ -91,7 +113,7 @@ export async function resolveNotificationChannels({
   // 2. User-level preference is the next fallback.
   const userRow = boardRow
     ? null
-    : await db('notification_preferences')
+    : await db<ChannelPreferenceRow>('notification_preferences')
         .where({ user_id: userId, type })
         .select('in_app_enabled', 'email_enabled')
         .first();


### PR DESCRIPTION
## Summary
- Type the five board-notification preference/participant DB reads using local migration-derived projections (0030, 0040, 0037, 0086, 0092, 0117).
- Preserve query predicates, selected columns, defaults, precedence, short-circuiting, public string type input and rejection behavior. Production Bun-transpiled JS is byte-identical (SHA256 `5c0121eb742c7a4285c2759719966ff579be266309e28948a5f87d74365520bf`). No non-erased production changes.
- Add a subprocess-isolated real-guard regression fixture covering explicit booleans, all member/guest combinations, every supported notification type plus an unknown string, every board/user channel combination, exact query scope and all five query rejection paths. Existing pure cascade tests remain untouched.

## Verification
Fresh BASE: `dbf04b430d79fff2f2ec61795935a81e283c10ae`.
- Focused ESLint: zero findings across all three touched files. Full lint: 2447 errors / 3 warnings, down 11 errors from 2458 / 3.
- Notification guard test directory: 27 pass / 0 fail. New real-guard test passed against BASE before production edits; deliberate removed board predicate mutation failed as expected and was restored (sensitivity RED, not a production defect).
- `bun run typecheck`: existing failure, 147 complete multiline diagnostic blocks identical as multisets BASE/HEAD; no additions/removals.
- `bun test`: BASE 1224 pass / 3 skip / 180 fail / 30 errors; HEAD 1225 pass / 3 skip / 180 fail / 30 errors. File-qualified full named failure multisets identical (150), and file-qualified complete unhandled error blocks identical (30). Parser asserts 150 + 30 = 180, reconciling Bun totals. No new failures.
- `bun run build:client`: pass. `git diff --check`: pass. BASE/HEAD emitted JS `cmp`: pass.

Evidence directory: `/tmp/chimedeck-lint-next-NBzmh4/` (`base-typecheck.log`, `head-typecheck.log`, `base-test.log`, `head-test.log`, `comparison.json`, `compare.py`, `diagnostics-blocks.json`, `named_failures-blocks.json`, `unhandled_errors-blocks.json`, `base-focused.log`, `mutation-red.log`, `head-focused.log`, `focused-lint.log`, `head-full-lint.log`, `build-client.log`, `base.js`, `head.js`). BASE/RED logs use the initial test filename; final added wrapper is `boardPreferenceReads.test.ts`, preserving the pre-existing pure-test file.

## Coverage limits / scope
Fake DB results prove guard execution and constructed queries, not PostgreSQL filtering, constraints, live DB connectivity, router/auth integration or delivery/pubsub. No UI changes or UI/E2E claim. No payment, dependency, config, deployment, suppression, or stable-branch changes. This PR is for separate independent review; no approval or merge performed.
