### PR TITLE
lint: coerce progress number to string in UploadProgressBar width

### DIFF
--- a/src/extensions/Attachments/components/UploadProgressBar.tsx
+++ b/src/extensions/Attachments/components/UploadProgressBar.tsx
@@ -29,7 +29,7 @@ export function UploadProgressBar({ progress, label = translations['attachments.
       ) : (
         <div
           className="h-full bg-blue-500 rounded transition-all duration-200"
-          style={{ width: `${Math.min(100, Math.max(0, progress))}%` }}
+          style={{ width: `${String(Math.min(100, Math.max(0, progress)))}%` }}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary

Fixes 1 `@typescript-eslint/restrict-template-expressions` finding in `src/extensions/Attachments/components/UploadProgressBar.tsx`. The template literal `${Math.min(100, Math.max(0, progress))}%` used a number; coerced with `String(...)`.

Behaviour-preserving: `String(number)` produces the same output as the implicit template-literal coercion.

## Scope

- Single cohesive component: `UploadProgressBar.tsx`
- 1 finding, `restrict-template-expressions`
- 1 insertion / 1 deletion

## Verification

- Focused lint on `UploadProgressBar.tsx`: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **147 errors — identical per-file counts to base** (pre-existing baseline, no new failures)
- `bun test`: **1444 tests, identical fail identities to base** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

`tests/e2e/attachments/attachmentPanel.spec.ts` has an "Upload progress bar" test that references `[data-testid="upload-progress-bar"]`, but it requires a seeded board/card and a running server (Playwright baseURL localhost:3000) — **not runnable in this environment**. This is a behaviour-preserving string-coercion change; executable UI coverage is recorded as **not run here**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.