### PR TITLE
lint: type archivedBoardGuard DB rows from migrations

### DIFF
--- a/server/middlewares/__tests__/archivedBoardGuard.contract.test.ts
+++ b/server/middlewares/__tests__/archivedBoardGuard.contract.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+
+test('archivedBoardGuard real handlers preserve not-found, archived and pass-through contracts', () => {
+  // Shared DB mock stays in a child process, away from other suites' mock.module state.
+  const fixture = fileURLToPath(new URL('./fixtures/archivedBoardGuard.fixture.ts', import.meta.url));
+  const result = Bun.spawnSync([process.execPath, fixture], { stdout: 'pipe', stderr: 'pipe' });
+  expect(result.stderr.toString()).toBe('');
+  expect(result.exitCode).toBe(0);
+});

--- a/server/middlewares/__tests__/fixtures/archivedBoardGuard.fixture.ts
+++ b/server/middlewares/__tests__/fixtures/archivedBoardGuard.fixture.ts
@@ -1,0 +1,167 @@
+import { strict as assert } from 'node:assert';
+import { mock } from 'bun:test';
+
+type Row = Record<string, unknown> | undefined;
+const rows: { boards?: Row; cards?: Row; lists?: Row; comments?: Row } = {};
+const calls: unknown[] = [];
+
+void mock.module('../../../common/db', () => ({
+  db(table: 'boards' | 'cards' | 'lists' | 'comments') {
+    calls.push(['table', table]);
+    return {
+      where(condition: unknown) {
+        calls.push(['where', condition]);
+        return this;
+      },
+      first() {
+        calls.push(['first']);
+        return Promise.resolve(rows[table]);
+      },
+    };
+  },
+}));
+
+const { requireBoardNotArchived, resolveBoardFromCard, resolveBoardFromComment } = await import(
+  '../../archivedBoardGuard'
+);
+
+// requireBoardNotArchived: board not found
+calls.length = 0;
+rows.boards = undefined;
+let response = await requireBoardNotArchived('board-missing');
+assert.equal(response?.status, 404);
+assert.deepEqual(await response.json(), {
+  error: { code: 'board-not-found', message: 'Board not found' },
+});
+assert.deepEqual(calls, [
+  ['table', 'boards'],
+  ['where', { id: 'board-missing' }],
+  ['first'],
+]);
+
+// requireBoardNotArchived: archived board
+calls.length = 0;
+rows.boards = { id: 'board-1', state: 'ARCHIVED' };
+response = await requireBoardNotArchived('board-1');
+assert.equal(response?.status, 403);
+assert.deepEqual(await response.json(), {
+  error: {
+    code: 'board-is-archived',
+    message: 'This board is archived and cannot be modified.',
+  },
+});
+
+// requireBoardNotArchived: active board passes through
+calls.length = 0;
+rows.boards = { id: 'board-1', state: 'ACTIVE' };
+assert.equal(await requireBoardNotArchived('board-1'), null);
+
+// resolveBoardFromCard: card not found
+calls.length = 0;
+rows.cards = undefined;
+let result = await resolveBoardFromCard('card-missing');
+assert.ok('error' in result);
+assert.equal(result.error.status, 404);
+assert.deepEqual(await result.error.json(), {
+  error: { code: 'card-not-found', message: 'Card not found' },
+});
+assert.deepEqual(calls, [
+  ['table', 'cards'],
+  ['where', { id: 'card-missing' }],
+  ['first'],
+]);
+
+// resolveBoardFromCard: card's list missing
+calls.length = 0;
+rows.cards = { id: 'card-1', list_id: 'list-missing' };
+rows.lists = undefined;
+result = await resolveBoardFromCard('card-1');
+assert.ok('error' in result);
+assert.equal(result.error.status, 404);
+assert.deepEqual(await result.error.json(), {
+  error: { code: 'card-not-found', message: 'Card parent list not found' },
+});
+
+// resolveBoardFromCard: list's board missing
+calls.length = 0;
+rows.cards = { id: 'card-1', list_id: 'list-1' };
+rows.lists = { id: 'list-1', board_id: 'board-missing' };
+rows.boards = undefined;
+result = await resolveBoardFromCard('card-1');
+assert.ok('error' in result);
+assert.equal(result.error.status, 404);
+assert.deepEqual(await result.error.json(), {
+  error: { code: 'board-not-found', message: 'Board not found' },
+});
+
+// resolveBoardFromCard: archived board propagates 403
+calls.length = 0;
+rows.cards = { id: 'card-1', list_id: 'list-1' };
+rows.lists = { id: 'list-1', board_id: 'board-1' };
+rows.boards = { id: 'board-1', state: 'ARCHIVED' };
+result = await resolveBoardFromCard('card-1');
+assert.ok('error' in result);
+assert.equal(result.error.status, 403);
+assert.deepEqual(await result.error.json(), {
+  error: {
+    code: 'board-is-archived',
+    message: 'This board is archived and cannot be modified.',
+  },
+});
+assert.deepEqual(calls, [
+  ['table', 'cards'],
+  ['where', { id: 'card-1' }],
+  ['first'],
+  ['table', 'lists'],
+  ['where', { id: 'list-1' }],
+  ['first'],
+  ['table', 'boards'],
+  ['where', { id: 'board-1' }],
+  ['first'],
+]);
+
+// resolveBoardFromCard: active board resolves { board }
+calls.length = 0;
+rows.boards = { id: 'board-1', state: 'ACTIVE' };
+result = await resolveBoardFromCard('card-1');
+assert.ok('board' in result);
+assert.deepEqual(result.board, { id: 'board-1', state: 'ACTIVE' });
+
+// resolveBoardFromComment: comment not found
+calls.length = 0;
+rows.comments = undefined;
+result = await resolveBoardFromComment('comment-missing');
+assert.ok('error' in result);
+assert.equal(result.error.status, 404);
+assert.deepEqual(await result.error.json(), {
+  error: { code: 'comment-not-found', message: 'Comment not found' },
+});
+assert.deepEqual(calls, [
+  ['table', 'comments'],
+  ['where', { id: 'comment-missing' }],
+  ['first'],
+]);
+
+// resolveBoardFromComment: delegates to resolveBoardFromCard with the comment's card_id
+calls.length = 0;
+rows.comments = { id: 'comment-1', card_id: 'card-1' };
+rows.cards = { id: 'card-1', list_id: 'list-1' };
+rows.lists = { id: 'list-1', board_id: 'board-1' };
+rows.boards = { id: 'board-1', state: 'ACTIVE' };
+result = await resolveBoardFromComment('comment-1');
+assert.ok('board' in result);
+assert.deepEqual(result.board, { id: 'board-1', state: 'ACTIVE' });
+assert.deepEqual(calls, [
+  ['table', 'comments'],
+  ['where', { id: 'comment-1' }],
+  ['first'],
+  ['table', 'cards'],
+  ['where', { id: 'card-1' }],
+  ['first'],
+  ['table', 'lists'],
+  ['where', { id: 'list-1' }],
+  ['first'],
+  ['table', 'boards'],
+  ['where', { id: 'board-1' }],
+  ['first'],
+]);

--- a/server/middlewares/archivedBoardGuard.ts
+++ b/server/middlewares/archivedBoardGuard.ts
@@ -2,10 +2,34 @@
 // Use this helper inside any mutation handler that resolves a board.
 import { db } from '../common/db';
 
+// db/migrations/0004_board.ts
+interface BoardStateRow {
+  id: string;
+  state: 'ACTIVE' | 'ARCHIVED';
+}
+
+// db/migrations/0006_card.ts
+interface CardListRow {
+  id: string;
+  list_id: string;
+}
+
+// db/migrations/0005_list.ts
+interface ListBoardRow {
+  id: string;
+  board_id: string;
+}
+
+// db/migrations/0010_comments_activity.ts
+interface CommentCardRow {
+  id: string;
+  card_id: string;
+}
+
 // Returns a 403 Response if the board (by id) is archived, null otherwise.
 // Also returns 404 if the board is not found.
 export async function requireBoardNotArchived(boardId: string): Promise<Response | null> {
-  const board = await db('boards').where({ id: boardId }).first();
+  const board = await db<BoardStateRow>('boards').where({ id: boardId }).first();
 
   if (!board) {
     return Response.json(
@@ -33,8 +57,8 @@ export async function requireBoardNotArchived(boardId: string): Promise<Response
 // Returns { error: Response } on failure or { board } on success.
 export async function resolveBoardFromCard(
   cardId: string,
-): Promise<{ error: Response } | { board: Record<string, unknown> }> {
-  const card = await db('cards').where({ id: cardId }).first();
+): Promise<{ error: Response } | { board: BoardStateRow }> {
+  const card = await db<CardListRow>('cards').where({ id: cardId }).first();
   if (!card) {
     return {
       error: Response.json(
@@ -44,7 +68,7 @@ export async function resolveBoardFromCard(
     };
   }
 
-  const list = await db('lists').where({ id: card.list_id }).first();
+  const list = await db<ListBoardRow>('lists').where({ id: card.list_id }).first();
   if (!list) {
     return {
       error: Response.json(
@@ -54,7 +78,7 @@ export async function resolveBoardFromCard(
     };
   }
 
-  const board = await db('boards').where({ id: list.board_id }).first();
+  const board = await db<BoardStateRow>('boards').where({ id: list.board_id }).first();
   if (!board) {
     return {
       error: Response.json(
@@ -84,8 +108,8 @@ export async function resolveBoardFromCard(
 // Convenience: resolve board from a commentId and return 403 if archived.
 export async function resolveBoardFromComment(
   commentId: string,
-): Promise<{ error: Response } | { board: Record<string, unknown> }> {
-  const comment = await db('comments').where({ id: commentId }).first();
+): Promise<{ error: Response } | { board: BoardStateRow }> {
+  const comment = await db<CommentCardRow>('comments').where({ id: commentId }).first();
   if (!comment) {
     return {
       error: Response.json(
@@ -95,5 +119,5 @@ export async function resolveBoardFromComment(
     };
   }
 
-  return resolveBoardFromCard(comment.card_id as string);
+  return resolveBoardFromCard(comment.card_id);
 }


### PR DESCRIPTION
## Summary
Type the DB rows in `server/middlewares/archivedBoardGuard.ts` (the shared archived-board guard used by mutation handlers) from `Record<string, unknown>`/implicit `any` to migration-derived interfaces, and add durable subprocess-isolated coverage. No repo-wide autofix/suppression/config/dependency changes.

## Rule family addressed
`@typescript-eslint/no-unsafe-assignment` (8) and `@typescript-eslint/no-unsafe-member-access` (5) — 13 of the 2304-error/3-warning baseline in `/tmp/chimedeck-full-lint-post-250.txt`, all in this one file.

## Change
- `BoardStateRow` (`db/migrations/0004_board.ts`: `id`, `state: 'ACTIVE'|'ARCHIVED'`)
- `CardListRow` (`0006_card.ts`: `id`, `list_id`)
- `ListBoardRow` (`0005_list.ts`: `id`, `board_id`)
- `CommentCardRow` (`0010_comments_activity.ts`: `id`, `card_id`)
- Passed as `db<Row>('table')` generics at each `.first()` call; `resolveBoardFromCard`/`resolveBoardFromComment` return `{ board: BoardStateRow }` instead of `{ board: Record<string, unknown> }`.
- Dropped a now-redundant `comment.card_id as string` cast (column is `notNullable()` in the migration, so the typed row already guarantees `string`).
- No later migration alters `boards`/`cards`/`lists`/`comments`, so these are the authoritative shapes.
- Response bodies, status codes (404/403), and Knex query call sequence are unchanged — verified by test assertions on both.

## Erasure proof
Bun-transpiled BASE vs HEAD output for this file is **byte-identical** (`diff` clean) — confirms the change is fully type-only with zero emitted-JS delta.

## New test
No existing test covered this file (confirmed via `git ls-files --error-unmatch`). Added, following the `requireVerified.contract.test.ts` pattern:
- `server/middlewares/__tests__/archivedBoardGuard.contract.test.ts` — spawns the fixture in a child Bun process (`Bun.spawnSync`) so its `mock.module('../../../common/db', ...)` cannot leak into or be replaced by other suites' shared DB mocks.
- `server/middlewares/__tests__/fixtures/archivedBoardGuard.fixture.ts` — exercises `requireBoardNotArchived`, `resolveBoardFromCard`, and `resolveBoardFromComment`: not-found propagation at each join hop (comment → card → list → board), archived-board 403 propagation, active-board pass-through, and exact `db(table).where(...).first()` call sequencing.

This is an isolated fake-DB unit/contract test proving payload/branch behaviour against the mock; it does **not** exercise a live Postgres connection, real Knex query builder, or the calling routes/middleware chain that invoke this guard — that live-DB/router integration path remains unverified by this PR (pre-existing gap, not introduced by this change). No UI touched — no UI/E2E run needed.

## Verification
All logs are unique per-file under `/tmp`, fresh on this branch:

- **BASE** (`origin/main` @ `1bbb7e2b`, clean fast-forward, matches historical baseline 1250 pass/3 skip/180 fail/30 errors):
  - typecheck: `/tmp/chimedeck-base-typecheck-archguard.txt` (pre-existing failures unrelated to this file; exit 2)
  - full `bun test`: `/tmp/chimedeck-base-test-archguard.txt` → **1250 pass, 3 skip, 180 fail, 30 errors**
- **HEAD** (this branch, `9b27cc13`):
  - focused ESLint on all 3 touched files: `/tmp/chimedeck-lint-archguard-all-touched.txt` → **0 problems**
  - focused test: `/tmp/chimedeck-focused-test-archguard.txt` → **1 pass**
  - typecheck: `/tmp/chimedeck-head-typecheck-archguard.txt` → **byte-identical** to BASE typecheck output (no new/removed diagnostics)
  - `bun run build:client`: `/tmp/chimedeck-head-buildclient-archguard.txt` → exit 0 (only pre-existing chunk-size warning)
  - `git diff --check`: clean (exit 0)
  - full `bun test`: `/tmp/chimedeck-head-test-archguard.txt` → **1251 pass** (+1, the new test), **3 skip, 180 fail, 30 errors** — identical counts to BASE plus the new passing test
  - Reconciliation: parsed `(fail)` identities (300) and `error:` identities (104) reconcile to the 180+30 aggregate on both BASE and HEAD, and the **full multisets are set-equal** (`bf==hf`, `be==he` in the reconciliation script) — no existing passing/failing/error identity was lost, changed, or newly introduced.

## Boundaries respected
- No `eslint --fix`, no suppressions, no config/dependency/deployment changes.
- No lockfile changes.
- Only the 3 files listed above are touched; no unrelated cleanup.
- Auth/runtime/API response contracts unchanged (same status codes, same JSON error bodies, same query shape).

## Not in scope of this PR (parent review)
- Live Postgres/Knex integration coverage for this guard and its callers.
- Any other pre-existing lint findings elsewhere in the repo.

Do not approve or merge this PR — a separate reviewer context inspects the diff and evidence per the lint-migration skill.
