### PR TITLE
refactor: type email verification middleware user read

### DIFF
--- a/server/middlewares/__tests__/fixtures/requireVerified.fixture.ts
+++ b/server/middlewares/__tests__/fixtures/requireVerified.fixture.ts
@@ -1,0 +1,80 @@
+import { strict as assert } from 'node:assert';
+import { mock } from 'bun:test';
+import type { AuthenticatedRequest } from '../../../extensions/auth/middlewares/authentication';
+
+let enabled = true;
+let row: { email_verified: boolean } | undefined;
+const errors: { flag?: Error; db?: Error } = {};
+const calls: unknown[] = [];
+
+void mock.module('../../../common/db', () => ({
+  db(table: string) {
+    calls.push(['table', table]);
+    return {
+      where(condition: unknown) {
+        calls.push(['where', condition]);
+        return this;
+      },
+      select(column: string) {
+        calls.push(['select', column]);
+        return this;
+      },
+      first() {
+        calls.push(['first']);
+        return errors.db ? Promise.reject(errors.db) : Promise.resolve(row);
+      },
+    };
+  },
+}));
+void mock.module('../../../mods/flags', () => ({
+  flags: {
+    isEnabled(key: string) {
+      calls.push(['flag', key]);
+      return errors.flag ? Promise.reject(errors.flag) : Promise.resolve(enabled);
+    },
+  },
+}));
+
+const { requireVerified } = await import('../../requireVerified');
+function request(id?: string): AuthenticatedRequest {
+  const req: AuthenticatedRequest = new Request('http://127.0.0.1/private');
+  if (id !== undefined) req.currentUser = { id, email: 'user@example.test' };
+  return req;
+}
+const flagCall = ['flag', 'EMAIL_VERIFICATION_ENABLED'];
+const queryCalls = [flagCall, ['table', 'users'], ['where', { id: 'user-1' }], ['select', 'email_verified'], ['first']];
+
+enabled = false;
+for (const req of [request(), request('user-1')]) {
+  calls.length = 0;
+  assert.equal(await requireVerified(req), null);
+  assert.deepEqual(calls, [flagCall]);
+}
+enabled = true;
+for (const req of [request(), request('')]) {
+  calls.length = 0;
+  const response = await requireVerified(req);
+  assert.equal(response?.status, 401);
+  assert.deepEqual(await response.json(), { error: { code: 'unauthorized', message: 'Authentication required' } });
+  assert.deepEqual(calls, [flagCall]);
+}
+for (const result of [undefined, { email_verified: false }, { email_verified: true }]) {
+  row = result;
+  calls.length = 0;
+  const response = await requireVerified(request('user-1'));
+  if (result?.email_verified) {
+    assert.equal(response, null);
+  } else {
+    assert.equal(response?.status, 403);
+    assert.deepEqual(await response.json(), { error: { code: 'email-not-verified', message: 'Please verify your email to continue.' } });
+  }
+  assert.deepEqual(calls, queryCalls);
+}
+errors.db = new Error('database unavailable');
+calls.length = 0;
+await assert.rejects(requireVerified(request('user-1')), errors.db);
+assert.deepEqual(calls, queryCalls);
+errors.flag = new Error('flags unavailable');
+calls.length = 0;
+await assert.rejects(requireVerified(request('user-1')), errors.flag);
+assert.deepEqual(calls, [flagCall]);

--- a/server/middlewares/__tests__/requireVerified.contract.test.ts
+++ b/server/middlewares/__tests__/requireVerified.contract.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+
+test('requireVerified real middleware preserves flag, identity, query, response and rejection contracts', () => {
+  // Shared DB/flags mocks stay in a child process, away from other suites.
+  const fixture = fileURLToPath(new URL('./fixtures/requireVerified.fixture.ts', import.meta.url));
+  const result = Bun.spawnSync([process.execPath, fixture], { stdout: 'pipe', stderr: 'pipe' });
+  expect(result.stderr.toString()).toBe('');
+  expect(result.exitCode).toBe(0);
+});

--- a/server/middlewares/requireVerified.ts
+++ b/server/middlewares/requireVerified.ts
@@ -5,6 +5,12 @@ import { db } from '../common/db';
 import { flags } from '../mods/flags';
 import type { AuthenticatedRequest } from '../extensions/auth/middlewares/authentication';
 
+// db/migrations/0002_auth.ts and 0014_email_verification.ts.
+interface VerificationUserRow {
+  id: string;
+  email_verified: boolean;
+}
+
 export async function requireVerified(req: AuthenticatedRequest): Promise<Response | null> {
   const verificationEnabled = await flags.isEnabled('EMAIL_VERIFICATION_ENABLED');
   if (!verificationEnabled) return null;
@@ -17,7 +23,7 @@ export async function requireVerified(req: AuthenticatedRequest): Promise<Respon
     );
   }
 
-  const user = await db('users').where({ id: userId }).select('email_verified').first();
+  const user = await db<VerificationUserRow>('users').where({ id: userId }).select('email_verified').first();
   if (!user?.email_verified) {
     return Response.json(
       { error: { code: 'email-not-verified', message: 'Please verify your email to continue.' } },


### PR DESCRIPTION
## Summary
- Type the `requireVerified` users query using migration-derived `id: string` and non-null `email_verified: boolean` (0002_auth, 0014_email_verification).
- Preserve optional missing-row handling and all flag/auth/query/response/error behavior. BASE/HEAD Bun-transpiled production JavaScript is byte-identical; no non-erased production changes.
- Add durable subprocess-isolated real-middleware coverage for disabled flags with/without identity, absent/empty identity, missing/unverified/verified rows, exact table/user predicate/projection/first calls, response bodies/statuses, and DB/flag rejection propagation.

## Validation
Fresh BASE captured on `dbc7ce159e4cca0d5d38b03693091c72475013bf` before edits.
- Focused ESLint on all three touched files: **0 errors, 0 warnings**.
- Focused contract test: **1 pass**, both BASE and HEAD. Temporary wrong-user predicate mutation produced the expected assertion failure; restored before typing (sensitivity RED, not a pre-existing defect).
- `bun run typecheck`: existing exit 2; **147 complete multiline diagnostic blocks identical**, none added/removed.
- `bun test`: BASE **1227 pass / 3 skip / 180 fail / 30 errors**; HEAD **1228 pass / 3 skip / 180 fail / 30 errors**. File-qualified multisets: **150 named failures + 30 complete unhandled-error blocks = 180 aggregate failures**, identical. All existing passing and skipped identities retained; one new passing contract test.
- `bun run build:client`: exit 0.
- `git diff --check`: exit 0.
- Full ESLint: **2431 errors / 3 warnings**, down from supplied post-242 baseline **2433 / 3**.

## Evidence and limitations
Local artifacts: `/tmp/chimedeck-lint-slice-wWjwOy/` with `base-typecheck.log`, `base-test.log`, `head-typecheck.log`, `head-test.log`, `base-parsed.json`, `head-parsed.json`, `comparison.json`, `compare.py`, `focused-base-final.log`, `mutation-red.log`, `focused-head.log`, `focused-eslint.log`, `head-full-eslint.log`, `build-client.log`, `base-emitted.js`, `head-emitted.js`.
Tests execute the real middleware with fake DB and flags in a separate Bun process. They establish branching, query-call and response contracts, not live PostgreSQL filtering/schema enforcement, real flag provider behavior, router composition, or upstream authentication. No UI changed; browser/E2E not run. No payment, configuration, dependency, deployment or stable-branch changes. Existing broad-suite/typecheck failures remain unresolved and explicitly compared above.

Implementation only; independent review and approval/merge remain with the parent reviewer.
