### PR TITLE
lint: type forgot-password user row lookup

### DIFF
--- a/server/extensions/auth/api/forgotPassword.fixture.ts
+++ b/server/extensions/auth/api/forgotPassword.fixture.ts
@@ -1,0 +1,130 @@
+// Subprocess fixture: exercises handleForgotPassword with a mocked DB module
+// isolated in a child process so the shared db mock cannot leak into the suite.
+import { mock } from 'bun:test';
+import assert from 'node:assert/strict';
+
+const scenario = process.argv[2];
+
+const existingUser = { id: 'user-a', email: 'known@example.com' };
+const calls: { table: string; op: string; filter?: unknown; payload?: unknown }[] = [];
+const sentEmails: { to: string; subject: string }[] = [];
+
+void mock.module('../../../common/db', () => ({
+  db: (table: string) => ({
+    where: (filter: unknown) => ({
+      first: () => {
+        calls.push({ table, op: 'first', filter });
+        if (scenario === 'missing-user') return Promise.resolve(undefined);
+        return Promise.resolve(existingUser);
+      },
+      update: (payload: unknown) => {
+        calls.push({ table, op: 'update', filter, payload });
+        return Promise.resolve(1);
+      },
+    }),
+  }),
+}));
+
+void mock.module('../../email', () => ({
+  send: (payload: { to: string; subject: string }) => {
+    sentEmails.push({ to: payload.to, subject: payload.subject });
+    return Promise.resolve();
+  },
+}));
+
+void mock.module('../../email/templates/passwordResetEmail', () => ({
+  buildPasswordResetEmail: () =>
+    Promise.resolve({ subject: 'Reset your password', html: '<p>reset</p>', text: 'reset' }),
+}));
+
+const { handleForgotPassword } = await import('./forgotPassword');
+
+if (scenario === 'rate-limited') {
+  const req = () =>
+    new Request('http://127.0.0.1/api/v1/auth/forgot-password', {
+      method: 'POST',
+      headers: { 'x-forwarded-for': '203.0.113.9' },
+      body: JSON.stringify({ email: existingUser.email }),
+    });
+  // Exhaust the 5/hour limit, then confirm the 6th request is short-circuited.
+  for (let i = 0; i < 5; i++) {
+    const res = await handleForgotPassword(req());
+    assert.equal(res.status, 200);
+  }
+  const beforeCalls = calls.length;
+  const limited = await handleForgotPassword(req());
+  assert.equal(limited.status, 200);
+  assert.deepEqual(await limited.json(), { data: { sent: true } });
+  assert.equal(calls.length, beforeCalls, 'rate-limited request must not touch the database');
+  assert.equal(sentEmails.length, 5, 'only the first 5 requests should send email');
+} else if (scenario === 'bad-json') {
+  const res = await handleForgotPassword(
+    new Request('http://127.0.0.1/api/v1/auth/forgot-password', {
+      method: 'POST',
+      headers: { 'x-forwarded-for': '203.0.113.10' },
+      body: '{not-json',
+    }),
+  );
+  assert.equal(res.status, 400);
+  assert.deepEqual(await res.json(), {
+    error: { code: 'bad-request', message: 'Invalid JSON body' },
+  });
+  assert.equal(calls.length, 0);
+} else if (scenario === 'missing-email') {
+  const res = await handleForgotPassword(
+    new Request('http://127.0.0.1/api/v1/auth/forgot-password', {
+      method: 'POST',
+      headers: { 'x-forwarded-for': '203.0.113.11' },
+      body: JSON.stringify({}),
+    }),
+  );
+  assert.equal(res.status, 400);
+  assert.deepEqual(await res.json(), {
+    error: { code: 'bad-request', message: 'email is required' },
+  });
+  assert.equal(calls.length, 0);
+} else if (scenario === 'missing-user') {
+  const res = await handleForgotPassword(
+    new Request('http://127.0.0.1/api/v1/auth/forgot-password', {
+      method: 'POST',
+      headers: { 'x-forwarded-for': '203.0.113.12' },
+      body: JSON.stringify({ email: 'nobody@example.com' }),
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { data: { sent: true } });
+  // Must look up the user but never issue an update or send an email — no enumeration signal.
+  assert.deepEqual(calls, [
+    { table: 'users', op: 'first', filter: { email: 'nobody@example.com' } },
+  ]);
+  assert.equal(sentEmails.length, 0);
+} else if (scenario === 'known-user') {
+  const res = await handleForgotPassword(
+    new Request('http://127.0.0.1/api/v1/auth/forgot-password', {
+      method: 'POST',
+      headers: { 'x-forwarded-for': '203.0.113.13' },
+      body: JSON.stringify({ email: '  Known@Example.com  ' }),
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { data: { sent: true } });
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[0], {
+    table: 'users',
+    op: 'first',
+    filter: { email: 'known@example.com' },
+  });
+  const updateCall = calls[1];
+  assert.ok(updateCall);
+  assert.equal(updateCall.table, 'users');
+  assert.equal(updateCall.op, 'update');
+  assert.deepEqual(updateCall.filter, { id: existingUser.id });
+  const payload = updateCall.payload as { password_reset_token: string; password_reset_token_expires_at: Date };
+  assert.equal(typeof payload.password_reset_token, 'string');
+  assert.equal(payload.password_reset_token.length, 64);
+  assert.ok(payload.password_reset_token_expires_at instanceof Date);
+  assert.equal(sentEmails.length, 1);
+  assert.deepEqual(sentEmails[0], { to: 'known@example.com', subject: 'Reset your password' });
+} else {
+  throw new Error(`unknown scenario: ${scenario ?? '(none)'}`);
+}

--- a/server/extensions/auth/api/forgotPassword.test.ts
+++ b/server/extensions/auth/api/forgotPassword.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const fixture = fileURLToPath(new URL('./forgotPassword.fixture.ts', import.meta.url));
+
+// Real db/email modules are mocked inside the child process only, so this
+// suite's shared DB mocks can never leak into (or be leaked into by) adjacent tests.
+test.each([
+  'rate-limited', 'bad-json', 'missing-email', 'missing-user', 'known-user',
+])('forgot password boundary: %s', (scenario) => {
+  const result = spawnSync(process.execPath, [fixture, scenario], { encoding: 'utf8' });
+  expect(result.error).toBeUndefined();
+  expect(result.stderr).toBe('');
+  expect(result.status).toBe(0);
+});

--- a/server/extensions/auth/api/forgotPassword.ts
+++ b/server/extensions/auth/api/forgotPassword.ts
@@ -11,6 +11,11 @@ import { env } from '../../../config/env';
 const RATE_LIMIT_MAX = 5;
 const RATE_LIMIT_WINDOW_SECONDS = 3600; // 1 hour
 
+type UserRow = {
+  id: string;
+  email: string;
+};
+
 export async function handleForgotPassword(req: Request): Promise<Response> {
   // Rate limit by IP: 5 requests per hour
   const ip = req.headers.get('x-forwarded-for') ?? req.headers.get('cf-connecting-ip') ?? 'unknown';
@@ -41,7 +46,7 @@ export async function handleForgotPassword(req: Request): Promise<Response> {
   const email = body.email.toLowerCase().trim();
 
   // Always return success — look up user silently
-  const user = await db('users').where({ email }).first();
+  const user = await db<UserRow>('users').where({ email }).first();
   if (user) {
     const token = randomBytes(32).toString('hex');
     const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 1 hour


### PR DESCRIPTION
## Scope
Small non-payment ESLint slice: types the `users` row lookup in `handleForgotPassword` to a minimal `UserRow { id, email }` shape (matching `db/migrations/0002_auth.ts` + `0026_password_reset.ts`), removing 3 `no-unsafe-*` findings. No runtime/auth/API contract changes — response codes, rate-limit behaviour, and no-enumeration guarantee are unchanged.

## Files touched
- `server/extensions/auth/api/forgotPassword.ts` (typed boundary)
- `server/extensions/auth/api/forgotPassword.test.ts` (new)
- `server/extensions/auth/api/forgotPassword.fixture.ts` (new, subprocess-isolated)

## Why a new test
No existing test covered this handler. Added a durable handler-level test using the repo's subprocess-isolation pattern (see `cardWritable.test.ts`/`.fixture.ts`): the child process mocks `../../../common/db`, `../../email`, and the email template module so this suite's DB/email mocks can never leak into (or be leaked into by) adjacent suites. Covers: rate-limit short-circuit (5/hr, DB untouched on the 6th), malformed JSON body, missing email field, unknown email (no-enumeration: 200 + no update/email), and known user (email normalization, reset token shape/expiry, update filter, email dispatch).

## Verification (fresh evidence, this run)
- Base @ `ef1c4dd9` (origin/main, clean ff): `bun run typecheck` → 147 errors (`/tmp/chimedeck-base-typecheck.log`); `bun test` → 1243 pass / 3 skip / 180 fail / 30 errors (`/tmp/chimedeck-base-test.log`), matching the recorded historical baseline.
- HEAD typecheck: 147 errors, **byte-identical diagnostic set** to base (`diff` clean) — no new/regressed diagnostics.
- HEAD `bun test`: 1248 pass / 3 skip / 180 fail / 30 errors (`/tmp/chimedeck-head-test.log`). Normalized fail-identity diff base→head is empty (0 lost, 0 new failures); the only new pass identities are the 5 new `forgot password boundary: *` tests. No existing passing identity was lost.
- Focused ESLint on all 3 touched files: 0 errors/warnings.
- Full-repo ESLint: 2344 errors / 3 warnings (base recorded 2347/3 in `/tmp/chimedeck-full-lint-post-247.txt`) — net -3 errors, no new findings elsewhere.
- `bun run build:client`: succeeds (`/tmp/chimedeck-head-buildclient.log`).
- `git diff --check`: clean.

## Coverage limits / honest gaps
- The fixture mocks the DB and email modules; it does **not** exercise a live Postgres connection, the real SES/console email adapter selection, or the real `memCache` TTL eviction beyond in-process behaviour — those remain unverified live-system gaps, consistent with the rest of this migration.
- No UI touched; no UI/E2E run needed for this slice.
- Type-only change; emitted JS is unaffected — the only source edit is a type parameter/interface addition, no logic changed.

Author: matthewvryanjh. Not self-approved/merged — for independent review per standing policy.