### PR TITLE
lint: replace non-null assertion in useTheme cycle with fallback

### DIFF
--- a/src/common/hooks/useTheme.ts
+++ b/src/common/hooks/useTheme.ts
@@ -63,7 +63,10 @@ export function useTheme(): { theme: Theme; setTheme: (t: Theme) => void; cycle:
   const cycle = () => {
     setTheme((current) => {
       const idx = THEME_CYCLE.indexOf(current);
-      return THEME_CYCLE[(idx + 1) % THEME_CYCLE.length]!;
+      // idx is always a valid index (current is always a member of THEME_CYCLE),
+      // so the modulo result is always in range; the fallback is unreachable but
+      // satisfies noUncheckedIndexedAccess without a non-null assertion.
+      return THEME_CYCLE[(idx + 1) % THEME_CYCLE.length] ?? 'dark';
     });
   };
 


### PR DESCRIPTION
## Summary

Fixes 1 `@typescript-eslint/no-non-null-assertion` finding in `src/common/hooks/useTheme.ts`. The `cycle` function used `THEME_CYCLE[(idx + 1) % THEME_CYCLE.length]!`; replaced the non-null assertion with an unreachable `?? 'dark'` fallback.

Behaviour-preserving: `idx` always comes from `indexOf(current)` where `current` is always a member of `THEME_CYCLE`, so `(idx + 1) % length` is always a valid index. The fallback never triggers; it only satisfies `noUncheckedIndexedAccess` without the assertion.

## Scope

- Single cohesive file: `src/common/hooks/useTheme.ts`
- 1 finding, `no-non-null-assertion`
- 4 insertions / 1 deletion

## Verification

- Focused lint on `useTheme.ts`: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **147 errors — identical per-file counts to base** (pre-existing baseline, no new failures)
- `bun test`: **1444 tests, identical fail identities to base** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

No executable UI/E2E coverage exists for `useTheme` (no test references it). This is a behaviour-preserving type-safety change; UI coverage is recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.