### PR TITLE
fix(webhooks): type update/delete row reads, erase non-null assertions

### DIFF
--- a/server/extensions/webhooks/api/__tests__/fixtures/updateDelete.ts
+++ b/server/extensions/webhooks/api/__tests__/fixtures/updateDelete.ts
@@ -1,0 +1,167 @@
+import { strict as assert } from 'node:assert';
+import { mock } from 'bun:test';
+
+const calls: unknown[] = [];
+const state: {
+  authError: Response | null;
+  row: Record<string, unknown> | undefined;
+  membershipError: Response | null;
+  updates: unknown[];
+  updatedRow: Record<string, unknown> | undefined;
+  firstCallCount: number;
+} = {
+  authError: null,
+  row: undefined,
+  membershipError: null,
+  updates: [],
+  updatedRow: undefined,
+  firstCallCount: 0,
+};
+
+void mock.module('../../../../../common/db', () => ({
+  db(table: string) {
+    calls.push(['db', table]);
+    return {
+      where(filter: Record<string, unknown>) {
+        calls.push(['where', filter]);
+        return this;
+      },
+      first() {
+        calls.push('first');
+        return Promise.resolve(state.firstCallCount++ === 0 ? state.row : (state.updatedRow ?? state.row));
+      },
+      select(...columns: string[]) {
+        calls.push(['select', columns]);
+        return this;
+      },
+      update(payload: Record<string, unknown>) {
+        state.updates.push(payload);
+        calls.push(['update', payload]);
+        return Promise.resolve(1);
+      },
+      del() {
+        calls.push('del');
+        return Promise.resolve(1);
+      },
+    };
+  },
+}));
+
+void mock.module('../../../../auth/middlewares/authentication', () => ({
+  authenticate(req: Request) {
+    calls.push(['authenticate', req]);
+    return Promise.resolve(state.authError);
+  },
+}));
+
+void mock.module('../../../../../middlewares/permissionManager', () => ({
+  hasRole(callerRole: string, minRole: string) {
+    const rank: Record<string, number> = { MEMBER: 0, ADMIN: 1, OWNER: 2 };
+    return (rank[callerRole] ?? 0) >= (rank[minRole] ?? 0);
+  },
+  requireWorkspaceMembership(req: { callerRole?: string }, workspaceId: string) {
+    calls.push(['requireWorkspaceMembership', workspaceId]);
+    if (state.membershipError) return Promise.resolve(state.membershipError);
+    req.callerRole = 'MEMBER';
+    return Promise.resolve(null);
+  },
+}));
+
+void mock.module('../../ssrfGuard', () => ({
+  isEndpointAllowed(url: string) {
+    calls.push(['isEndpointAllowed', url]);
+    return Promise.resolve(true);
+  },
+}));
+
+const { handleUpdateWebhook } = await import('../../update');
+const { handleDeleteWebhook } = await import('../../delete');
+
+function authedReq(userId: string, body?: unknown): Request {
+  const init: RequestInit = body
+    ? { method: 'PATCH', body: JSON.stringify(body) }
+    : { method: 'DELETE' };
+  const req = new Request('http://localhost/api/v1/webhooks/hook-1', init);
+  (req as unknown as { currentUser: { id: string } }).currentUser = { id: userId };
+  return req;
+}
+
+// 1. Auth short-circuit.
+state.authError = new Response('denied', { status: 401 });
+assert.equal(await handleUpdateWebhook(authedReq('user-1'), 'hook-1'), state.authError);
+assert.equal(await handleDeleteWebhook(authedReq('user-1'), 'hook-1'), state.authError);
+state.authError = null;
+
+// 2. Not found.
+state.row = undefined;
+const nf = await handleUpdateWebhook(authedReq('user-1'), 'hook-1');
+assert.equal(nf.status, 404);
+const nfd = await handleDeleteWebhook(authedReq('user-1'), 'hook-1');
+assert.equal(nfd.status, 404);
+
+// 3. Workspace-scoped webhook: membership check runs with the real workspace_id.
+state.row = { id: 'hook-1', workspace_id: 'ws-1', created_by: 'owner-1' };
+calls.length = 0;
+await handleUpdateWebhook(authedReq('owner-1', { label: 'New' }), 'hook-1');
+const membershipCall = calls.find(
+  (c) => Array.isArray(c) && c[0] === 'requireWorkspaceMembership',
+) as [string, string];
+assert.deepEqual(membershipCall, ['requireWorkspaceMembership', 'ws-1']);
+
+// 4. Global webhook (workspace_id: null since migration 0107) still calls
+// requireWorkspaceMembership with null — preserving pre-typing runtime behaviour
+// exactly, not skipping the call for global webhooks.
+state.row = { id: 'hook-1', workspace_id: null, created_by: 'owner-1' };
+calls.length = 0;
+await handleDeleteWebhook(authedReq('owner-1'), 'hook-1');
+const globalMembershipCall = calls.find(
+  (c) => Array.isArray(c) && c[0] === 'requireWorkspaceMembership',
+) as [string, string | null];
+assert.deepEqual(globalMembershipCall, ['requireWorkspaceMembership', null]);
+
+// 5. Membership failure propagates.
+state.membershipError = new Response('forbidden', { status: 403 });
+state.row = { id: 'hook-1', workspace_id: 'ws-1', created_by: 'owner-1' };
+const membershipFail = await handleUpdateWebhook(authedReq('owner-1', { label: 'x' }), 'hook-1');
+assert.equal(membershipFail, state.membershipError);
+state.membershipError = null;
+
+// 6. Non-owner, non-admin caller is rejected.
+state.row = { id: 'hook-1', workspace_id: 'ws-1', created_by: 'owner-1' };
+const forbidden = await handleDeleteWebhook(authedReq('intruder'), 'hook-1');
+assert.equal(forbidden.status, 403);
+
+// 7. Owner can update; response reflects the post-update projection read.
+state.row = { id: 'hook-1', workspace_id: 'ws-1', created_by: 'owner-1' };
+state.updatedRow = {
+  id: 'hook-1',
+  label: 'Updated Label',
+  endpoint_url: 'https://example.com/hook',
+  event_types: ['card.created'],
+  is_active: true,
+  created_at: new Date('2026-01-01T00:00:00.000Z'),
+};
+state.firstCallCount = 0;
+const updateOk = await handleUpdateWebhook(authedReq('owner-1', { label: 'Updated Label' }), 'hook-1');
+assert.equal(updateOk.status, 200);
+assert.deepEqual(await updateOk.json(), {
+  data: {
+    id: 'hook-1',
+    label: 'Updated Label',
+    endpointUrl: 'https://example.com/hook',
+    eventTypes: ['card.created'],
+    isActive: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+  },
+});
+state.updatedRow = undefined;
+
+// 8. Owner can delete.
+state.row = { id: 'hook-1', workspace_id: 'ws-1', created_by: 'owner-1' };
+const deleteOk = await handleDeleteWebhook(authedReq('owner-1'), 'hook-1');
+assert.equal(deleteOk.status, 200);
+assert.deepEqual(await deleteOk.json(), { data: {} });
+
+console.info(
+  'webhook update/delete auth, workspace-scoped and global membership calls, ownership and success paths verified',
+);

--- a/server/extensions/webhooks/api/__tests__/updateDelete.test.ts
+++ b/server/extensions/webhooks/api/__tests__/updateDelete.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'bun:test';
+
+// Isolate shared auth/DB/permissionManager mocks while exercising the real
+// update/delete handlers in a subprocess.
+test('real webhook update/delete preserve auth, membership call and ownership checks', async () => {
+  const child = Bun.spawn(
+    [process.execPath, new URL('./fixtures/updateDelete.ts', import.meta.url).pathname],
+    { stdout: 'pipe', stderr: 'pipe' },
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  expect(stderr).toBe('');
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain(
+    'webhook update/delete auth, workspace-scoped and global membership calls, ownership and success paths verified',
+  );
+});

--- a/server/extensions/webhooks/api/delete.ts
+++ b/server/extensions/webhooks/api/delete.ts
@@ -8,11 +8,19 @@ import {
   type WorkspaceScopedRequest,
 } from '../../../middlewares/permissionManager';
 
+// Read projection from migrations 0106/0107 — workspace_id is nullable since
+// webhooks became global; created_by remains required.
+interface WebhookRow {
+  id: string;
+  workspace_id: string | null;
+  created_by: string;
+}
+
 export async function handleDeleteWebhook(req: Request, webhookId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const webhook = await db('webhooks').where({ id: webhookId }).first();
+  const webhook = await db<WebhookRow>('webhooks').where({ id: webhookId }).first();
   if (!webhook) {
     return Response.json(
       { name: 'webhook-not-found', data: { message: 'Webhook not found' } },
@@ -21,10 +29,23 @@ export async function handleDeleteWebhook(req: Request, webhookId: string): Prom
   }
 
   const scopedReq = req as WorkspaceScopedRequest;
-  const membershipError = await requireWorkspaceMembership(scopedReq, webhook.workspace_id);
+  // [preserve] webhook.workspace_id can be null since migration 0107 made webhooks
+  // global; requireWorkspaceMembership's parameter type is widened here to match
+  // the unchanged runtime call, not to alter behaviour for null workspace_id.
+  const membershipError = await requireWorkspaceMembership(
+    scopedReq,
+    webhook.workspace_id as string,
+  );
   if (membershipError) return membershipError;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const currentUser = (req as AuthenticatedRequest).currentUser;
+  if (!currentUser) {
+    return Response.json(
+      { error: { code: 'unauthorized', message: 'Authentication required' } },
+      { status: 401 },
+    );
+  }
+  const userId = currentUser.id;
   const isOwner = webhook.created_by === userId;
   const isAdminOrAbove = scopedReq.callerRole ? hasRole(scopedReq.callerRole, 'ADMIN') : false;
 

--- a/server/extensions/webhooks/api/update.ts
+++ b/server/extensions/webhooks/api/update.ts
@@ -10,11 +10,33 @@ import {
 import { WEBHOOK_EVENT_TYPES, type WebhookEventType } from '../common/eventTypes';
 import { isEndpointAllowed } from './ssrfGuard';
 
+// Read projection from migrations 0106/0107 — workspace_id is nullable since
+// webhooks became global; created_by remains required.
+interface WebhookRow {
+  id: string;
+  workspace_id: string | null;
+  created_by: string;
+  label: string;
+  endpoint_url: string;
+  event_types: unknown;
+  is_active: boolean;
+  created_at: Date;
+}
+
+interface WebhookUpdateProjection {
+  id: string;
+  label: string;
+  endpoint_url: string;
+  event_types: unknown;
+  is_active: boolean;
+  created_at: Date;
+}
+
 export async function handleUpdateWebhook(req: Request, webhookId: string): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const webhook = await db('webhooks').where({ id: webhookId }).first();
+  const webhook = await db<WebhookRow>('webhooks').where({ id: webhookId }).first();
   if (!webhook) {
     return Response.json(
       { name: 'webhook-not-found', data: { message: 'Webhook not found' } },
@@ -23,10 +45,23 @@ export async function handleUpdateWebhook(req: Request, webhookId: string): Prom
   }
 
   const scopedReq = req as WorkspaceScopedRequest;
-  const membershipError = await requireWorkspaceMembership(scopedReq, webhook.workspace_id);
+  // [preserve] webhook.workspace_id can be null since migration 0107 made webhooks
+  // global; requireWorkspaceMembership's parameter type is widened here to match
+  // the unchanged runtime call, not to alter behaviour for null workspace_id.
+  const membershipError = await requireWorkspaceMembership(
+    scopedReq,
+    webhook.workspace_id as string,
+  );
   if (membershipError) return membershipError;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const currentUser = (req as AuthenticatedRequest).currentUser;
+  if (!currentUser) {
+    return Response.json(
+      { error: { code: 'unauthorized', message: 'Authentication required' } },
+      { status: 401 },
+    );
+  }
+  const userId = currentUser.id;
   const isOwner = webhook.created_by === userId;
   const isAdminOrAbove = scopedReq.callerRole ? hasRole(scopedReq.callerRole, 'ADMIN') : false;
 
@@ -104,10 +139,18 @@ export async function handleUpdateWebhook(req: Request, webhookId: string): Prom
 
   await db('webhooks').where({ id: webhookId }).update(updates);
 
-  const updated = await db('webhooks')
+  const updated = await db<WebhookUpdateProjection>('webhooks')
     .where({ id: webhookId })
     .select('id', 'label', 'endpoint_url', 'event_types', 'is_active', 'created_at')
     .first();
+  if (!updated) {
+    // [why] row was just confirmed to exist and updated above; this branch is
+    // unreachable in practice but keeps the projection read type-safe.
+    return Response.json(
+      { name: 'webhook-not-found', data: { message: 'Webhook not found' } },
+      { status: 404 },
+    );
+  }
 
   return Response.json({
     data: {


### PR DESCRIPTION
Types the webhooks row reads in update.ts/delete.ts via migration-derived interfaces (0106/0107, workspace_id nullable since webhooks became global). Preserves the existing runtime call to requireWorkspaceMembership with a workspace_id cast (behaviour-identical to the prior implicit-any pass-through; not attempting to fix null-workspace handling in this slice). Also erases two pre-existing non-null-assertion findings on currentUser by replacing them with explicit 401 guards -- unreachable in practice since authenticate() already short-circuits earlier, but type-safe and behaviour-preserving. Added a durable subprocess-isolated handler test (no prior handler-level coverage existed) covering auth guard, membership call argument, and ownership-check branching for both endpoints.

Verification:
- Focused ESLint: 0 errors/warnings on all 4 touched files
- bun run typecheck: byte-identical vs main
- bun test: 1243->1249 pass (net matches worker's earlier baseline plus my +1 test), 3 skip/180 fail/30 errors unchanged
- bun run build:client: passed
- git diff --check: passed

No payments/Stripe/billing/monetisation involved. No repo-wide autofix/config/dependency changes.