### PR TITLE
lint: add unreachable fallback for UNITS index in formatBytes

### DIFF
--- a/src/extensions/Attachments/utils/formatBytes.ts
+++ b/src/extensions/Attachments/utils/formatBytes.ts
@@ -16,5 +16,8 @@ export function formatBytes(bytes: number): string {
 
   // Show up to 1 decimal place, trimming trailing zeros
   const formatted = unitIndex === 0 ? String(value) : value.toFixed(1).replace(/\.0$/, '');
-  return `${formatted} ${UNITS[unitIndex]}`;
+  // unitIndex is always < UNITS.length (the while loop only increments while
+  // unitIndex < UNITS.length - 1), so the index is always valid; the fallback
+  // is unreachable but satisfies noUncheckedIndexedAccess.
+  return `${formatted} ${UNITS[unitIndex] ?? 'B'}`;
 }


### PR DESCRIPTION
## Summary

Fixes 1 `@typescript-eslint/restrict-template-expressions` finding in `src/extensions/Attachments/utils/formatBytes.ts`. `UNITS[unitIndex]` is `string | undefined` under `noUncheckedIndexedAccess`; added an unreachable `?? 'B'` fallback.

Behaviour-preserving: `unitIndex` is always `< UNITS.length` (the while loop only increments while `unitIndex < UNITS.length - 1`), so the index is always valid. The fallback never triggers; it only satisfies the type checker.

## Scope

- Single cohesive file: `src/extensions/Attachments/utils/formatBytes.ts`
- 1 finding, `restrict-template-expressions`
- 4 insertions / 1 deletion

## Verification

- Focused lint on `formatBytes.ts`: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **147 errors — identical per-file counts to base** (pre-existing baseline, no new failures)
- `bun test`: **1444 tests, identical fail identities to base** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

`formatBytes` is a pure utility function (no UI). No executable UI/E2E coverage applies.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.