### PR TITLE
lint: add braces to void-returning arrow handler in PasswordInput

### DIFF
--- a/src/extensions/Auth/components/PasswordInput.tsx
+++ b/src/extensions/Auth/components/PasswordInput.tsx
@@ -30,7 +30,7 @@ const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
           <button
             type="button"
             aria-label={visible ? 'Hide password' : 'Show password'}
-            onClick={() => setVisible((v) => !v)}
+            onClick={() => { setVisible((v) => !v); }}
             className="absolute right-3 top-1/2 -translate-y-1/2 text-subtle hover:text-base focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
           >
             {visible ? <EyeSlashIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}


### PR DESCRIPTION
## Summary

Fixes 1 `@typescript-eslint/no-confusing-void-expression` finding in `src/extensions/Auth/components/PasswordInput.tsx`. The `onClick` arrow shorthand returned a void expression (`setVisible(...)`); wrapping it in braces makes the arrow return `void` explicitly.

Behaviour-preserving: both forms return `undefined` (a useState setter returns void).

## Scope

- Single cohesive component: `PasswordInput.tsx`
- 1 finding, `no-confusing-void-expression`
- 1 insertion / 1 deletion

## Verification

- Focused lint on `PasswordInput.tsx`: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **147 errors — identical per-file counts to base** (pre-existing baseline, no new failures)
- `bun test`: **1444 tests, identical fail identities to base** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

No executable UI/E2E coverage exists for `PasswordInput` (no test references it; only consumers LoginForm/SignupForm import it). This is a behaviour-preserving brace change; UI coverage is recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.