### PR TITLE
lint: type api_tokens list projection, remove non-null assertion

### DIFF
--- a/server/extensions/apiToken/api/__tests__/fixtures/list.ts
+++ b/server/extensions/apiToken/api/__tests__/fixtures/list.ts
@@ -1,0 +1,175 @@
+import { strict as assert } from 'node:assert';
+import { mock } from 'bun:test';
+
+// Real handler under test: handleListTokens. Shared db and authenticate
+// modules are mocked here in a subprocess so this fixture cannot leak
+// state into (or be replaced by) adjacent test files.
+const calls: unknown[][] = [];
+
+const state: {
+  currentUser: { id: string; email: string } | undefined;
+  rows: Array<{
+    id: string;
+    name: string;
+    token_prefix: string;
+    expires_at: string | null;
+    last_used_at: string | null;
+    created_at: string;
+  }>;
+} = {
+  currentUser: { id: 'user-1', email: 'user1@example.com' },
+  rows: [
+    {
+      id: 'tok-1',
+      name: 'CI token',
+      token_prefix: 'hf_abc123',
+      expires_at: null,
+      last_used_at: '2026-02-01T00:00:00.000Z',
+      created_at: '2026-01-01T00:00:00.000Z',
+    },
+    {
+      id: 'tok-2',
+      name: 'Deploy token',
+      token_prefix: 'hf_def456',
+      expires_at: '2026-06-01T00:00:00.000Z',
+      last_used_at: null,
+      created_at: '2026-01-02T00:00:00.000Z',
+    },
+  ],
+};
+
+void mock.module('../../../../../common/db', () => ({
+  db: (table: string) => {
+    calls.push(['db', table]);
+    assert.equal(table, 'api_tokens');
+    return {
+      where: (filter: Record<string, unknown>) => {
+        calls.push(['where', filter]);
+        assert.deepEqual(filter, { user_id: 'user-1' });
+        return {
+          whereNull: (col: string) => {
+            calls.push(['whereNull', col]);
+            assert.equal(col, 'revoked_at');
+            return {
+              orderBy: (col: string, dir: string) => {
+                calls.push(['orderBy', col, dir]);
+                assert.equal(col, 'created_at');
+                assert.equal(dir, 'desc');
+                return {
+                  select: (...cols: unknown[]) => {
+                    calls.push(['select', cols]);
+                    assert.deepEqual(cols, [
+                      'id',
+                      'name',
+                      'token_prefix',
+                      'expires_at',
+                      'last_used_at',
+                      'created_at',
+                    ]);
+                    return Promise.resolve(state.rows);
+                  },
+                };
+              },
+            };
+          },
+        };
+      },
+    };
+  },
+}));
+
+void mock.module('../../../../auth/middlewares/authentication', () => ({
+  authenticate: (req: { currentUser?: { id: string; email: string } }) => {
+    calls.push(['authenticate']);
+    if (!state.currentUser) {
+      return Promise.resolve(
+        Response.json({ error: { code: 'unauthorized', message: 'Missing Bearer token' } }, { status: 401 }),
+      );
+    }
+    req.currentUser = state.currentUser;
+    return Promise.resolve(null);
+  },
+}));
+
+async function run(): Promise<void> {
+  const { handleListTokens } = await import('../../list');
+
+  // 1. Unauthenticated request short-circuits with the auth middleware's response.
+  state.currentUser = undefined;
+  const unauthedReq = new Request('http://localhost/api/v1/tokens');
+  const unauthedRes = await handleListTokens(unauthedReq);
+  assert.equal(unauthedRes.status, 401);
+
+  // 2. Authenticated request scopes the query to the current user and
+  //    excludes revoked tokens, ordered by created_at desc.
+  state.currentUser = { id: 'user-1', email: 'user1@example.com' };
+  calls.length = 0;
+  const authedReq = new Request('http://localhost/api/v1/tokens');
+  const authedRes = await handleListTokens(authedReq);
+  assert.equal(authedRes.status, 200);
+  const body = (await authedRes.json()) as {
+    data: Array<{
+      id: string;
+      name: string;
+      prefix: string;
+      expiresAt: string | null;
+      lastUsedAt: string | null;
+      createdAt: string;
+    }>;
+  };
+
+  // 3. Response never surfaces raw token/hash — only the documented public shape.
+  assert.equal(body.data.length, 2);
+  for (const item of body.data) {
+    assert.equal(Object.prototype.hasOwnProperty.call(item, 'token'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(item, 'token_hash'), false);
+  }
+  assert.deepEqual(body.data[0], {
+    id: 'tok-1',
+    name: 'CI token',
+    prefix: 'hf_abc123',
+    expiresAt: null,
+    lastUsedAt: '2026-02-01T00:00:00.000Z',
+    createdAt: '2026-01-01T00:00:00.000Z',
+  });
+  assert.deepEqual(body.data[1], {
+    id: 'tok-2',
+    name: 'Deploy token',
+    prefix: 'hf_def456',
+    expiresAt: '2026-06-01T00:00:00.000Z',
+    lastUsedAt: null,
+    createdAt: '2026-01-02T00:00:00.000Z',
+  });
+
+  // 4. Missing-optional-field nulling: expires_at/last_used_at `??` fallback preserved.
+  state.rows = [
+    {
+      id: 'tok-3',
+      name: 'No optional fields',
+      token_prefix: 'hf_ghi789',
+      expires_at: undefined as unknown as null,
+      last_used_at: undefined as unknown as null,
+      created_at: '2026-01-03T00:00:00.000Z',
+    },
+  ];
+  const nullFallbackRes = await handleListTokens(new Request('http://localhost/api/v1/tokens'));
+  const nullFallbackBody = (await nullFallbackRes.json()) as {
+    data: Array<{ expiresAt: string | null; lastUsedAt: string | null }>;
+  };
+  const [nullFallbackItem] = nullFallbackBody.data;
+  assert.ok(nullFallbackItem);
+  assert.equal(nullFallbackItem.expiresAt, null);
+  assert.equal(nullFallbackItem.lastUsedAt, null);
+
+  assert.ok(calls.some((entry) => entry[0] === 'authenticate'));
+  assert.ok(calls.some((entry) => entry[0] === 'select'));
+
+  console.info(
+    'handleListTokens real user-scope filter, revoked exclusion, ordering, and public-field-only response verified',
+  );
+}
+
+run().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/extensions/apiToken/api/__tests__/list.test.ts
+++ b/server/extensions/apiToken/api/__tests__/list.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'bun:test';
+
+// Isolate shared db/authenticate mocks while exercising the real
+// handleListTokens handler in a subprocess so this fixture cannot leak
+// state into (or be replaced by) adjacent tests.
+test('handleListTokens scopes to current user, excludes revoked tokens, orders by created_at desc, and never leaks raw token/hash', async () => {
+  const child = Bun.spawn(
+    [process.execPath, new URL('./fixtures/list.ts', import.meta.url).pathname],
+    { stdout: 'pipe', stderr: 'pipe' },
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  expect(stderr).toBe('');
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain(
+    'handleListTokens real user-scope filter, revoked exclusion, ordering, and public-field-only response verified',
+  );
+});

--- a/server/extensions/apiToken/api/list.ts
+++ b/server/extensions/apiToken/api/list.ts
@@ -3,13 +3,31 @@
 import { db } from '../../../common/db';
 import { authenticate, type AuthenticatedRequest } from '../../auth/middlewares/authentication';
 
+type ApiTokenListRow = {
+  id: string;
+  user_id: string;
+  name: string;
+  token_prefix: string;
+  expires_at: string | null;
+  last_used_at: string | null;
+  revoked_at: string | null;
+  created_at: string;
+};
+
 export async function handleListTokens(req: Request): Promise<Response> {
-  const authError = await authenticate(req as AuthenticatedRequest);
+  const authenticatedReq = req as AuthenticatedRequest;
+  const authError = await authenticate(authenticatedReq);
   if (authError) return authError;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const userId = authenticatedReq.currentUser?.id;
+  if (!userId) {
+    return Response.json(
+      { name: 'unauthorized', data: { message: 'Missing authenticated user' } },
+      { status: 401 },
+    );
+  }
 
-  const tokens = await db('api_tokens')
+  const tokens = await db<ApiTokenListRow>('api_tokens')
     .where({ user_id: userId })
     .whereNull('revoked_at')
     .orderBy('created_at', 'desc')


### PR DESCRIPTION
## Scope

Small ESLint slice: `server/extensions/apiToken/api/list.ts` (GET /api/v1/tokens handler).

Non-payment server file. No repo-wide autofix, suppression, config, dependency, deployment, or `stable`-branch changes.

## Changes

- Added `ApiTokenListRow` typed from migration `db/migrations/0093_api_tokens.ts`, including the filter column (`user_id`) and adjacent `revoked_at` column alongside every selected column, per prior slice guidance on Knex row typing.
- Replaced `db('api_tokens')` implicit-`any` select with `db<ApiTokenListRow>('api_tokens')`.
- Replaced `currentUser!.id` non-null assertion with an explicit `if (!userId) return 401` guard. This is intentionally behaviour-preserving: `authenticate()` always populates `currentUser` on its null-return (success) path today, so the new branch is unreachable in current code, but it removes the lint-forbidden assertion without widening any type.
- Added a subprocess-isolated handler-level test (none existed before) covering: 401 short-circuit when unauthenticated, `user_id`/`revoked_at` query scope, `created_at desc` ordering, and that the response never leaks `token`/`token_hash` — only the documented public shape.

## Resolves (from `/tmp/chimedeck-full-lint-post-252.txt`)

6 findings in `server/extensions/apiToken/api/list.ts`:
- `@typescript-eslint/no-unsafe-assignment` × 5
- `@typescript-eslint/no-unsafe-member-access` × 5 (`.id`, `.name`, `.token_prefix`, `.expires_at`, `.last_used_at`, `.created_at` — 6 listed in the raw scan, one folds into the same union)
- `@typescript-eslint/no-non-null-assertion` × 1

## Verification

All logs under unique `/tmp/chimedeck-*-apitoken*.txt` paths.

| Gate | Base (pre-edit) | Head (post-edit) | Result |
|---|---|---|---|
| `bun run typecheck` | 147 `error TS` lines (`/tmp/chimedeck-base-typecheck-apitoken.txt`) | 147 `error TS` lines, **byte-identical diff** (`/tmp/chimedeck-head-typecheck-apitoken.txt`) | No new diagnostics |
| `bun test` (full suite) | 1252 pass / 3 skip / 180 fail / 30 errors (`/tmp/chimedeck-base-test-apitoken.txt`) | 1253 pass / 3 skip / 180 fail / 30 errors (`/tmp/chimedeck-head-test-apitoken.txt`) | +1 pass = the new handler test; named-failure multiset (147 distinct `(fail)` identities, parsed up to the first summary line) is **identical set** base vs head — no existing failing/passing identity was lost or newly broken |
| Focused `eslint` on all 3 touched files | — | 0 errors, 0 warnings (`/tmp/chimedeck-lint-apitoken-final.txt`) | clean |
| Focused `bun test` on the new test file | — | 1 pass (`/tmp/chimedeck-apitoken-list-test2.txt`) | clean |
| `bun run build:client` | — | exit 0 (`/tmp/chimedeck-head-build-apitoken.txt`) | unaffected server-only change |
| `git diff --check` | — | exit 0, no whitespace errors | clean |

## Coverage / honesty notes

- The new test mocks `../../../../../common/db` and `../../../../auth/middlewares/authentication` inside a **child process** (`Bun.spawn`), matching the shared-mock-isolation pattern from prior slices, so it cannot leak `mock.module` state into other suites.
- This is a **fake-transport** test: it proves the handler builds the exact Knex query chain (`where({user_id})` → `whereNull('revoked_at')` → `orderBy('created_at','desc')` → `select(...)`) and shapes the response correctly. It does **not** exercise a live Postgres connection, the real `authenticate()` implementation, or actual `api_tokens` schema constraints — those remain unverified live-DB/auth-middleware gaps, consistent with this repo's established labeling convention.
- No UI touched; no UI/E2E coverage needed for this slice.
- DB type is derived directly from `db/migrations/0093_api_tokens.ts` (columns `id`, `user_id`, `name`, `token_hash`, `token_prefix`, `expires_at`, `last_used_at`, `revoked_at`, `created_at`); the row type here narrows to the subset actually read/filtered (excludes `token_hash`, which this handler never selects — consistent with "never returns the raw token or hash value").
- Runtime/API/auth contracts unchanged: same table, same columns, same filter/order, same response JSON shape (`id`, `name`, `prefix`, `expiresAt`, `lastUsedAt`, `createdAt`).

## Do not merge

This PR is opened by `matthewvryanjh` for independent review only. No approval or merge performed by this agent — a separate reviewer context should inspect the diff and evidence before `hermesrobinson-dev` approves and merges, per standing repo practice.
