### PR TITLE
lint: add braces to void-returning arrow handler in VisibilitySelector

### DIFF
--- a/src/extensions/Board/components/BoardSettings/VisibilitySelector.tsx
+++ b/src/extensions/Board/components/BoardSettings/VisibilitySelector.tsx
@@ -47,7 +47,7 @@ const VisibilitySelector = ({ value, onChange, disabled = false }: Props) => {
             name="board-visibility"
             value={opt.value}
             checked={value === opt.value}
-            onChange={() => !disabled && onChange(opt.value)}
+            onChange={() => { if (!disabled) onChange(opt.value); }}
             disabled={disabled}
             className="mt-0.5 accent-blue-500"
           />


### PR DESCRIPTION
## Summary

Fixes 1 `@typescript-eslint/no-confusing-void-expression` finding in `src/extensions/Board/components/BoardSettings/VisibilitySelector.tsx`. The `onChange` arrow shorthand returned a void expression (`!disabled && onChange(opt.value)`); wrapping it in braces makes the arrow return `void` explicitly.

Behaviour-preserving: both forms return `undefined`; the `!disabled` guard and `onChange(opt.value)` call are unchanged.

## Scope

- Single cohesive component: `VisibilitySelector.tsx`
- 1 finding, `no-confusing-void-expression`
- 1 insertion / 1 deletion

## Verification

- Focused lint on `VisibilitySelector.tsx`: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **147 errors — identical per-file counts to base** (pre-existing baseline, no new failures)
- `bun test`: **1444 tests, identical fail identities to base** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

No executable UI/E2E coverage exists for `VisibilitySelector` (no test references it; only consumers BoardSettings import it). This is a behaviour-preserving brace change; UI coverage is recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.