### PR TITLE
lint: type writeEvent insert/select rows from migrations

### DIFF
--- a/server/mods/events/__tests__/fixtures/writeEvent.fixture.ts
+++ b/server/mods/events/__tests__/fixtures/writeEvent.fixture.ts
@@ -1,0 +1,149 @@
+import { strict as assert } from 'node:assert';
+import { mock } from 'bun:test';
+
+// Shared DB mock stays in a child process, away from other suites' mock.module state.
+const calls: unknown[] = [];
+let insertedRow: Record<string, unknown> | undefined;
+
+void mock.module('../../../../common/db', () => ({
+  db(table: string) {
+    calls.push(['table', table]);
+    return {
+      insert(payload: Record<string, unknown>, returning: string[]) {
+        calls.push(['insert', payload, returning]);
+        return Promise.resolve(insertedRow === undefined ? [] : [insertedRow]);
+      },
+    };
+  },
+}));
+
+const snapshotCalls: unknown[] = [];
+void mock.module('../../snapshot/policy', () => ({
+  checkAndWriteSnapshot(args: unknown) {
+    snapshotCalls.push(args);
+    return Promise.resolve();
+  },
+}));
+
+const publishCalls: unknown[] = [];
+void mock.module('../../../pubsub/publisher', () => ({
+  publisher: {
+    publish(boardId: string, message: string) {
+      publishCalls.push([boardId, message]);
+      return Promise.resolve();
+    },
+  },
+}));
+
+const { writeEvent } = await import('../../write');
+
+// Throws when the insert returns no row (defensive guard; should never happen
+// against a real DB, but proves the function fails closed rather than
+// returning an unsafely-cast undefined event).
+calls.length = 0;
+insertedRow = undefined;
+await assert.rejects(
+  () =>
+    writeEvent({
+      type: 'card.created',
+      boardId: 'board-1',
+      entityId: 'card-1',
+      actorId: 'user-1',
+      payload: { foo: 'bar' },
+    }),
+  /Failed to write event row/,
+);
+
+// boardId present: builds the insert payload, awaits checkAndWriteSnapshot
+// and publisher.publish as best-effort (their promises are not awaited by
+// writeEvent itself, so we poll briefly), and returns the hydrated row.
+calls.length = 0;
+snapshotCalls.length = 0;
+publishCalls.length = 0;
+const createdAt = new Date('2024-01-01T00:00:00.000Z');
+insertedRow = {
+  id: 'event-1',
+  type: 'card.created',
+  board_id: 'board-1',
+  entity_id: 'card-1',
+  actor_id: 'user-1',
+  payload: { foo: 'bar' },
+  sequence: 42n,
+  created_at: createdAt,
+};
+
+const result = await writeEvent({
+  type: 'card.created',
+  boardId: 'board-1',
+  entityId: 'card-1',
+  actorId: 'user-1',
+  payload: { foo: 'bar' },
+});
+
+assert.deepEqual(result, insertedRow);
+assert.equal(calls.length, 2);
+const [tableCall, insertCall] = calls as [
+  ['table', string],
+  ['insert', Record<string, unknown>, string[]],
+];
+assert.deepEqual(tableCall, ['table', 'events']);
+assert.equal(insertCall[0], 'insert');
+assert.equal(insertCall[2][0], '*');
+const insertPayload = insertCall[1];
+assert.equal(typeof insertPayload.id, 'string');
+assert.equal(insertPayload.type, 'card.created');
+assert.equal(insertPayload.board_id, 'board-1');
+assert.equal(insertPayload.entity_id, 'card-1');
+assert.equal(insertPayload.actor_id, 'user-1');
+assert.equal(insertPayload.payload, JSON.stringify({ foo: 'bar' }));
+assert.equal(typeof insertPayload.created_at, 'string');
+
+// give the fire-and-forget snapshot/publish promises a tick to resolve
+await new Promise((resolve) => setTimeout(resolve, 10));
+assert.deepEqual(snapshotCalls, [{ boardId: 'board-1', sequence: 42n }]);
+assert.equal(publishCalls.length, 1);
+const [publishBoardId, publishMessageRaw] = publishCalls[0] as [string, string];
+assert.equal(publishBoardId, 'board-1');
+const publishMessage = JSON.parse(publishMessageRaw) as Record<string, unknown>;
+assert.equal(publishMessage.type, 'card.created');
+assert.equal(publishMessage.entity_id, 'card-1');
+assert.equal(publishMessage.actor_id, 'user-1');
+assert.deepEqual(publishMessage.payload, { foo: 'bar' });
+assert.equal(publishMessage.version, 42);
+assert.equal(publishMessage.sequence, '42');
+assert.equal(publishMessage.timestamp, createdAt.toISOString());
+assert.equal(typeof publishMessage.emittedAt, 'number');
+
+// boardId absent: no snapshot/publish side effects, insert still runs with
+// board_id null.
+calls.length = 0;
+snapshotCalls.length = 0;
+publishCalls.length = 0;
+insertedRow = {
+  id: 'event-2',
+  type: 'workspace.renamed',
+  board_id: null,
+  entity_id: 'workspace-1',
+  actor_id: 'user-1',
+  payload: {},
+  sequence: 43n,
+  created_at: createdAt,
+};
+
+const noBoardResult = await writeEvent({
+  type: 'workspace.renamed',
+  entityId: 'workspace-1',
+  actorId: 'user-1',
+  payload: {},
+});
+
+assert.deepEqual(noBoardResult, insertedRow);
+const [, noBoardInsertCall] = calls as [
+  ['table', string],
+  ['insert', Record<string, unknown>, string[]],
+];
+assert.equal(noBoardInsertCall[1].board_id, null);
+
+await new Promise((resolve) => setTimeout(resolve, 10));
+assert.deepEqual(snapshotCalls, []);
+assert.deepEqual(publishCalls, []);

--- a/server/mods/events/__tests__/writeEvent.contract.test.ts
+++ b/server/mods/events/__tests__/writeEvent.contract.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+
+test('writeEvent real handler preserves insert payload, guard, snapshot and publish contracts', () => {
+  // Shared DB mock stays in a child process, away from other suites' mock.module state.
+  const fixture = fileURLToPath(new URL('./fixtures/writeEvent.fixture.ts', import.meta.url));
+  const result = Bun.spawnSync([process.execPath, fixture], { stdout: 'pipe', stderr: 'pipe' });
+  expect(result.stderr.toString()).toBe('');
+  expect(result.exitCode).toBe(0);
+});

--- a/server/mods/events/write.ts
+++ b/server/mods/events/write.ts
@@ -24,9 +24,19 @@ export interface WrittenEvent {
   created_at: Date;
 }
 
+interface EventInsertRow {
+  id: string;
+  type: string;
+  board_id: string | null;
+  entity_id: string;
+  actor_id: string;
+  payload: string;
+  created_at: string;
+}
+
 export async function writeEvent(input: WriteEventInput): Promise<WrittenEvent> {
   const id = randomUUID();
-  const [event] = await db('events').insert({
+  const [insertedRow]: EventInsertRow[] = await db<EventInsertRow>('events').insert({
     id,
     type: input.type,
     board_id: input.boardId ?? null,
@@ -35,6 +45,15 @@ export async function writeEvent(input: WriteEventInput): Promise<WrittenEvent> 
     payload: JSON.stringify(input.payload),
     created_at: new Date().toISOString(),
   }, ['*']);
+
+  if (!insertedRow) {
+    throw new Error('Failed to write event row');
+  }
+
+  // `returning('*')` hydrates jsonb/timestamptz columns back to a parsed
+  // object and a Date (unlike the JSON-string/ISO-string insert payload),
+  // matching WrittenEvent's shape.
+  const event = insertedRow as unknown as WrittenEvent;
 
   if (input.boardId) {
     checkAndWriteSnapshot({ boardId: input.boardId, sequence: event.sequence }).catch(() => {});
@@ -54,5 +73,5 @@ export async function writeEvent(input: WriteEventInput): Promise<WrittenEvent> 
     publisher.publish(input.boardId, message).catch(() => {});
   }
 
-  return event as WrittenEvent;
+  return event;
 }


### PR DESCRIPTION
## Summary

Type-only ESLint slice for `server/mods/events/write.ts` (event persistence boundary used by nearly every mutating handler except payments). No repo-wide autofix/suppression/config/dependency changes.

- Typed the `db('events').insert()` call and the `returning('*')` row through migration-derived `EventInsertRow` (JSON-string/ISO-string payload, matching what the insert actually sends) and `WrittenEvent` (the hydrated jsonb/Date shape on read), eliminating all 16 `@typescript-eslint/no-unsafe-*` findings in this file.
- Added a defensive `if (!insertedRow) throw` guard instead of the previous unchecked `event as WrittenEvent` cast on a possibly-empty insert result. This cannot trigger against a real Postgres insert-with-returning, but it replaces a silent unsafe cast with fail-closed behaviour.
- No other runtime/auth/API contract changes.

## Baseline vs HEAD comparison

BASE (before edits, `origin/main` @ `cf10480c`):
- `bun run typecheck`: pre-existing failures only (Workspace/duck, featureFlagsSlice — unrelated to this file). Log: `/tmp/base_typecheck_srv-1788967135-85912.txt`
- `bun test`: **1251 pass, 3 skip, 180 fail, 30 errors**, 2600 expect() calls, 1434 tests / 236 files. Log: `/tmp/base_bun_test_srv-1788967135-85912.txt`

HEAD (after both commits):
- `bun run typecheck`: byte-identical diagnostic output to BASE (`diff` exit 0). Log: `/tmp/head2_typecheck_srv-1788967135-85912.txt`
- `bun test`: **1252 pass, 3 skip, 180 fail, 30 errors**, 2602 expect() calls, 1435 tests / 237 files. Log: `/tmp/head_bun_test_srv-1788967135-85912.txt`
- Named pass/fail identity diff (timings stripped): **only addition is the new `writeEvent` handler test**; zero identities lost, zero new failures. Diff artifacts: `/tmp/base_names_notime_srv-1788967135-85912.txt`, `/tmp/head_names_notime_srv-1788967135-85912.txt`

## Emitted JS comparison (erasure check)

`bun build` of `server/mods/events/write.ts` at BASE (`cf10480c`) vs HEAD, both with all imports externalized:
- All type annotations/interfaces erase cleanly — zero diff attributable to typing.
- The only non-erased delta is the intended behaviour addition: `event` renamed to `insertedRow`, plus the new `if (!insertedRow) throw new Error(...)` guard. Reported honestly as a real (defensive-only) change, not claimed as byte-identical.

## Verification run (this branch)

- Focused ESLint on touched files: `server/mods/events/write.ts`, `server/mods/events/__tests__/writeEvent.contract.test.ts`, `server/mods/events/__tests__/fixtures/writeEvent.fixture.ts` — **0 problems**.
- `bun test server/mods/events/__tests__/writeEvent.contract.test.ts` — 1 pass.
- `bun run typecheck` — no new diagnostics vs BASE.
- `bun run build:client` — succeeds (exit 0).
- `git diff --check` — clean.

## New test coverage

`server/mods/events/__tests__/writeEvent.contract.test.ts` + `fixtures/writeEvent.fixture.ts` (subprocess-isolated per project convention — DB, `checkAndWriteSnapshot`, and `publisher` are `mock.module`d only inside a spawned child process so this suite cannot leak mocks into others):
- Empty-insert guard throws (fail-closed) instead of silently returning an unsafely-cast `undefined`.
- Insert payload shape (id/type/board_id/entity_id/actor_id/JSON-stringified payload/ISO created_at) for both board-scoped and board-less events.
- Best-effort `checkAndWriteSnapshot`/`publisher.publish` dispatch only fires when `boardId` is present; verified message shape (`version`, `sequence` as string, `timestamp`, `emittedAt`).
- Returned value matches the hydrated `WrittenEvent` row from the mocked `insert(...).returning('*')`.

**Coverage limits (explicit gap):** this is a fully mocked/fake-transport test proving the function's own branching, payload construction and error handling. It does **not** exercise real Postgres column/type coercion (jsonb round-trip, bigint sequence generation, real `board_snapshots` interaction) or the real in-memory/Redis pubsub adapter — those remain unverified live-DB/pubsub paths, same as the archivedBoardGuard precedent (PR #251). No UI change; UI/E2E out of scope for this slice.

## Files changed
- `server/mods/events/write.ts` (typed insert/select boundary)
- `server/mods/events/__tests__/writeEvent.contract.test.ts` (new)
- `server/mods/events/__tests__/fixtures/writeEvent.fixture.ts` (new)

Do not approve/merge — parent performs independent review per standing process.
