### PR TITLE
lint: type board-plugin allowed-domains DB rows

### DIFF
--- a/server/extensions/plugins/api/board-plugins/__tests__/allowedDomains.contract.test.ts
+++ b/server/extensions/plugins/api/board-plugins/__tests__/allowedDomains.contract.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+
+test('board plugin allowed-domains handler preserves guard, validation, and config-merge contracts', () => {
+  // Shared DB/auth mocks stay in a child process, away from other suites'
+  // mock.module state (see server/mods/events/__tests__/writeEvent.contract.test.ts).
+  const fixture = fileURLToPath(new URL('./fixtures/allowedDomains.fixture.ts', import.meta.url));
+  const result = Bun.spawnSync([process.execPath, fixture], { stdout: 'pipe', stderr: 'pipe' });
+  if (result.exitCode !== 0) {
+    console.error(result.stderr.toString());
+  }
+  expect(result.stderr.toString()).toBe('');
+  expect(result.exitCode).toBe(0);
+});

--- a/server/extensions/plugins/api/board-plugins/__tests__/fixtures/allowedDomains.fixture.ts
+++ b/server/extensions/plugins/api/board-plugins/__tests__/fixtures/allowedDomains.fixture.ts
@@ -1,0 +1,187 @@
+import { strict as assert } from 'node:assert';
+import { mock } from 'bun:test';
+
+// Shared DB mock stays in a child process, away from other suites' mock.module state.
+type Row = Record<string, unknown>;
+
+const boards: Row[] = [{ id: 'board-1', workspace_id: 'ws-1' }];
+const memberships: Row[] = [{ user_id: 'user-1', workspace_id: 'ws-1', role: 'ADMIN' }];
+let boardPlugins: Row[] = [
+  {
+    id: 'bp-1',
+    board_id: 'board-1',
+    plugin_id: 'plugin-1',
+    enabled_by: 'user-1',
+    enabled_at: new Date('2024-01-01T00:00:00.000Z'),
+    disabled_at: null,
+    config: {},
+  },
+];
+const plugins: Row[] = [
+  { id: 'plugin-1', whitelisted_domains: ['api.example.com', 'cdn.example.com'] },
+  { id: 'plugin-no-domains', whitelisted_domains: null },
+];
+
+const updateCalls: Array<{ table: string; where: Row; payload: Row }> = [];
+
+void mock.module('../../../../../../common/db', () => ({
+  db(table: string) {
+    return {
+      where(criteria: Row) {
+        const source =
+          table === 'boards'
+            ? boards
+            : table === 'memberships'
+              ? memberships
+              : table === 'board_plugins'
+                ? boardPlugins
+                : table === 'plugins'
+                  ? plugins
+                  : [];
+        const matches = (row: Row) =>
+          Object.entries(criteria).every(([key, value]) => row[key] === value);
+        return {
+          whereNull(column: string) {
+            const filtered = source.filter((row) => matches(row) && row[column] == null);
+            return {
+              first: <T>() => Promise.resolve(filtered[0] as T | undefined),
+            };
+          },
+          first: <T>() => Promise.resolve(source.find(matches) as T | undefined),
+          update(payload: Row) {
+            updateCalls.push({ table, where: criteria, payload });
+            boardPlugins = boardPlugins.map((row) =>
+              matches(row) ? { ...row, ...payload } : row,
+            );
+            return Promise.resolve(1);
+          },
+        };
+      },
+    };
+  },
+}));
+
+void mock.module('../../../../../auth/middlewares/authentication', () => ({
+  authenticate(req: { currentUser?: { id: string; email: string } }) {
+    req.currentUser = { id: 'user-1', email: 'admin@example.com' };
+    return Promise.resolve(null);
+  },
+}));
+
+const { handleSetBoardPluginAllowedDomains } = await import('../../allowed-domains');
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/v1/boards/board-1/plugins/plugin-1/allowed-domains', {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}
+
+// ─── invalid JSON body ──────────────────────────────────────────────────────
+{
+  const req = new Request('http://localhost/x', { method: 'PATCH', body: '{not json' });
+  const res = await handleSetBoardPluginAllowedDomains(req, 'board-1', 'plugin-1');
+  assert.equal(res.status, 400);
+  const json = (await res.json()) as { error: { code: string } };
+  assert.equal(json.error.code, 'bad-request');
+}
+
+// ─── plugin not enabled on board (no active board_plugins row) ────────────
+{
+  const res = await handleSetBoardPluginAllowedDomains(
+    makeRequest({ allowedDomains: ['api.example.com'] }),
+    'board-1',
+    'plugin-missing',
+  );
+  assert.equal(res.status, 404);
+  const json = (await res.json()) as { error: { code: string } };
+  assert.equal(json.error.code, 'plugin-not-enabled');
+}
+
+// ─── allowedDomains not an array ───────────────────────────────────────────
+{
+  const res = await handleSetBoardPluginAllowedDomains(
+    makeRequest({ allowedDomains: 'not-an-array' }),
+    'board-1',
+    'plugin-1',
+  );
+  assert.equal(res.status, 422);
+  const json = (await res.json()) as { error: { code: string } };
+  assert.equal(json.error.code, 'invalid-allowed-domains');
+}
+
+// ─── domain not in plugin's whitelistedDomains ─────────────────────────────
+{
+  const res = await handleSetBoardPluginAllowedDomains(
+    makeRequest({ allowedDomains: ['not-whitelisted.com'] }),
+    'board-1',
+    'plugin-1',
+  );
+  assert.equal(res.status, 422);
+  const json = (await res.json()) as { name: string; data: { message: string } };
+  assert.equal(json.name, 'domain-not-whitelisted-by-plugin');
+  assert.equal(json.data.message, "'not-whitelisted.com' is not in the plugin's whitelistedDomains");
+}
+
+// ─── plugin has no whitelisted domains (null) — any non-null request rejected
+{
+  boardPlugins.push({
+    id: 'bp-2',
+    board_id: 'board-1',
+    plugin_id: 'plugin-no-domains',
+    enabled_by: 'user-1',
+    enabled_at: new Date(),
+    disabled_at: null,
+    config: {},
+  });
+  const res = await handleSetBoardPluginAllowedDomains(
+    makeRequest({ allowedDomains: ['anything.com'] }),
+    'board-1',
+    'plugin-no-domains',
+  );
+  assert.equal(res.status, 422);
+  const json = (await res.json()) as { name: string };
+  assert.equal(json.name, 'domain-not-whitelisted-by-plugin');
+}
+
+// ─── success: valid subset persists config and preserves existing keys ────
+{
+  updateCalls.length = 0;
+  boardPlugins = boardPlugins.map((row) =>
+    row.id === 'bp-1' ? { ...row, config: { unrelated: 'keep-me' } } : row,
+  );
+  const res = await handleSetBoardPluginAllowedDomains(
+    makeRequest({ allowedDomains: ['api.example.com'] }),
+    'board-1',
+    'plugin-1',
+  );
+  assert.equal(res.status, 200);
+  const json = (await res.json()) as {
+    data: { boardPluginId: string; allowedDomains: string[] };
+  };
+  assert.equal(json.data.boardPluginId, 'bp-1');
+  assert.deepEqual(json.data.allowedDomains, ['api.example.com']);
+
+  assert.equal(updateCalls.length, 1);
+  const [updateCall] = updateCalls;
+  assert.ok(updateCall);
+  assert.equal(updateCall.table, 'board_plugins');
+  assert.deepEqual(updateCall.where, { id: 'bp-1' });
+  const persistedConfig = JSON.parse(updateCall.payload.config as string) as Row;
+  assert.equal(persistedConfig.unrelated, 'keep-me');
+  assert.deepEqual(persistedConfig.allowedDomains, ['api.example.com']);
+}
+
+// ─── success: null allowedDomains clears restriction without domain checks ─
+{
+  updateCalls.length = 0;
+  const res = await handleSetBoardPluginAllowedDomains(
+    makeRequest({ allowedDomains: null }),
+    'board-1',
+    'plugin-1',
+  );
+  assert.equal(res.status, 200);
+  const json = (await res.json()) as { data: { allowedDomains: string[] | null } };
+  assert.equal(json.data.allowedDomains, null);
+  assert.equal(updateCalls.length, 1);
+}

--- a/server/extensions/plugins/api/board-plugins/allowed-domains.ts
+++ b/server/extensions/plugins/api/board-plugins/allowed-domains.ts
@@ -4,6 +4,23 @@
 import { db } from '../../../../common/db';
 import { boardAdminGuard, type BoardAdminRequest } from '../../middlewares/board-admin-guard';
 
+// Row shapes derived from db/migrations/0021_plugins.ts and
+// db/migrations/0023_plugin_whitelisted_domains.ts.
+interface BoardPluginRow {
+  id: string;
+  board_id: string;
+  plugin_id: string;
+  enabled_by: string | null;
+  enabled_at: Date;
+  disabled_at: Date | null;
+  config: Record<string, unknown>;
+}
+
+interface PluginRow {
+  id: string;
+  whitelisted_domains: string[] | null;
+}
+
 export async function handleSetBoardPluginAllowedDomains(
   req: Request,
   boardId: string,
@@ -26,7 +43,7 @@ export async function handleSetBoardPluginAllowedDomains(
   const boardPlugin = await db('board_plugins')
     .where({ board_id: boardId, plugin_id: pluginId })
     .whereNull('disabled_at')
-    .first();
+    .first<BoardPluginRow | undefined>();
 
   if (!boardPlugin) {
     return Response.json(
@@ -36,7 +53,7 @@ export async function handleSetBoardPluginAllowedDomains(
   }
 
   // Fetch the plugin's whitelisted domains.
-  const plugin = await db('plugins').where({ id: pluginId }).first();
+  const plugin = await db('plugins').where({ id: pluginId }).first<PluginRow | undefined>();
   if (!plugin) {
     return Response.json(
       { error: { code: 'plugin-not-found', message: 'Plugin not found' } },
@@ -60,11 +77,12 @@ export async function handleSetBoardPluginAllowedDomains(
 
     // Every allowed domain must be declared in the plugin's whitelistedDomains.
     for (const domain of allowedDomains) {
-      if (!whitelistedDomains.includes(domain as string)) {
+      const domainValue = domain as string;
+      if (!whitelistedDomains.includes(domainValue)) {
         return Response.json(
           {
             name: 'domain-not-whitelisted-by-plugin',
-            data: { message: `'${domain}' is not in the plugin's whitelistedDomains` },
+            data: { message: `'${domainValue}' is not in the plugin's whitelistedDomains` },
           },
           { status: 422 },
         );
@@ -73,8 +91,8 @@ export async function handleSetBoardPluginAllowedDomains(
   }
 
   // Merge allowedDomains into existing config (replace, not deep-merge).
-  const existingConfig = boardPlugin.config ?? {};
-  const newConfig = { ...existingConfig, allowedDomains };
+  // config is NOT NULL (defaults to '{}') per db/migrations/0021_plugins.ts.
+  const newConfig = { ...boardPlugin.config, allowedDomains };
 
   await db('board_plugins')
     .where({ id: boardPlugin.id })


### PR DESCRIPTION
## Scope
Type the board_plugins/plugins Knex row lookups in `server/extensions/plugins/api/board-plugins/allowed-domains.ts` to eliminate all `no-unsafe-*` / `restrict-template-expressions` ESLint errors in this file. Non-payment slice (plugins domain).

## Changes
- Add `BoardPluginRow`/`PluginRow` interfaces derived from `db/migrations/0021_plugins.ts` and `db/migrations/0023_plugin_whitelisted_domains.ts`.
- Type `.first<...>()` calls on the two Knex queries instead of leaving them `any`.
- Hoist the templated `domain` into `domainValue` (fixes a `restrict-template-expressions` finding surfaced once typing was applied).
- Drop the dead `boardPlugin.config ?? {}` fallback — migration 0021 declares `config` `NOT NULL DEFAULT '{}'`, so the fallback was unreachable and ESLint's `no-unnecessary-condition` flagged it once typed.

## Behaviour preservation
Bun-transpiled JS (`bun build --target=bun --no-bundle`) is byte-identical between base and head except for the two non-erased edits above (local-const hoist with the same runtime value, and the unreachable `?? {}` removal). Full diff captured in the commit message.

## Tests
No handler-level test existed for this boundary. Added:
- `server/extensions/plugins/api/board-plugins/__tests__/allowedDomains.contract.test.ts` — spawns the fixture in a child Bun process (isolates its `mock.module` DB/auth mocks from the rest of the suite, per repo convention in `server/mods/events/__tests__/writeEvent.contract.test.ts`).
- `.../fixtures/allowedDomains.fixture.ts` — exercises: invalid JSON body, plugin-not-enabled, non-array `allowedDomains`, domain not in `whitelistedDomains`, plugin with `whitelisted_domains: null`, successful merge preserving unrelated `config` keys, and `allowedDomains: null` clearing the restriction.

This is a fake/mocked-DB smoke test proving the handler's own logic (guard call, validation branches, config merge, response shapes). It does **not** exercise live Postgres, the real `boardAdminGuard`/`authenticate` chain, or the router's regex dispatch — those remain unverified by this slice.

## Verification (fresh evidence, this repo checkout)
- Base commit: `4ccaa22a` (origin/main, clean fast-forward)
- `bun run typecheck`: **byte-identical** output base vs head (`/tmp/chimedeck-base-typecheck-allowed-domains.txt` vs `/tmp/chimedeck-head-typecheck-allowed-domains.txt`); pre-existing failures are unrelated client-side `featureFlagsSlice.ts` errors.
- `bun test` (full suite):
  - base: 1254 pass / 3 skip / 180 fail / 30 errors (matches historical baseline exactly)
  - head: 1255 pass (+1, the new test) / 3 skip / 180 fail / 30 errors
  - Parsed named `(fail)` identities are **set-identical** between base and head (147/147, 0 added, 0 removed) — no existing passing/failing identity was lost or changed.
  - Logs: `/tmp/chimedeck-base-test-allowed-domains.txt`, `/tmp/chimedeck-head-test-allowed-domains.txt`
- Focused `eslint` on all 3 touched files: 0 errors (`/tmp/chimedeck-focused-lint-allowed-domains-final.txt`)
- Focused `bun test` on the new file: 1 pass (`/tmp/chimedeck-focused-test-allowed-domains-final.txt`)
- `bun run build:client`: exit 0 (`/tmp/chimedeck-head-buildclient-allowed-domains.txt`)
- `git diff --check`: clean

## Boundaries
- No repo-wide `eslint --fix`, no suppression, no config/dependency/deployment changes.
- No payments/monetisation/Stripe/subscription/billing files touched.
- Live DB/router/auth-chain coverage remains unverified by this slice (fake-DB fixture only, isolated in a subprocess).

Do not approve or merge — separate reviewer context per repo policy.
