### PR TITLE
lint: add braces to void-returning arrow handler in BoardCard

### DIFF
--- a/src/extensions/Board/components/BoardCard.tsx
+++ b/src/extensions/Board/components/BoardCard.tsx
@@ -92,7 +92,7 @@ const BoardCard = ({ board, onClick, onArchive, onDelete, onDuplicate, onStar, o
           </div>
         </div>
 
-        <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
+        <div className="flex gap-2" onClick={(e) => { e.stopPropagation(); }}>
           <button
             className="text-xs text-blue-600 hover:underline"
             onClick={onDuplicate}


### PR DESCRIPTION
## Summary

Fixes 1 `@typescript-eslint/no-confusing-void-expression` finding in `src/extensions/Board/components/BoardCard.tsx`. The `onClick` arrow shorthand returned a void expression (`e.stopPropagation()`); wrapping it in braces makes the arrow return `void` explicitly.

Behaviour-preserving: both forms return `undefined`.

## Scope

- Single cohesive component: `BoardCard.tsx`
- 1 finding, `no-confusing-void-expression`
- 1 insertion / 1 deletion

## Verification

- Focused lint on `BoardCard.tsx`: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **147 errors — identical per-file counts to base** (pre-existing baseline, no new failures)
- `bun test`: **1444 tests, identical fail identities to base** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

No executable UI/E2E coverage exists for `BoardCard` (no test references it; only consumers BoardListPage/WorkspaceDashboard import it). This is a behaviour-preserving brace change; UI coverage is recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.