### PR TITLE
lint: remove dead eslint-disable comments for uninstalled plugins

### DIFF
--- a/src/common/components/MentionInput/MentionInput.tsx
+++ b/src/common/components/MentionInput/MentionInput.tsx
@@ -69,7 +69,6 @@ const MentionInput = ({
         aria-autocomplete="list"
         aria-expanded={showSuggestions}
         style={{ overflow: 'hidden' }}
-        // eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus={autoFocus}
       />
       {showSuggestions && (

--- a/src/extensions/Attachments/components/AttachmentThumbnail.tsx
+++ b/src/extensions/Attachments/components/AttachmentThumbnail.tsx
@@ -183,7 +183,6 @@ export function VideoLightbox({
       >
         <XMarkIcon className="h-8 w-8" />
       </button>
-      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <video
         src={src}
         controls

--- a/src/extensions/Attachments/components/PasteListener.tsx
+++ b/src/extensions/Attachments/components/PasteListener.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 // Renders nothing — purely side-effect component.
 export function PasteListener({ enabled, onFiles, onLink }: Props): null {
-  const stableOnFiles = useCallback(onFiles, []); // eslint-disable-line react-hooks/exhaustive-deps
+  const stableOnFiles = useCallback(onFiles, []);
   useClipboardPaste({ enabled, onFiles: stableOnFiles, onLink });
   return null;
 }

--- a/src/extensions/Attachments/hooks/useAttachmentUpload.ts
+++ b/src/extensions/Attachments/hooks/useAttachmentUpload.ts
@@ -162,7 +162,6 @@ export function useAttachmentUpload({
 
       return newEntries.map((e) => e.clientId);
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [cardId, deferred],
   );
 
@@ -179,7 +178,6 @@ export function useAttachmentUpload({
         void uploadFile(entry);
       }
     });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   function notifyFlushComplete() {

--- a/src/extensions/Auth/containers/ConfirmEmailChangePage/ConfirmEmailChangePage.tsx
+++ b/src/extensions/Auth/containers/ConfirmEmailChangePage/ConfirmEmailChangePage.tsx
@@ -23,7 +23,6 @@ export default function ConfirmEmailChangePage() {
     if (token) {
       dispatch(confirmEmailChangeThunk({ token }));
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/src/extensions/Auth/containers/VerifyEmailPage/VerifyEmailPage.tsx
+++ b/src/extensions/Auth/containers/VerifyEmailPage/VerifyEmailPage.tsx
@@ -26,7 +26,6 @@ export default function VerifyEmailPage() {
     if (token) {
       dispatch(verifyEmailThunk({ token }));
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/src/extensions/Board/components/BoardSearchBar.tsx
+++ b/src/extensions/Board/components/BoardSearchBar.tsx
@@ -75,7 +75,6 @@ const BoardSearchBar = ({ boardId, token, initialQuery = '', onQueryChange, onSe
     setLoading(false);
     setPanelOpen(false);
   // Only reset on boardId change; initialQuery is intentionally excluded here
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [boardId]);
 
   // Notify parent whenever the committed search query changes (for URL sync)

--- a/src/extensions/Board/components/VirtualCardList.tsx
+++ b/src/extensions/Board/components/VirtualCardList.tsx
@@ -41,7 +41,6 @@ const VirtualCardList = ({ cards, renderCard, estimatedCardHeight = 80 }: Props)
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { useVirtualizer } = require('@tanstack/react-virtual');
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks -- conditional only on count, never changes
   const virtualizer = useVirtualizer({
     count: cards.length,
     getScrollElement: () => parentRef.current,

--- a/src/extensions/Board/realtime.ts
+++ b/src/extensions/Board/realtime.ts
@@ -49,6 +49,5 @@ export function useWorkspaceSync({ workspaceId, token }: UseWorkspaceSyncOptions
       socket.disconnect();
     };
     // Reconnect when workspace or token changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspaceId, token]);
 }

--- a/src/extensions/CalendarView/CalendarView.tsx
+++ b/src/extensions/CalendarView/CalendarView.tsx
@@ -79,7 +79,6 @@ const CalendarView = ({ cards, lists: _lists, onCardClick, addToast }: Props) =>
   }, []);
 
   // ── Drag-to-reschedule (shared between month and week grids) ──────────────
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- addToast identity is stable in callers
   const { handleCardDrop } = useCalendarDrag({ cards, ...(addToast ? { addToast } : {}) });
 
   const hasUnscheduled = cards.length > scheduledCards.length;

--- a/src/extensions/Card/components/CardReferenceChip.tsx
+++ b/src/extensions/Card/components/CardReferenceChip.tsx
@@ -54,7 +54,6 @@ const CardReferenceChip = ({ node, selected, updateAttributes }: ReactNodeViewPr
       .catch(() => {
         setLoading(false);
       });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [href]);
 
   const displayTitle = preview?.title ?? (loading ? '…' : href);

--- a/src/extensions/Comment/components/CommentEditor.tsx
+++ b/src/extensions/Comment/components/CommentEditor.tsx
@@ -866,7 +866,6 @@ const CommentEditor = ({
       if (insertMarkdownRef.current) insertMarkdownRef.current = null;
     };
   // [why] insertMarkdownRef identity is stable (ref object), so this runs once on mount/unmount.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [insertMarkdownRef]);
 
   useEffect(() => {
@@ -903,7 +902,6 @@ const CommentEditor = ({
     if (!restoredDraft) return;
     pendingHydratedContentRef.current = restoredDraft;
   // [why] Only restore when the draft first becomes available — not on every render
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [restoredDraft]);
 
   const handleSubmit = useCallback(async () => {

--- a/src/extensions/Comment/components/CommentReplyThread.tsx
+++ b/src/extensions/Comment/components/CommentReplyThread.tsx
@@ -83,7 +83,6 @@ const CommentReplyThread = ({
     if (expanded && !hasFetchedRef.current) {
       void loadReplies();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expanded, loadReplies]);
 
   // Also fetch when the reply editor is shown and there are existing replies to display
@@ -91,7 +90,6 @@ const CommentReplyThread = ({
     if (showReplyEditor && localReplyCount > 0 && !hasFetchedRef.current) {
       void loadReplies();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showReplyEditor, localReplyCount, loadReplies]);
 
   const handleSubmitReply = async (content: string) => {

--- a/src/extensions/CustomFields/api.ts
+++ b/src/extensions/CustomFields/api.ts
@@ -224,7 +224,7 @@ export function useBoardCardFieldValues(
       .then((map) => { if (!cancelled) setValuesMap(map); })
       .catch(() => { /* silently degrade — card badges just won't show */ });
     return () => { cancelled = true; };
-  }, [boardId, cardIdsKey, tick]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [boardId, cardIdsKey, tick]);
 
   return valuesMap;
 }

--- a/src/extensions/DeveloperDocs/containers/McpDocsPage/McpDocsPage.tsx
+++ b/src/extensions/DeveloperDocs/containers/McpDocsPage/McpDocsPage.tsx
@@ -92,7 +92,6 @@ const McpDocsPage = () => {
                 '<strong>stdio</strong> — a local Bun subprocess that communicates over stdin/stdout. Best for Claude Desktop and Cursor.',
                 `<strong>Remote HTTP</strong> — a persistent HTTP endpoint (<code class="${inlineCodeClass}">/api/mcp</code>) served on the same port as ChimeDeck. Best for remote agents, CI, and web-based AI assistants.`,
               ].map((step, i) => (
-                // eslint-disable-next-line react/no-array-index-key
                 <li key={i} className="flex gap-3">
                   <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-indigo-700 text-xs font-bold text-inverse">
                     {i + 1}
@@ -123,7 +122,6 @@ const McpDocsPage = () => {
                 'Go to <strong>User Settings → API Tokens</strong>.',
                 'Click <strong>Generate new token</strong> and copy the value.',
               ].map((step, i) => (
-                // eslint-disable-next-line react/no-array-index-key
                 <li key={i} className="flex gap-3">
                   <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-indigo-700 text-xs font-bold text-inverse">
                     {i + 1}
@@ -238,7 +236,6 @@ const McpDocsPage = () => {
                 `<strong>Interact</strong> — subsequent <code class="${inlineCodeClass}">POST</code> requests (tool calls / notifications) or <code class="${inlineCodeClass}">GET</code> requests (SSE stream) must include the <code class="${inlineCodeClass}">mcp-session-id</code> header.`,
                 `<strong>Terminate</strong> — <code class="${inlineCodeClass}">DELETE /api/mcp</code> with the session ID tears down the session immediately.`,
               ].map((step, i) => (
-                // eslint-disable-next-line react/no-array-index-key
                 <li key={i} className="flex gap-3">
                   <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-indigo-700 text-xs font-bold text-inverse">
                     {i + 1}

--- a/src/extensions/DeveloperDocs/containers/PluginDocsPage/PluginDocsPage.tsx
+++ b/src/extensions/DeveloperDocs/containers/PluginDocsPage/PluginDocsPage.tsx
@@ -87,7 +87,6 @@ const PluginDocsPage = () => {
                 'connector.html loads the jhInstance SDK and calls jhInstance.initialize(capabilities, config).',
                 'The SDK brokers all communication between the plugin iframe and the board UI via postMessage.',
               ].map((step, i) => (
-                // eslint-disable-next-line react/no-array-index-key
                 <li key={i} className="flex gap-3">
                   <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-indigo-700 text-xs font-bold text-inverse">
                     {i + 1}

--- a/src/extensions/OfflineDrafts/hooks/useOfflineCommentDraft.ts
+++ b/src/extensions/OfflineDrafts/hooks/useOfflineCommentDraft.ts
@@ -127,7 +127,6 @@ export function useOfflineCommentDraft({
       cancelled = true;
     };
     // [why] Only re-run when the card changes — not on every token change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cardId, userId, workspaceId, token]);
 
   // ---------- Debounced local + server persistence on content change ----------

--- a/src/extensions/OfflineDrafts/hooks/useOfflineDescriptionDraft.ts
+++ b/src/extensions/OfflineDrafts/hooks/useOfflineDescriptionDraft.ts
@@ -138,7 +138,6 @@ export function useOfflineDescriptionDraft({
       cancelled = true;
     };
     // [why] Only re-run when the card changes — not on every description change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cardId, userId, workspaceId, token]);
 
   // ---------- Debounced local + server persistence on content change ----------

--- a/src/extensions/Plugins/components/PluginAllowedDomainsPanel.tsx
+++ b/src/extensions/Plugins/components/PluginAllowedDomainsPanel.tsx
@@ -25,7 +25,6 @@ const PluginAllowedDomainsPanel = ({ boardPlugin, boardId }: Props) => {
   // null → all whitelistedDomains are permitted; array → only those in the array
   const initialSelected = useMemo<string[]>(
     () => (savedAllowedDomains === null ? [...whitelistedDomains] : savedAllowedDomains),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [boardPlugin.id],
   );
 

--- a/src/extensions/Plugins/containers/PluginRegistryPage/PluginRegistryPage.tsx
+++ b/src/extensions/Plugins/containers/PluginRegistryPage/PluginRegistryPage.tsx
@@ -82,7 +82,7 @@ const PluginRegistryPage = () => {
       if (selectedCategory) params.category = selectedCategory;
       dispatch(fetchPluginsThunk(params));
     }
-  }, [isAdmin, dispatch]); // eslint-disable-line react-hooks/exhaustive-deps — fetch once on mount
+  }, [isAdmin, dispatch]);
 
   // Re-fetch when filters change
   const dispatchFetch = useCallback(

--- a/src/extensions/Plugins/modals/EditPluginModal.tsx
+++ b/src/extensions/Plugins/modals/EditPluginModal.tsx
@@ -135,7 +135,6 @@ const EditPluginModal = ({ open, plugin, isSubmitting, serverError, onClose, onS
       isPublic,
       whitelistedDomains: finalDomains,
     });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [plugin, name, description, connectorUrl, manifestUrl, iconUrl, author, authorEmail, supportEmail, categories, categoryInput, isPublic, whitelistedDomains, domainInput, onSubmit]);
 
   if (!open || !plugin) return null;

--- a/src/extensions/Plugins/modals/RegisterPluginModal.tsx
+++ b/src/extensions/Plugins/modals/RegisterPluginModal.tsx
@@ -109,7 +109,6 @@ const RegisterPluginModal = ({ open, isSubmitting, serverError, onClose, onSubmi
       categories: finalCategories,
       isPublic,
     });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name, slug, description, connectorUrl, manifestUrl, iconUrl, author, authorEmail, supportEmail, categories, categoryInput, isPublic, onSubmit]);
 
   if (!open) return null;

--- a/src/extensions/Realtime/hooks/useWebSocket.ts
+++ b/src/extensions/Realtime/hooks/useWebSocket.ts
@@ -149,7 +149,6 @@ export function useWebSocket({
       socket.disconnect({ boardId });
     };
     // We intentionally only reconnect when boardId/token change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [boardId, token]);
 
   return { connected: connectionState === 'connected', connectionState, pollingActive };

--- a/src/extensions/TimelineView/TimelineView.tsx
+++ b/src/extensions/TimelineView/TimelineView.tsx
@@ -52,7 +52,6 @@ const TimelineView = ({ cards, lists, onCardClick, addToast: _addToast }: Timeli
   }, [dayWidth]);
 
   // Auto-scroll to today when component first mounts or zoom changes.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { scrollToToday(); }, [zoom]);
 
   const todayIso = useMemo(() => today.toISOString().slice(0, 10), [today]);


### PR DESCRIPTION
## Summary

Removes 29 inert `eslint-disable` comments across 24 files. These reference rules from `react-hooks`, `jsx-a11y`, and `react` plugins that are **not installed** in this repo, so the rules are never enforced. ESLint currently reports each as `Definition for rule '...' was not found`.

This is a prerequisite slice: it clears the "rule not found" family repo-wide (29 findings) and makes the lint config honest. It does **not** install the plugins (that would change what's enforced and increase debt) and does **not** touch any other rule family.

## Scope

- Rule family: dead `eslint-disable` comments for uninstalled plugins (`react-hooks/*`, `jsx-a11y/*`, `react/*`)
- 24 files, 29 comment removals (3 inline `eslint-disable-line`, 26 standalone `eslint-disable-next-line`)
- Comment-only change: emitted JS is byte-identical (comments stripped by transpiler)

## Verification

- Focused lint on touched scope: "rule not found" family = **0** (130 remaining findings in those files are from *other* rule families — separate debt, not this slice)
- Repo-wide lint: 2226 → **2197** problems (exactly 29 removed)
- `bun run typecheck`: exit 2, **147 errors — identical per-file counts to base** (pre-existing baseline, no new failures)
- `bun test`: **1444 tests, identical fail identities to base** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**
- UI/E2E: no UI behaviour change (comment-only); no executable UI coverage required

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.