### PR TITLE
lint: add braces to void-returning arrow handlers in AttachmentThumbnail

### DIFF
--- a/src/extensions/Attachments/components/AttachmentThumbnail.tsx
+++ b/src/extensions/Attachments/components/AttachmentThumbnail.tsx
@@ -116,7 +116,7 @@ export function AttachmentThumbnail({ attachment }: Props): React.ReactElement {
     <>
       <div className="w-24">
         <button
-          onClick={() => setLightboxOpen(true)}
+          onClick={() => { setLightboxOpen(true); }}
           className="relative h-16 w-full rounded overflow-hidden border border-border hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-blue-500"
           aria-label={translations['attachments.thumbnail.image.preview.ariaLabel'].replace('{name}', attachment.name)}
         >
@@ -130,7 +130,7 @@ export function AttachmentThumbnail({ attachment }: Props): React.ReactElement {
         {fullSrc && (
           <button
             type="button"
-            onClick={() => setLightboxOpen(true)}
+            onClick={() => { setLightboxOpen(true); }}
             className="mt-1 block w-full truncate text-left text-[10px] text-link hover:underline"
             title={displayName}
           >
@@ -139,7 +139,7 @@ export function AttachmentThumbnail({ attachment }: Props): React.ReactElement {
         )}
       </div>
       {lightboxOpen && fullSrc && (
-        <ImageLightbox src={fullSrc} name={attachment.name} onClose={() => setLightboxOpen(false)} />
+        <ImageLightbox src={fullSrc} name={attachment.name} onClose={() => { setLightboxOpen(false); }} />
       )}
     </>
   );
@@ -291,7 +291,7 @@ export function VideoThumbnail({ attachment }: Props): React.ReactElement {
   return (
     <>
       <button
-        onClick={() => setLightboxOpen(true)}
+        onClick={() => { setLightboxOpen(true); }}
         className="relative w-24 h-16 rounded overflow-hidden border border-border bg-bg-surface hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-blue-500 flex items-center justify-center group"
         aria-label={translations['attachments.thumbnail.video.play.ariaLabel'].replace('{name}', attachment.name)}
       >
@@ -300,7 +300,7 @@ export function VideoThumbnail({ attachment }: Props): React.ReactElement {
         <PlayIcon className="absolute h-5 w-5 text-white/80 group-hover:text-white" aria-hidden="true" />
       </button>
       {lightboxOpen && (
-        <VideoLightbox src={src} name={attachment.name} onClose={() => setLightboxOpen(false)} />
+        <VideoLightbox src={src} name={attachment.name} onClose={() => { setLightboxOpen(false); }} />
       )}
     </>
   );


### PR DESCRIPTION
## Summary

Fixes 5 `@typescript-eslint/no-confusing-void-expression` findings in `src/extensions/Attachments/components/AttachmentThumbnail.tsx`. The `onClick`/`onClose` arrow-function shorthands returned a void expression (`setLightboxOpen(...)`); wrapping them in braces makes the arrow return `void` explicitly.

Behaviour-preserving: both forms return `undefined`. Verified the emitted JS differs only in the intended brace wrapping (no other change).

## Scope

- Single cohesive component: `AttachmentThumbnail.tsx`
- 5 findings, all `no-confusing-void-expression`
- 5 insertions / 5 deletions

## Verification

- Focused lint on `AttachmentThumbnail.tsx`: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **147 errors — identical per-file counts to base** (pre-existing baseline, no new failures)
- `bun test`: **1444 tests, identical fail identities to base** (pre-existing 180 fail / 30 errors baseline, no new failures)
- Focused test `tests/integration/attachments/thumbnails.test.ts`: **7 pass / 0 fail**
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**
- Emitted JS comparison: only the intended brace wrapping differs; both forms return `undefined`

## UI/E2E coverage

No executable UI/E2E coverage exists for `AttachmentThumbnail` (no test references the component; Playwright is scoped to `tests/e2e`). This is a behaviour-preserving brace change; UI coverage is recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.