### PR TITLE
Type users/profile GET+PATCH handler DB row reads

### DIFF
--- a/server/extensions/users/api/profile/__tests__/fixtures/profileHandlers.ts
+++ b/server/extensions/users/api/profile/__tests__/fixtures/profileHandlers.ts
@@ -1,0 +1,172 @@
+import { strict as assert } from 'node:assert';
+import { mock } from 'bun:test';
+
+const calls: unknown[] = [];
+const state: {
+  authError: Response | null;
+  currentUser: { id: string } | null;
+  row: Record<string, unknown> | undefined;
+  updated: Record<string, unknown>[];
+} = { authError: null, currentUser: { id: 'user-1' }, row: undefined, updated: [] };
+
+void mock.module('../../../../../../common/db', () => ({
+  db(table: string) {
+    calls.push(table);
+    return {
+      where(filter: Record<string, unknown>) {
+        calls.push(['where', filter]);
+        return this;
+      },
+      whereNot(filter: Record<string, unknown>) {
+        calls.push(['whereNot', filter]);
+        return this;
+      },
+      update(values: Record<string, unknown>) {
+        calls.push(['update', values]);
+        return this;
+      },
+      returning(columns: string) {
+        calls.push(['returning', columns]);
+        return Promise.resolve(state.updated);
+      },
+      first() {
+        calls.push('first');
+        return Promise.resolve(state.row);
+      },
+    };
+  },
+}));
+void mock.module('../../../../../auth/middlewares/authentication', () => ({
+  authenticate(req: Request) {
+    calls.push(req);
+    (req as { currentUser?: unknown }).currentUser = state.currentUser;
+    return Promise.resolve(state.authError);
+  },
+}));
+void mock.module('../../../../../../common/avatar/resolveAvatarUrl', () => ({
+  buildAvatarProxyUrl({ userId, avatarUrl }: { userId: string; avatarUrl: string | null }) {
+    calls.push(['buildAvatarProxyUrl', userId, avatarUrl]);
+    return avatarUrl ? `/api/v1/users/${userId}/avatar` : null;
+  },
+}));
+
+const { handleGetProfile } = await import('../../get');
+const { handleUpdateProfile } = await import('../../update');
+
+// --- GET: auth short-circuit ---
+const getReq = new Request('http://localhost/api/v1/users/me');
+state.authError = new Response('denied', { status: 401 });
+assert.equal((await handleGetProfile(getReq)).status, 401);
+state.authError = null;
+
+// --- GET: missing authenticated user guard ---
+state.currentUser = null;
+calls.length = 0;
+const noUserRes = await handleGetProfile(new Request('http://localhost/api/v1/users/me'));
+assert.equal(noUserRes.status, 401);
+assert.deepEqual(await noUserRes.json(), {
+  error: { code: 'unauthorized', message: 'Missing authenticated user' },
+});
+state.currentUser = { id: 'user-1' };
+
+// --- GET: user not found ---
+state.row = undefined;
+calls.length = 0;
+const notFoundRes = await handleGetProfile(new Request('http://localhost/api/v1/users/me'));
+assert.equal(notFoundRes.status, 404);
+
+// --- GET: full projection, nullable fields and boolean preserved ---
+state.row = {
+  id: 'user-1',
+  email: 'user@example.com',
+  name: 'Alice',
+  nickname: null,
+  avatar_url: null,
+  email_verified: false,
+  created_at: '2026-01-01T00:00:00.000Z',
+};
+calls.length = 0;
+const okRes = await handleGetProfile(new Request('http://localhost/api/v1/users/me'));
+assert.equal(okRes.status, 200);
+assert.deepEqual(await okRes.json(), {
+  data: {
+    id: 'user-1',
+    email: 'user@example.com',
+    name: 'Alice',
+    nickname: null,
+    avatar_url: null,
+    email_verified: false,
+    created_at: '2026-01-01T00:00:00.000Z',
+  },
+});
+
+// --- UPDATE: rejects invalid nickname without touching DB ---
+calls.length = 0;
+const badNicknameReq = new Request('http://localhost/api/v1/users/me', {
+  method: 'PATCH',
+  body: JSON.stringify({ nickname: 'a b' }),
+});
+const badNicknameRes = await handleUpdateProfile(badNicknameReq);
+assert.equal(badNicknameRes.status, 400);
+assert.deepEqual(calls, [badNicknameReq]);
+
+// --- UPDATE: nickname uniqueness conflict ---
+calls.length = 0;
+state.row = { id: 'user-2' };
+const conflictReq = new Request('http://localhost/api/v1/users/me', {
+  method: 'PATCH',
+  body: JSON.stringify({ nickname: 'taken' }),
+});
+const conflictRes = await handleUpdateProfile(conflictReq);
+assert.equal(conflictRes.status, 409);
+assert.deepEqual(calls, [
+  conflictReq,
+  'users',
+  ['where', { nickname: 'taken' }],
+  ['whereNot', { id: 'user-1' }],
+  'first',
+]);
+
+// --- UPDATE: applies nickname + name, returns full projection ---
+calls.length = 0;
+state.row = undefined;
+state.updated = [{
+  id: 'user-1',
+  email: 'user@example.com',
+  name: 'Alice B',
+  nickname: 'alice_b',
+  avatar_url: 's3://bucket/key',
+  email_verified: true,
+  created_at: '2026-01-01T00:00:00.000Z',
+}];
+const updateReq = new Request('http://localhost/api/v1/users/me', {
+  method: 'PATCH',
+  body: JSON.stringify({ nickname: 'alice_b', name: 'Alice B' }),
+});
+const updateRes = await handleUpdateProfile(updateReq);
+assert.equal(updateRes.status, 200);
+assert.deepEqual(await updateRes.json(), {
+  data: {
+    id: 'user-1',
+    email: 'user@example.com',
+    name: 'Alice B',
+    nickname: 'alice_b',
+    avatar_url: '/api/v1/users/user-1/avatar',
+    email_verified: true,
+    created_at: '2026-01-01T00:00:00.000Z',
+  },
+});
+assert.deepEqual(calls, [
+  updateReq,
+  'users',
+  ['where', { nickname: 'alice_b' }],
+  ['whereNot', { id: 'user-1' }],
+  'first',
+  'users',
+  ['where', { id: 'user-1' }],
+  ['update', { name: 'Alice B', nickname: 'alice_b' }],
+  ['returning', '*'],
+  ['buildAvatarProxyUrl', 'user-1', 's3://bucket/key'],
+]);
+
+console.info('profile get/update auth guards, nickname validation, uniqueness and projection verified');

--- a/server/extensions/users/api/profile/__tests__/profileHandlers.test.ts
+++ b/server/extensions/users/api/profile/__tests__/profileHandlers.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'bun:test';
+
+// Isolate shared DB/auth mocks in a subprocess while exercising real handlers.
+test('real profile get/update handlers preserve auth, nickname validation and projection', async () => {
+  const child = Bun.spawn(
+    [process.execPath, new URL('./fixtures/profileHandlers.ts', import.meta.url).pathname],
+    { stdout: 'pipe', stderr: 'pipe' },
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  expect(stderr).toBe('');
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain('profile get/update auth guards, nickname validation, uniqueness');
+});

--- a/server/extensions/users/api/profile/get.ts
+++ b/server/extensions/users/api/profile/get.ts
@@ -3,12 +3,31 @@ import { db } from '../../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../../auth/middlewares/authentication';
 import { buildAvatarProxyUrl } from '../../../../common/avatar/resolveAvatarUrl';
 
+// Matches the `users` table columns read here (migrations 0002, 0014, 0015).
+type UserRow = {
+  id: string;
+  email: string;
+  name: string;
+  nickname: string | null;
+  avatar_url: string | null;
+  email_verified: boolean;
+  created_at: string;
+};
+
 export async function handleGetProfile(req: Request): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const { currentUser } = req as AuthenticatedRequest;
-  const user = await db('users').where({ id: currentUser!.id }).first();
+  const authenticatedReq = req as AuthenticatedRequest;
+  const { currentUser } = authenticatedReq;
+  if (!currentUser) {
+    return Response.json(
+      { error: { code: 'unauthorized', message: 'Missing authenticated user' } },
+      { status: 401 },
+    );
+  }
+
+  const user = await db('users').where({ id: currentUser.id }).first<UserRow | undefined>();
 
   if (!user) {
     return Response.json(
@@ -26,7 +45,7 @@ export async function handleGetProfile(req: Request): Promise<Response> {
       name: user.name,
       nickname: user.nickname ?? null,
       avatar_url: avatarUrl,
-      email_verified: user.email_verified ?? false,
+      email_verified: user.email_verified,
       created_at: user.created_at,
     },
   });

--- a/server/extensions/users/api/profile/update.ts
+++ b/server/extensions/users/api/profile/update.ts
@@ -5,11 +5,29 @@ import { buildAvatarProxyUrl } from '../../../../common/avatar/resolveAvatarUrl'
 
 const NICKNAME_PATTERN = /^[a-zA-Z0-9_-]{1,50}$/;
 
+// Matches the `users` table columns read/written here (migrations 0002, 0014, 0015).
+type UserRow = {
+  id: string;
+  email: string;
+  name: string;
+  nickname: string | null;
+  avatar_url: string | null;
+  email_verified: boolean;
+  created_at: string;
+};
+
 export async function handleUpdateProfile(req: Request): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const { currentUser } = req as AuthenticatedRequest;
+  const authenticatedReq = req as AuthenticatedRequest;
+  const { currentUser } = authenticatedReq;
+  if (!currentUser) {
+    return Response.json(
+      { error: { code: 'unauthorized', message: 'Missing authenticated user' } },
+      { status: 401 },
+    );
+  }
 
   let body: { nickname?: string; name?: string };
   try {
@@ -47,8 +65,8 @@ export async function handleUpdateProfile(req: Request): Promise<Response> {
     // Check uniqueness — exclude the current user
     const existing = await db('users')
       .where({ nickname: body.nickname })
-      .whereNot({ id: currentUser!.id })
-      .first();
+      .whereNot({ id: currentUser.id })
+      .first<Pick<UserRow, 'id'> | undefined>();
 
     if (existing) {
       return Response.json(
@@ -68,9 +86,9 @@ export async function handleUpdateProfile(req: Request): Promise<Response> {
   }
 
   const [user] = await db('users')
-    .where({ id: currentUser!.id })
+    .where({ id: currentUser.id })
     .update(updates)
-    .returning('*');
+    .returning<UserRow[]>('*');
 
   if (!user) {
     return Response.json(
@@ -88,7 +106,7 @@ export async function handleUpdateProfile(req: Request): Promise<Response> {
       name: user.name,
       nickname: user.nickname ?? null,
       avatar_url: avatarUrl,
-      email_verified: user.email_verified ?? false,
+      email_verified: user.email_verified,
       created_at: user.created_at,
     },
   });


### PR DESCRIPTION
## Scope

Small, cohesive server-side ESLint slice: `server/extensions/users/api/profile/{get,update}.ts`
(GET/PATCH `/api/v1/users/me`, full-profile variant with nickname). Non-payment.

## Change

Replace `any`-typed, non-null-asserted `db('users')` reads with a migration-derived
`UserRow` type (columns from `db/migrations/0002_auth.ts`, `0014_email_verification.ts`,
`0015_user_profile.ts`), matching the existing typed pattern already used in
`server/extensions/users/api/me.ts`.

- `currentUser!.id` → explicit `if (!currentUser) return 401` guard (was previously a
  non-null assertion; the guard makes the failure mode explicit instead of throwing).
- `.first()` / `.returning('*')` are typed against `UserRow` (and `Pick<UserRow, 'id'>`
  for the existence-only nickname-uniqueness check).
- Dropped the now-redundant `email_verified ?? false` fallback: migration 0014 makes the
  column `NOT NULL DEFAULT false`, so the type is `boolean`, not `boolean | undefined`.

No route, auth, or response-shape/API-contract changes.

## Tests

Added `server/extensions/users/api/profile/__tests__/profileHandlers.test.ts`, which
spawns a subprocess fixture (`__tests__/fixtures/profileHandlers.ts`) that mocks
`common/db`, `auth/middlewares/authentication`, and `common/avatar/resolveAvatarUrl`
in isolation (per repo convention, to avoid `mock.module` leakage into the shared
suite) and exercises the **real** `handleGetProfile` / `handleUpdateProfile` handlers:

- auth short-circuit (401)
- missing-`currentUser` guard (401, exact body)
- user-not-found (404)
- full projection incl. nullable `nickname`/`avatar_url` and boolean `email_verified`
- nickname-format rejection without touching the DB
- nickname-uniqueness conflict (409) with exact `where`/`whereNot` query shape
- successful update returning full projection with avatar-proxy URL substitution

This is durable handler-level coverage of the changed module, not a mock-only smoke test.
Live DB/router integration and browser/E2E coverage are **not** exercised here (none
existed before this slice either); that gap is pre-existing and unchanged.

## Verification (fresh BASE captured before edits, `origin/main` @ `30bea5aa`)

| Gate | BASE | HEAD | Result |
|---|---|---|---|
| `bun test` (full suite) | 1228 pass / 3 skip / 180 fail / 30 errors | 1229 pass / 3 skip / 180 fail / 30 errors | +1 pass (new test); fail/error **named identities reconciled — no new, none lost** (verified via full-multiline diff, timestamps normalized) |
| `bun run typecheck` | 147 diagnostics | 147 diagnostics | Byte-identical diagnostic set (`diff` empty) |
| Focused `eslint` on touched files | 18 errors (get.ts) + 18 errors (update.ts) pre-slice | 0 | Clean |
| `bun run build:client` | — | exit 0 | Passes (pre-existing >500kB chunk-size warning only) |
| `git diff --check` | — | clean | No whitespace issues |

Logs (unique per run):
- `/tmp/chimedeck-base-typecheck.log`, `/tmp/chimedeck-head-typecheck-244.log`
- `/tmp/chimedeck-base-test.log`, `/tmp/chimedeck-head-test-244.log`
- `/tmp/base-fails-244.txt`, `/tmp/head-fails-244.txt` (+ normalized variants)
- `/tmp/chimedeck-slice-eslint-244.txt`
- `/tmp/chimedeck-head-buildclient-244.log`

## Emitted-JS comparison (Bun `--target bun --external '*'` transpile, base vs head)

Not byte-identical — two real, intentional deltas (reported honestly, not erased):

1. `get.ts`/`update.ts`: `const { currentUser } = req;` → explicit
   `if (!currentUser) return 401` block. Behavior-preserving in the reachable
   path (authenticate() only returns without error when currentUser is set),
   but is a genuine defensive-guard addition replacing a non-null assertion.
2. `email_verified ?? false` → `email_verified`: erased fallback, verified
   equivalent for all real rows given the `NOT NULL DEFAULT false` migration
   constraint (0014_email_verification.ts).

No other emitted-JS differences.

## Boundaries

- No repo-wide `eslint --fix`, no suppression comments, no config/dependency/
  deployment changes.
- No payments/billing/subscription code touched.
- Not merging this PR — opening for separate review per standing policy.
