### PR TITLE
refactor(events): type board deletion membership recipients

### DIFF
--- a/server/extensions/events/mods/publishBoardDeleted.fixture.ts
+++ b/server/extensions/events/mods/publishBoardDeleted.fixture.ts
@@ -1,0 +1,77 @@
+import { strict as assert } from 'node:assert';
+import { mock } from 'bun:test';
+
+const calls: unknown[] = [];
+let members: { user_id: string }[] = [];
+let failing = '';
+const failure = new Error('transport failed');
+const event = { id: 'event-a', sequence: 42n, created_at: '2026-01-01T00:00:00Z' };
+void mock.module('../../../common/db', () => ({
+  db(table: string) {
+    calls.push(table);
+    return {
+      where(filter: Record<string, string>) {
+        calls.push(filter);
+        return this;
+      },
+      select(column: string) {
+        calls.push(column);
+        return failing === 'db' ? Promise.reject(failure) : Promise.resolve(members);
+      },
+    };
+  },
+}));
+void mock.module('../../../mods/events/write', () => ({
+  writeEvent(input: unknown) {
+    calls.push(['write', input]);
+    return failing === 'write' ? Promise.reject(failure) : Promise.resolve(event);
+  },
+}));
+void mock.module('../../../mods/pubsub/index', () => ({
+  pubsub: {
+    publish(channel: string, message: string) {
+      calls.push(['pubsub', channel, JSON.parse(message) as unknown]);
+      return failing === 'pubsub' ? Promise.reject(failure) : Promise.resolve();
+    },
+  },
+}));
+void mock.module('../../realtime/userChannel', () => ({
+  publishToUser(userId: string, message: unknown) {
+    calls.push(['user', userId, message]);
+    return failing === 'user' ? Promise.reject(failure) : Promise.resolve();
+  },
+}));
+const { publishBoardDeleted } = await import('./publishBoardDeleted');
+const input = { boardId: 'deleted-board', workspaceId: 'workspace-a', actorId: 'actor-a' };
+const originalNow = Date.now;
+Date.now = () => 123;
+const message = {
+  type: 'board_deleted', entity_id: input.boardId, actor_id: input.actorId,
+  payload: { boardId: input.boardId, workspaceId: input.workspaceId },
+  version: 42, sequence: '42', timestamp: event.created_at, emittedAt: 123,
+};
+const prefix = [
+  ['write', { type: 'board_deleted', boardId: null, entityId: input.boardId, actorId: input.actorId, payload: message.payload }],
+  ['pubsub', 'workspace:workspace-a', message],
+  'memberships', { workspace_id: input.workspaceId }, 'user_id',
+];
+try {
+  for (const rows of [[], [{ user_id: 'user-a' }], [{ user_id: 'user-a' }, { user_id: 'user-b' }]]) {
+    members = rows;
+    calls.length = 0;
+    assert.deepEqual(await publishBoardDeleted(input), { eventId: event.id });
+    assert.deepEqual(calls, [...prefix, ...rows.map(row => ['user', row.user_id, message])]);
+  }
+  failing = 'pubsub';
+  calls.length = 0;
+  assert.deepEqual(await publishBoardDeleted(input), { eventId: event.id });
+  assert.deepEqual(calls, [...prefix, ...members.map(row => ['user', row.user_id, message])]);
+  for (const stage of ['write', 'db', 'user']) {
+    failing = stage;
+    calls.length = 0;
+    await assert.rejects(publishBoardDeleted(input), failure);
+    assert.deepEqual(calls, stage === 'write' ? prefix.slice(0, 1) : stage === 'db' ? prefix : [...prefix, ['user', 'user-a', message]]);
+  }
+} finally {
+  Date.now = originalNow;
+}

--- a/server/extensions/events/mods/publishBoardDeleted.test.ts
+++ b/server/extensions/events/mods/publishBoardDeleted.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'bun:test';
+
+test('board deletion publisher preserves workspace fanout and failure contracts', () => {
+  const result = Bun.spawnSync([process.execPath, `${import.meta.dir}/publishBoardDeleted.fixture.ts`], {
+    stdout: 'pipe', stderr: 'pipe',
+  });
+  expect(result.stderr.toString()).toBe('');
+  expect(result.exitCode).toBe(0);
+});

--- a/server/extensions/events/mods/publishBoardDeleted.ts
+++ b/server/extensions/events/mods/publishBoardDeleted.ts
@@ -7,6 +7,12 @@ import { writeEvent } from '../../../mods/events/write';
 import { publishToUser } from '../../realtime/userChannel';
 import { pubsub } from '../../../mods/pubsub/index';
 
+// Both columns are NOT NULL strings in db/migrations/0003_workspace.ts.
+interface MembershipRecipientRow {
+  user_id: string;
+  workspace_id: string;
+}
+
 export interface PublishBoardDeletedInput {
   boardId: string;
   workspaceId: string;
@@ -52,7 +58,7 @@ export async function publishBoardDeleted({
 
   // Fan out directly to connected workspace member sockets so the event is
   // received immediately regardless of whether the client is watching a board.
-  const members = await db('memberships')
+  const members = await db<MembershipRecipientRow>('memberships')
     .where({ workspace_id: workspaceId })
     .select('user_id');
 


### PR DESCRIPTION
## Scope
Type the board-deletion publisher's membership recipient query from `0003_workspace.ts` (non-null string user/workspace IDs). No query, runtime, auth, API, payment, UI, configuration or dependency changes. Production BASE/HEAD Bun-transpiled JavaScript is byte-identical (`cmp` exit 0); no non-erased production changes.

Add subprocess-isolated real-publisher contract coverage: empty/single/multiple recipients; exact workspace predicate/projection; event payload with null boardId; workspace and sequential user fanout/message fields; swallowed pubsub rejection; propagated write/DB/user rejection and short-circuiting. New paths were checked against tracked files before creation. BASE passes the new test. Temporary wrong-workspace predicate mutation fails on the exact predicate assertion, restored before the type-only edit (sensitivity RED, not a production bug).

## Verification
Base: `28a539ff3a9d8a907a13150aecd0c87e8e3342c0`, clean fetched/fast-forwarded main. Fresh BASE broad checks captured before edits.
- Focused ESLint all 3 touched files: zero errors/warnings.
- Focused executable test: 1 pass, 0 fail.
- Full ESLint: 2445 errors / 3 warnings (down 2 from supplied post-240 baseline 2447 / 3).
- `bun run typecheck`: exit 2, same 147 complete multiline diagnostic blocks, no additions/removals.
- `bun test`: BASE 1225 pass / 3 skip / 180 fail / 30 errors; HEAD 1226 pass / 3 skip / 180 fail / 30 errors. File-qualified named failure and complete unhandled-error block multisets unchanged. 150 named failures + 30 unhandled errors reconcile to 180 failures; all existing passing and skipped identities preserved, one new pass.
- `bun run build:client`: exit 0.
- `git diff --check`: exit 0.

Evidence directory on implementation host: `/tmp/chimedeck-lint-slice-EGpWWM/`. Logs: `base-typecheck.txt`, `base-test.txt`, `head-typecheck.txt`, `head-test.txt`, `base-focused.txt`, `mutation-red.txt`, `head-focused.txt`, `focused-eslint.txt`, `head-full-lint.txt`, `build-client.txt`, `diff-check.txt`. Comparison artifacts: `compare.py`, `comparison.json`, `{base,head}-diagnostics.json`, `{base,head}-identities.json`, `{base,head}.js`.

## Limits
Real publisher exercised with fake DB, event writer, pubsub and user transport in a child Bun process; does not prove live SQL filtering/schema acceptance, persistence, Redis/WebSocket delivery or delete-route authentication. No UI changed or UI/E2E acceptance claimed. Existing broad-suite failures remain, not green. Independent parent review required; no approval or merge performed.
