### PR TITLE
refactor(webhooks): type global list read boundary

### DIFF
--- a/server/extensions/webhooks/api/__tests__/fixtures/listRead.ts
+++ b/server/extensions/webhooks/api/__tests__/fixtures/listRead.ts
@@ -1,0 +1,69 @@
+import { strict as assert } from 'node:assert';
+import { mock } from 'bun:test';
+
+const calls: unknown[] = [];
+const state: { authError: Response | null; failure?: Error; rows: unknown[] } = {
+  authError: null,
+  rows: [],
+};
+void mock.module('../../../../../common/db', () => ({
+  db(table: string) {
+    calls.push(table);
+    return {
+      where(filter: Record<string, boolean>) {
+        calls.push(filter);
+        return this;
+      },
+      orderBy(column: string, direction: string) {
+        calls.push([column, direction]);
+        return this;
+      },
+      select(...columns: string[]) {
+        calls.push(columns);
+        return state.failure ? Promise.reject(state.failure) : Promise.resolve(state.rows);
+      },
+    };
+  },
+}));
+void mock.module('../../../../auth/middlewares/authentication', () => ({
+  authenticate(req: Request) {
+    calls.push(req);
+    return Promise.resolve(state.authError);
+  },
+}));
+const { handleListWebhooks } = await import('../../list');
+const req = new Request('http://localhost/api/v1/webhooks');
+const query = [req, 'webhooks', { is_active: true }, ['created_at', 'desc'],
+  ['id', 'label', 'endpoint_url', 'event_types', 'is_active', 'created_at']];
+
+state.authError = new Response('denied', { status: 401 });
+assert.equal(await handleListWebhooks(req), state.authError);
+assert.deepEqual(calls, [req]);
+state.authError = null;
+calls.length = 0;
+const empty = await handleListWebhooks(req);
+assert.equal(empty.status, 200);
+assert.deepEqual(await empty.json(), { data: [] });
+assert.deepEqual(calls, query);
+
+// JSONB is not schema-constrained to strings or arrays: preserve its value.
+for (const eventTypes of [[], ['card.created'], { unexpected: true }, null, 42]) {
+  calls.length = 0;
+  state.rows = [{ id: 'hook-a', label: 'A', endpoint_url: 'https://example.com/a',
+    event_types: eventTypes, is_active: true, created_at: new Date('2026-01-02T03:04:05Z'),
+    signing_secret: 'must-not-leak', workspace_id: null, created_by: 'another-user' },
+  { id: 'hook-b', label: 'B', endpoint_url: 'https://example.com/b',
+    event_types: [], is_active: true, created_at: '2026-01-01T00:00:00.000Z' }];
+  const response = await handleListWebhooks(req);
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { data: [
+    { id: 'hook-a', label: 'A', endpointUrl: 'https://example.com/a', eventTypes,
+      isActive: true, createdAt: '2026-01-02T03:04:05.000Z' },
+    { id: 'hook-b', label: 'B', endpointUrl: 'https://example.com/b', eventTypes: [],
+      isActive: true, createdAt: '2026-01-01T00:00:00.000Z' },
+  ] });
+  assert.deepEqual(calls, query);
+}
+state.failure = new Error('webhook read failed');
+await assert.rejects(handleListWebhooks(req), state.failure);
+console.info('webhook list auth short-circuit, global query, projection, JSONB and rejection verified');

--- a/server/extensions/webhooks/api/__tests__/listRead.test.ts
+++ b/server/extensions/webhooks/api/__tests__/listRead.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'bun:test';
+
+// Isolate shared auth/DB mocks while exercising the real handler.
+test('real webhook list preserves authentication, global active query and secret-free response', async () => {
+  const child = Bun.spawn([process.execPath, new URL('./fixtures/listRead.ts', import.meta.url).pathname], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  expect(stderr).toBe('');
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain('JSONB and rejection verified');
+});

--- a/server/extensions/webhooks/api/list.ts
+++ b/server/extensions/webhooks/api/list.ts
@@ -4,11 +4,21 @@ import { db } from '../../../common/db';
 import { authenticate } from '../../auth/middlewares/authentication';
 import type { AuthenticatedRequest } from '../../auth/middlewares/authentication';
 
+// Read projection from migrations 0106/0107; the registry is global.
+interface WebhookListRow {
+  id: string;
+  label: string;
+  endpoint_url: string;
+  event_types: unknown;
+  is_active: boolean;
+  created_at: Date;
+}
+
 export async function handleListWebhooks(req: Request): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const rows = await db('webhooks')
+  const rows = await db<WebhookListRow>('webhooks')
     .where({ is_active: true })
     .orderBy('created_at', 'desc')
     .select('id', 'label', 'endpoint_url', 'event_types', 'is_active', 'created_at');


### PR DESCRIPTION
## Summary
- Type the global webhook-list Knex read projection from migrations 0106/0107; retain unconstrained JSONB as `unknown`.
- Preserve authentication, active-only global query, descending creation order, exact selected columns and secret-free response. Production Bun-transpiled JavaScript is byte-identical to base.
- Add durable subprocess-isolated coverage of the real handler with mocked auth/DB boundaries: auth short-circuit, empty/populated results, global query/projection, JSONB values, timestamp serialization and rejection propagation.

## Verification
Base: c7133e2b0961675f4fbfabfbde4ddd435be9e7c4.
- Focused ESLint on all three touched files: 0 errors/warnings (12 existing production errors removed).
- Focused test: passes against base and head. Temporary descending-to-ascending mutation fails the query assertion; restored and passes.
- `bun run build:client` and `git diff --check`: pass.
- `bun run typecheck`: existing failure, exactly the same 147 complete multiline diagnostic blocks at base/head.
- `bun test`: base 1226 pass / 3 skip / 180 fail / 30 errors; head 1227 pass / 3 skip / 180 fail / 30 errors. File-qualified multisets match for all 150 named failures and 30 complete unhandled-error blocks; no passing identities lost, one new pass. Named failures + unhandled errors reconcile to 180.
- Evidence: `/tmp/chimedeck-webhook-list-cA4oMo/` (logs, emitted JS, comparison.py, comparison.json, parsed identities).

## Limits
No live database, router, or real authentication integration is claimed: transport seams are mocked in an isolated child process. Type assertions describe the migration-backed DB read; they do not add runtime validation. No payment/billing, dependencies, configuration, deployment, or stable changes. Independent review required; not approved or merged.
