### PR TITLE
fix(activity): type board/actor/notification row reads in mapActivityToNotification

### DIFF
--- a/server/extensions/activity/mods/__tests__/fixtures/mapActivityToNotification.ts
+++ b/server/extensions/activity/mods/__tests__/fixtures/mapActivityToNotification.ts
@@ -1,0 +1,229 @@
+import { strict as assert } from 'node:assert';
+import { mock } from 'bun:test';
+
+// Real handler under test: mapActivityToNotification. Shared DB and
+// notification-guard modules are mocked here in a subprocess so this
+// fixture cannot leak state into (or be replaced by) adjacent tests.
+const calls: unknown[] = [];
+
+const state: {
+  board: Record<string, unknown> | undefined;
+  boardMembers: Array<{ user_id: string }>;
+  boardGuests: Array<{ user_id: string }>;
+  actor: Record<string, unknown> | undefined;
+  globalEnabled: boolean;
+  boardPreference: { notificationsEnabled: boolean; onlyRelatedToMe: boolean };
+  inAppEnabled: boolean;
+  insertedRow: Record<string, unknown> | undefined;
+} = {
+  board: { id: 'board-1', title: 'Board One', workspace_id: 'ws-1' },
+  boardMembers: [{ user_id: 'member-1' }, { user_id: 'actor-1' }],
+  boardGuests: [{ user_id: 'guest-1' }],
+  actor: { id: 'actor-1', nickname: null, name: 'Actor Name', avatar_url: null },
+  globalEnabled: true,
+  boardPreference: { notificationsEnabled: true, onlyRelatedToMe: false },
+  inAppEnabled: true,
+  insertedRow: {
+    id: 'notif-1',
+    user_id: 'member-1',
+    type: 'card_created',
+    source_type: 'board_activity',
+    source_id: 'activity-1',
+    card_id: 'card-1',
+    board_id: 'board-1',
+    actor_id: 'actor-1',
+    read: false,
+    created_at: '2026-01-01T00:00:00.000Z',
+  },
+};
+
+void mock.module('../../../../../common/db', () => ({
+  db: Object.assign(
+    (table: string) => {
+      calls.push(['db', table]);
+      if (table === 'boards') {
+        return {
+          where: (filter: Record<string, unknown>) => {
+            calls.push(['boards.where', filter]);
+            return {
+              select: (...cols: unknown[]) => {
+                calls.push(['boards.select', cols]);
+                return { first: () => Promise.resolve(state.board) };
+              },
+            };
+          },
+        };
+      }
+      if (table === 'board_members') {
+        return {
+          where: (filter: Record<string, unknown>) => {
+            calls.push(['board_members.where', filter]);
+            return { select: (..._cols: unknown[]) => Promise.resolve(state.boardMembers) };
+          },
+        };
+      }
+      if (table === 'board_guest_access') {
+        return {
+          where: (filter: Record<string, unknown>) => {
+            calls.push(['board_guest_access.where', filter]);
+            return { select: (..._cols: unknown[]) => Promise.resolve(state.boardGuests) };
+          },
+        };
+      }
+      if (table === 'users') {
+        return {
+          where: (filter: Record<string, unknown>) => {
+            calls.push(['users.where', filter]);
+            return {
+              select: (...cols: unknown[]) => {
+                calls.push(['users.select', cols]);
+                return { first: () => Promise.resolve(state.actor) };
+              },
+            };
+          },
+        };
+      }
+      if (table === 'notifications') {
+        return {
+          insert: (payload: Record<string, unknown>, returning: unknown) => {
+            calls.push(['notifications.insert', payload, returning]);
+            return Promise.resolve(state.insertedRow ? [state.insertedRow] : []);
+          },
+        };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+    { raw: (sql: string) => sql },
+  ),
+}));
+
+void mock.module('../../../../notifications/mods/preferenceGuard', () => ({
+  preferenceGuard: (input: { userId: string; type: string }) => {
+    calls.push(['preferenceGuard', input]);
+    return Promise.resolve({ in_app_enabled: state.inAppEnabled });
+  },
+}));
+
+void mock.module('../../../../notifications/mods/boardPreferenceGuard', () => ({
+  resolveBoardNotificationPreference: (input: { userId: string; boardId: string }) => {
+    calls.push(['resolveBoardNotificationPreference', input]);
+    return Promise.resolve(state.boardPreference);
+  },
+}));
+
+void mock.module('../../../../notifications/mods/globalPreferenceGuard', () => ({
+  globalPreferenceGuard: (input: { userId: string }) => {
+    calls.push(['globalPreferenceGuard', input]);
+    return Promise.resolve(state.globalEnabled);
+  },
+}));
+
+const publishedMessages: Array<{ userId: string; message: unknown }> = [];
+void mock.module('../../../../realtime/userChannel', () => ({
+  publishToUser: (userId: string, message: unknown) => {
+    publishedMessages.push({ userId, message });
+    return Promise.resolve();
+  },
+}));
+
+void mock.module('../../../../../common/avatar/resolveAvatarUrl', () => ({
+  buildAvatarProxyUrl: (input: { userId: string; avatarUrl: string }) => `proxy:${input.avatarUrl}`,
+}));
+
+const dispatchedEmails: unknown[] = [];
+void mock.module('../../../../notifications/mods/emailDispatch', () => ({
+  dispatchNotificationEmail: (input: unknown) => {
+    dispatchedEmails.push(input);
+    return Promise.resolve();
+  },
+}));
+
+void mock.module('../../../../../config/env', () => ({
+  env: { NOTIFICATION_PREFERENCES_ENABLED: true },
+}));
+
+void mock.module('../../../../notifications/mods/relatedCardRecipients', () => ({
+  getCardRelatedUserIds: (input: { cardId: string | null }) => {
+    calls.push(['getCardRelatedUserIds', input]);
+    return Promise.resolve([]);
+  },
+  isRecipientRelatedCardNotification: () => true,
+}));
+
+const { mapActivityToNotification } = await import('../../mapActivityToNotification');
+
+function activity(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'activity-1',
+    action: 'card_created',
+    actor_id: 'actor-1',
+    payload: { cardId: 'card-1', cardTitle: 'Card One', listName: 'To Do' },
+    created_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// 1. Unsupported action is a no-op — no DB reads at all.
+calls.length = 0;
+await mapActivityToNotification({
+  activity: activity({ action: 'unsupported_action' }) as never,
+  boardId: 'board-1',
+});
+assert.equal(calls.length, 0);
+
+// 2. Board not found short-circuits before recipient resolution.
+state.board = undefined;
+calls.length = 0;
+await mapActivityToNotification({ activity: activity() as never, boardId: 'board-1' });
+assert.deepEqual(
+  calls.filter((c) => Array.isArray(c) && c[0] === 'db'),
+  [['db', 'boards']],
+);
+state.board = { id: 'board-1', title: 'Board One', workspace_id: 'ws-1' };
+
+// 3. Happy path: actor excluded from recipients, board member + guest notified,
+// notification row inserted with typed columns preserved, and the WS payload
+// carries the actor/board fields resolved from the typed reads.
+calls.length = 0;
+publishedMessages.length = 0;
+dispatchedEmails.length = 0;
+await mapActivityToNotification({ activity: activity() as never, boardId: 'board-1' });
+
+const insertCall = calls.find(
+  (c) => Array.isArray(c) && c[0] === 'notifications.insert',
+) as [string, Record<string, unknown>, unknown];
+assert.ok(insertCall, 'expected a notifications.insert call');
+assert.equal(insertCall[1].actor_id, 'actor-1');
+assert.equal(insertCall[1].board_id, 'board-1');
+assert.equal(insertCall[1].type, 'card_created');
+assert.deepEqual(insertCall[2], ['*']);
+
+const recipientIds = publishedMessages.map((m) => m.userId).sort();
+assert.deepEqual(recipientIds, ['guest-1', 'member-1']);
+
+const publishedPayload = publishedMessages[0]?.message as {
+  payload: { notification: Record<string, unknown> };
+};
+assert.equal(publishedPayload.payload.notification.board_title, 'Board One');
+assert.equal(publishedPayload.payload.notification.card_title, 'Card One');
+const actorField = (publishedPayload.payload.notification as { actor: { name: string } }).actor;
+assert.equal(actorField.name, 'Actor Name');
+
+assert.equal(dispatchedEmails.length, 2);
+
+// 4. Global opt-out guard blocks the recipient before the DB insert runs.
+state.globalEnabled = false;
+calls.length = 0;
+publishedMessages.length = 0;
+dispatchedEmails.length = 0;
+await mapActivityToNotification({ activity: activity() as never, boardId: 'board-1' });
+assert.equal(publishedMessages.length, 0);
+assert.equal(
+  calls.some((c) => Array.isArray(c) && c[0] === 'notifications.insert'),
+  false,
+);
+state.globalEnabled = true;
+
+console.info(
+  'mapActivityToNotification real board/user/notification reads, recipient exclusion, insert payload and opt-out guard verified',
+);

--- a/server/extensions/activity/mods/__tests__/mapActivityToNotification.test.ts
+++ b/server/extensions/activity/mods/__tests__/mapActivityToNotification.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'bun:test';
+
+// Isolate shared DB/notification-guard mocks while exercising the real
+// mapActivityToNotification handler in a subprocess so this fixture cannot
+// leak state into (or be replaced by) adjacent tests.
+test('mapActivityToNotification resolves board/actor reads, excludes actor, notifies recipients, and respects opt-out guards', async () => {
+  const child = Bun.spawn(
+    [process.execPath, new URL('./fixtures/mapActivityToNotification.ts', import.meta.url).pathname],
+    { stdout: 'pipe', stderr: 'pipe' },
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  expect(stderr).toBe('');
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain(
+    'mapActivityToNotification real board/user/notification reads, recipient exclusion, insert payload and opt-out guard verified',
+  );
+});

--- a/server/extensions/activity/mods/mapActivityToNotification.ts
+++ b/server/extensions/activity/mods/mapActivityToNotification.ts
@@ -44,7 +44,35 @@ const CHECKLIST_NOTIFICATION_TYPES = new Set<NotificationType>([
   'checklist_item_due_date_updated',
 ]);
 
+// Row projection derived from migration 0017 (notifications).
+interface NotificationRow {
+  id: string;
+  user_id: string;
+  type: string;
+  source_type: string;
+  source_id: string;
+  card_id: string | null;
+  board_id: string | null;
+  actor_id: string;
+  read: boolean;
+  created_at: string;
+}
+
 const SUPPORTED_ACTIONS = new Set<string>(Object.keys(ACTIVITY_TO_NOTIFICATION));
+
+// Read projections derived from migrations 0004 (boards) and 0002/0015 (users).
+interface BoardRow {
+  id: string;
+  title: string;
+  workspace_id: string;
+}
+
+interface ActorRow {
+  id: string;
+  nickname: string | null;
+  name: string;
+  avatar_url: string | null;
+}
 
 export interface MapActivityToNotificationInput {
   activity: WrittenActivity;
@@ -61,7 +89,7 @@ export async function mapActivityToNotification({
     const notificationType = ACTIVITY_TO_NOTIFICATION[activity.action as ActivityAction];
     const payload = normalisePayload(activity.payload);
 
-    const board = await db('boards')
+    const board = await db<BoardRow>('boards')
       .where({ id: boardId })
       .select('id', 'title', 'workspace_id')
       .first();
@@ -120,7 +148,7 @@ export async function mapActivityToNotification({
     // Resolve actor display info once for the WS payload.
     const actor = await db('users')
       .where({ id: activity.actor_id })
-      .select('id', 'nickname', db.raw("COALESCE(name, email) as name"), 'avatar_url')
+      .select<ActorRow[]>('id', 'nickname', db.raw("COALESCE(name, email) as name"), 'avatar_url')
       .first();
     const actorAvatarUrl = actor?.avatar_url
       ? buildAvatarProxyUrl({ userId: actor.id, avatarUrl: actor.avatar_url })
@@ -192,7 +220,7 @@ export async function mapActivityToNotification({
       }
 
       if (inAppEnabled) {
-        db('notifications')
+        db<NotificationRow>('notifications')
           .insert(
             {
               user_id: recipientId,
@@ -207,7 +235,7 @@ export async function mapActivityToNotification({
             },
             ['*'],
           )
-          .then(([inserted]) => {
+          .then(([inserted]: NotificationRow[]) => {
             if (inserted) {
               return publishToUser(recipientId, {
                 type: 'notification_created',


### PR DESCRIPTION
## Scope

Type-only lint slice for `server/extensions/activity/mods/mapActivityToNotification.ts` — a non-payment server boundary that had 10 `no-unsafe-*` errors (17 total across the file's two Knex read calls plus the notifications insert/publish path).

## Changes

- Added migration-derived row interfaces (`BoardRow` from 0004, `ActorRow` from 0002/0015, `NotificationRow` from 0017) and typed the three `db(...)` calls (`boards` read, `users` read, `notifications` insert).
- No runtime/auth/API contract change: same tables, same columns, same query shape, same recipient/opt-out logic.
- Added a subprocess-isolated handler test (`__tests__/mapActivityToNotification.test.ts` + `__tests__/fixtures/mapActivityToNotification.ts`) — none existed before; the module was previously only exercised via a full mock in an adjacent test. Covers: unsupported action no-op, board-not-found short-circuit, happy path (actor exclusion from recipients, board-member + board-guest fan-out, typed insert payload, WS payload actor/board fields, email dispatch), and the global opt-out guard blocking both insert and publish.

## Verification

- Focused ESLint on all 3 touched files: 0 errors — `/tmp/chimedeck-activity-map-notification-focused-test.txt` (bun test output, 1 pass)
- `bun run typecheck`: BASE vs HEAD diff is byte-identical (147 pre-existing client-only diagnostics, unrelated to this file) — `/tmp/chimedeck-base-mapActivityToNotification-typecheck.txt`, `/tmp/chimedeck-head-mapActivityToNotification-typecheck.txt`
- Full `bun test`: BASE 1249 pass / 3 skip / 180 fail / 30 errors → HEAD 1250 pass / 3 skip / 180 fail / 30 errors (+1 = the new test). Named-failure-identity sets are set-equal (147 unique failing names both sides, zero new, zero resolved) — `/tmp/chimedeck-base-mapActivityToNotification-fulltest.txt`, `/tmp/chimedeck-head-mapActivityToNotification-fulltest.txt`
- `bun run build:client`: succeeds — `/tmp/chimedeck-head-mapActivityToNotification-buildclient.txt`
- `git diff --check` against `main`: clean
- Bun-transpiled emitted JS for `mapActivityToNotification.ts` is byte-identical BASE vs HEAD (`diff` exit 0) — confirms the production-code change is fully type-erased, not a behaviour change.

## Coverage limits (honest gaps)

- The new test mocks the shared DB module and all notification-guard/email/realtime dependencies; it is a real handler-level test (imports and calls the actual exported function) but does **not** exercise a live Postgres connection, the real `preferenceGuard`/`boardPreferenceGuard`/`globalPreferenceGuard` implementations, or real WebSocket publish transport. Those remain unverified-live-DB/transport gaps, consistent with the rest of this migration's fixture pattern (see `webhooks/api/__tests__/fixtures/updateDelete.ts`).
- Pre-existing 180 fail / 30 errors and 147 typecheck diagnostics are untouched baseline debt outside this slice's scope, not newly introduced.

## Boundaries respected

- No repo-wide autofix/suppression/config/dependency/deployment changes.
- No payment/billing/subscription/Stripe files touched.
- Lockfiles untouched.

Do not approve or merge — parent will review independently.
