### PR TITLE
lint: coerce activeCount number to string in AutomationHeaderButton aria-label

### DIFF
--- a/src/extensions/Automation/components/AutomationHeaderButton.tsx
+++ b/src/extensions/Automation/components/AutomationHeaderButton.tsx
@@ -25,7 +25,7 @@ const AutomationHeaderButton = ({ activeCount, onClick, hasBackground = false }:
     {activeCount > 0 && (
       <span
         className="absolute -top-0.5 -right-0.5 flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-blue-500 px-1 text-[10px] font-bold leading-none text-inverse"
-        aria-label={`${activeCount} active automation${activeCount !== 1 ? 's' : ''}`}
+        aria-label={`${String(activeCount)} active automation${activeCount !== 1 ? 's' : ''}`}
       >
         {activeCount > 99 ? '99+' : activeCount}
       </span>


### PR DESCRIPTION
## Summary

Fixes 1 `@typescript-eslint/restrict-template-expressions` finding in `src/extensions/Automation/components/AutomationHeaderButton.tsx`. The aria-label template literal used a number (`activeCount`); coerced with `String(...)`.

Behaviour-preserving: `String(number)` produces the same output as the implicit template-literal coercion.

## Scope

- Single cohesive component: `AutomationHeaderButton.tsx`
- 1 finding, `restrict-template-expressions`
- 1 insertion / 1 deletion

## Verification

- Focused lint on `AutomationHeaderButton.tsx`: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **147 errors — identical per-file counts to base** (pre-existing baseline, no new failures)
- `bun test`: **1444 tests, identical fail identities to base** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

No executable UI/E2E coverage exists for `AutomationHeaderButton` (no test references it; only consumers BoardHeader/BoardButtonsBar import it). This is a behaviour-preserving string-coercion change; UI coverage is recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.