### PR TITLE
lint: type attachment thumbnail worker DB row + handler test

### DIFF
--- a/server/extensions/attachment/workers/__tests__/thumbnail.fixture.ts
+++ b/server/extensions/attachment/workers/__tests__/thumbnail.fixture.ts
@@ -1,0 +1,91 @@
+import { mock } from 'bun:test';
+import assert from 'node:assert/strict';
+
+const scenario = process.argv[2] ?? '';
+
+const attachmentBase = { id: 'attachment-a', card_id: 'card-a' };
+
+const dbCalls: { table: string; filter: unknown; update?: unknown }[] = [];
+const s3Calls: { command: string; input: unknown }[] = [];
+
+function attachmentFor(scenarioName: string): Record<string, unknown> | undefined {
+  if (scenarioName === 'missing-attachment') return undefined;
+  if (scenarioName === 'unsupported-mime') return { ...attachmentBase, mime_type: 'application/pdf', s3_key: 'k' };
+  if (scenarioName === 'null-mime') return { ...attachmentBase, mime_type: null, s3_key: 'k' };
+  if (scenarioName === 'missing-s3-key') return { ...attachmentBase, mime_type: 'image/png', s3_key: null };
+  if (scenarioName === 'gif') return { ...attachmentBase, mime_type: 'image/gif', s3_key: 'k' };
+  return { ...attachmentBase, mime_type: 'image/png', s3_key: 'k' };
+}
+
+void mock.module('../../../../common/db', () => ({
+  db: (table: string) =>
+    ({
+      where: (filter: unknown) => ({
+        first: () => {
+          dbCalls.push({ table, filter, update: undefined });
+          return Promise.resolve(attachmentFor(scenario));
+        },
+        update: (patch: unknown) => {
+          dbCalls.push({ table, filter, update: patch });
+          return Promise.resolve(1);
+        },
+      }),
+    }) as unknown,
+}));
+
+void mock.module('../../common/config/s3', () => ({
+  s3ServerClient: {
+    send: (command: { constructor: { name: string }; input: unknown }) => {
+      s3Calls.push({ command: command.constructor.name, input: command.input });
+      if (command.constructor.name === 'GetObjectCommand') {
+        return Promise.resolve({
+          Body: (function* () {
+            yield new Uint8Array([1, 2, 3]);
+          })(),
+        });
+      }
+      return Promise.resolve({});
+    },
+  },
+  s3Config: { bucket: 'test-bucket' },
+}));
+
+void mock.module('sharp', () => ({
+  default: () => ({
+    metadata: () => Promise.resolve({ width: 200, height: 100 }),
+    resize: () => ({
+      webp: () => ({
+        toBuffer: () => Promise.resolve(Buffer.from('webp-bytes')),
+      }),
+    }),
+  }),
+}));
+
+const { generateThumbnail } = await import('../thumbnail');
+
+await generateThumbnail({ attachmentId: 'attachment-a' });
+
+const updateCall = dbCalls.find((c) => c.table === 'attachments' && c.update !== undefined);
+
+if (scenario === 'missing-attachment') {
+  assert.equal(updateCall, undefined);
+  assert.equal(s3Calls.length, 0);
+} else if (scenario === 'unsupported-mime' || scenario === 'null-mime') {
+  assert.equal(updateCall, undefined);
+  assert.equal(s3Calls.length, 0);
+} else if (scenario === 'missing-s3-key') {
+  assert.equal(updateCall, undefined);
+  assert.equal(s3Calls.length, 0);
+} else if (scenario === 'gif') {
+  assert.equal(s3Calls.filter((c) => c.command === 'PutObjectCommand').length, 0);
+  assert.deepEqual(updateCall?.update, { width: 200, height: 100 });
+} else {
+  assert.equal(scenario, 'ready');
+  assert.equal(s3Calls.filter((c) => c.command === 'GetObjectCommand').length, 1);
+  assert.equal(s3Calls.filter((c) => c.command === 'PutObjectCommand').length, 1);
+  assert.deepEqual(updateCall?.update, {
+    thumbnail_key: 'thumbnails/card-a/attachment-a.webp',
+    width: 200,
+    height: 100,
+  });
+}

--- a/server/extensions/attachment/workers/__tests__/thumbnail.test.ts
+++ b/server/extensions/attachment/workers/__tests__/thumbnail.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const fixture = fileURLToPath(new URL('./thumbnail.fixture.ts', import.meta.url));
+
+// Keep shared DB/S3/sharp mocks out of the suite; import the real handler in
+// each isolated child process so adjacent tests cannot leak their mocks in.
+test.each([
+  'missing-attachment',
+  'unsupported-mime',
+  'null-mime',
+  'missing-s3-key',
+  'gif',
+  'ready',
+])('generateThumbnail: %s', (scenario) => {
+  const result = spawnSync(process.execPath, [fixture, scenario], { encoding: 'utf8' });
+  expect(result.error).toBeUndefined();
+  expect(result.stderr).toBe('');
+  expect(result.status).toBe(0);
+});

--- a/server/extensions/attachment/workers/thumbnail.ts
+++ b/server/extensions/attachment/workers/thumbnail.ts
@@ -19,8 +19,19 @@ const THUMBNAIL_SUPPORTED_TYPES = new Set([
   'image/webp',
 ]);
 
+// Attachment columns consumed here, from 0011_attachments.ts and
+// 0033_attachments_enhanced.ts / 0108_attachment_dimensions.ts (width/height).
+interface AttachmentRow {
+  id: string;
+  card_id: string;
+  mime_type: string | null;
+  s3_key: string | null;
+  width: number | null;
+  height: number | null;
+}
+
 export async function generateThumbnail({ attachmentId }: { attachmentId: string }): Promise<void> {
-  const attachment = await db('attachments').where({ id: attachmentId }).first();
+  const attachment = await db<AttachmentRow>('attachments').where({ id: attachmentId }).first();
   if (!attachment) return;
 
   // Use mime_type (client-provided on upload) to gate image-only processing
@@ -48,8 +59,8 @@ export async function generateThumbnail({ attachmentId }: { attachmentId: string
   // Persist dimensions and return without generating a thumbnail_key.
   if (mimeType === 'image/gif') {
     await db('attachments').where({ id: attachmentId }).update({
-      width: metadata.width ?? null,
-      height: metadata.height ?? null,
+      width: metadata.width,
+      height: metadata.height,
     });
     return;
   }
@@ -75,7 +86,7 @@ export async function generateThumbnail({ attachmentId }: { attachmentId: string
 
   await db('attachments').where({ id: attachmentId }).update({
     thumbnail_key: thumbnailKey,
-    width: metadata.width ?? null,
-    height: metadata.height ?? null,
+    width: metadata.width,
+    height: metadata.height,
   });
 }


### PR DESCRIPTION
## Scope
Non-payment server ESLint slice, one file domain: `server/extensions/attachment/workers/thumbnail.ts`.

## Change
- Type the `attachments` row read in `generateThumbnail()` with a local `AttachmentRow` interface derived from `0011_attachments.ts`, `0033_attachments_enhanced.ts`, `0108_attachment_dimensions.ts` (`id`, `card_id`, `mime_type`, `s3_key`, `width`, `height`), replacing the previously untyped `db()` read that produced 6 `no-unsafe-assignment`/`no-unsafe-member-access` findings.
- Removed now-redundant `?? null` on `metadata.width`/`metadata.height` writes — sharp's `Metadata.width`/`height` are non-optional `number`s, so eslint's `no-unnecessary-condition` now correctly flags the fallback as dead. Behaviour unchanged: sharp always returns numeric dimensions for a successfully decoded image.
- Added a real handler-level test (none existed for this boundary): `server/extensions/attachment/workers/__tests__/thumbnail.test.ts` + `thumbnail.fixture.ts`, following the existing subprocess-isolated db/S3-mock pattern used by `attachment/mods/virusScan/update.test.ts` so shared DB mocks can't leak across the suite. Covers: missing-attachment, unsupported-mime, null-mime, missing-s3-key, gif (dimensions only, no `thumbnail_key`), and the happy path (webp thumbnail generated + `thumbnail_key`/width/height persisted).

No runtime/auth/API contract changes; DB typing is migration-derived only.

## Verification (fresh, this slice)
- Focused ESLint on all 3 touched files: **0 errors, 0 warnings**.
- `bun run typecheck`: diagnostic set (by TS error code + message) identical base vs head.
- `bun run build:client`: clean, exit 0.
- `git diff --check`: clean.
- `bun test` (full suite):
  - BASE: 1255 pass / 3 skip / 180 fail / 30 errors — matches historical baseline exactly.
  - HEAD: 1261 pass / 3 skip / 180 fail / 30 errors (+6 new passing tests, all from this slice's new file).
  - Failing-test-name multiset (147 unique file-qualified identities) reconciled **identical** base vs head — no existing passing identity lost, no new failure introduced. Remaining 180/30 pre-existing failures/errors are unrelated environment gaps (DB/service dependencies not available in this sandbox), consistent with historical baseline.
- New test run in isolation: `bun test server/extensions/attachment/workers/__tests__/thumbnail.test.ts` → 6/6 pass.

## Evidence (local /tmp, this run)
- `/tmp/chimedeck-base-typecheck-thumbnail.log`, `/tmp/chimedeck-head2-typecheck-thumbnail.log`
- `/tmp/chimedeck-base-test-thumbnail.log`, `/tmp/chimedeck-head-test-thumbnail.log`
- `/tmp/chimedeck-build-client-thumbnail.log`
- `/tmp/thumbnail-test-compare.txt` (failure-identity reconciliation)

## Coverage limits (honest gaps)
- New test isolates the handler behind mocked `db`, `s3ServerClient`, and `sharp` in a child process (fake-transport smoke coverage). It does **not** exercise a live S3 endpoint, a live Postgres `attachments` table, or the real `sharp` binary/codec path — those remain unverified live-dependency gaps, consistent with this repo's established pattern for this domain.
- No UI touched by this slice; no UI/E2E run needed.

## Boundaries respected
- No repo-wide `eslint --fix`, no suppression comments, no config/dependency/deployment changes, no lockfile changes.
- No payments/billing/subscription/Stripe files touched.

Do not approve or merge this PR — a separate reviewer will inspect the diff and evidence.
