### PR TITLE
lint: add braces to void-returning arrow handlers (batch 1)

### DIFF
--- a/src/extensions/Attachment/components/AttachmentItem.tsx
+++ b/src/extensions/Attachment/components/AttachmentItem.tsx
@@ -39,7 +39,7 @@ export function AttachmentItem({ attachment, onDelete, onDownload }: Props): Rea
         </Button>
       )}
       <IconButton
-        onClick={() => onDelete(attachment.id)}
+        onClick={() => { onDelete(attachment.id); }}
         aria-label={translations['attachment.item.action.delete.ariaLabel']}
         icon={<XMarkIcon className="h-4 w-4" aria-hidden="true" />}
         variant="ghost"

--- a/src/extensions/Automation/components/shared/IconPicker.tsx
+++ b/src/extensions/Automation/components/shared/IconPicker.tsx
@@ -94,7 +94,7 @@ const IconPicker: FC<Props> = ({ value, onChange }) => {
             type="button"
             title={name.replace('Icon', '')}
             aria-pressed={selected}
-            onClick={() => onChange(name)}
+            onClick={() => { onChange(name); }}
             className={[
               'flex items-center justify-center rounded-md p-1.5 transition-colors',
               selected

--- a/src/extensions/Automation/reducers.ts
+++ b/src/extensions/Automation/reducers.ts
@@ -14,7 +14,7 @@ export function useOptimisticAutomations(
   const [automations, setAutomations] = useState<Automation[]>(initial);
 
   // Keep the list in sync with fresh data from the server (e.g., after reload).
-  const setAll = useCallback((list: Automation[]) => setAutomations(list), []);
+  const setAll = useCallback((list: Automation[]) => { setAutomations(list); }, []);
 
   const toggleEnabled = useCallback(
     async ({

--- a/src/extensions/Board/components/CreateBoardModal.tsx
+++ b/src/extensions/Board/components/CreateBoardModal.tsx
@@ -27,7 +27,7 @@ const CreateBoardModal = ({ onClose, onCreate }: Props) => {
             type="text"
             placeholder="Board title"
             value={title}
-            onChange={(e) => setTitle(e.target.value)}
+            onChange={(e) => { setTitle(e.target.value); }}
             className="rounded border border-border bg-bg-overlay px-3 py-2 text-sm text-base placeholder:text-subtle focus:outline-none focus:ring-2 focus:ring-primary"
           />
           <div className="flex justify-end gap-2">

--- a/src/extensions/BoardViewSwitcher/BoardViewTab.tsx
+++ b/src/extensions/BoardViewSwitcher/BoardViewTab.tsx
@@ -43,7 +43,7 @@ const BoardViewTab = ({ viewType, isActive, onClick, hasBackground = false, segm
       role="tab"
       aria-selected={isActive}
       aria-label={LABELS[viewType]}
-      onClick={() => onClick(viewType)}
+      onClick={() => { onClick(viewType); }}
       data-testid={`board-view-tab-${viewType}`}
       className={`flex items-center gap-1.5 px-3 py-2.5 text-sm font-medium transition-colors ${stateClass}`}
     >

--- a/src/extensions/Card/components/CardTile.tsx
+++ b/src/extensions/Card/components/CardTile.tsx
@@ -34,7 +34,7 @@ const CardTile = ({
     <div
       className={`group rounded bg-bg-surface px-3 py-2 shadow-sm cursor-pointer hover:bg-blue-50 transition-colors${card.archived ? ' opacity-60' : ''}`}
       style={style}
-      onClick={() => onClick(card.id)}
+      onClick={() => { onClick(card.id); }}
       role="button"
       tabIndex={0}
       aria-label={`Card: ${card.title}`}

--- a/src/extensions/DeveloperDocs/containers/CliDocsPage/CliDocsPage.tsx
+++ b/src/extensions/DeveloperDocs/containers/CliDocsPage/CliDocsPage.tsx
@@ -39,7 +39,7 @@ const CliDocsPage = () => {
       <main className="flex-1 overflow-y-auto">
         <div className="border-b border-border bg-bg-base px-8 py-5">
           <button
-            onClick={() => navigate(-1)}
+            onClick={() => { navigate(-1); }}
             className="mb-2 flex items-center gap-1 text-sm text-muted hover:text-subtle"
           >
             ← Back

--- a/src/extensions/DeveloperDocs/containers/McpDocsPage/McpDocsPage.tsx
+++ b/src/extensions/DeveloperDocs/containers/McpDocsPage/McpDocsPage.tsx
@@ -58,7 +58,7 @@ const McpDocsPage = () => {
         {/* Header */}
         <div className="border-b border-border bg-bg-base px-8 py-5">
           <button
-            onClick={() => navigate(-1)}
+            onClick={() => { navigate(-1); }}
             className="mb-2 flex items-center gap-1 text-sm text-muted hover:text-subtle"
           >
             ← Back

--- a/src/extensions/DeveloperDocs/containers/PluginDocsPage/PluginDocsPage.tsx
+++ b/src/extensions/DeveloperDocs/containers/PluginDocsPage/PluginDocsPage.tsx
@@ -48,7 +48,7 @@ const PluginDocsPage = () => {
         {/* Header */}
         <div className="border-b border-border bg-bg-base px-8 py-5">
           <button
-            onClick={() => navigate(-1)}
+            onClick={() => { navigate(-1); }}
             className="mb-2 flex items-center gap-1 text-sm text-muted hover:text-subtle"
           >
             ← Back

--- a/src/extensions/Plugins/components/DiscoverPluginSearch.tsx
+++ b/src/extensions/Plugins/components/DiscoverPluginSearch.tsx
@@ -59,7 +59,7 @@ const DiscoverPluginSearch = ({
       {categories.length > 0 && (
         <select
           value={selectedCategory ?? ''}
-          onChange={(e) => onCategoryChange(e.target.value || null)}
+          onChange={(e) => { onCategoryChange(e.target.value || null); }}
           className="bg-bg-overlay border border-border text-base text-sm rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary sm:w-44"
         >
           <option value="">{translations['plugins.searchBar.allCategories']}</option>

--- a/src/extensions/Plugins/components/PluginAllowedDomainsPanel.tsx
+++ b/src/extensions/Plugins/components/PluginAllowedDomainsPanel.tsx
@@ -82,7 +82,7 @@ const PluginAllowedDomainsPanel = ({ boardPlugin, boardId }: Props) => {
               type="checkbox"
               id={`allowed-domain-${domain}`}
               checked={selected.includes(domain)}
-              onChange={() => toggleDomain(domain)}
+              onChange={() => { toggleDomain(domain); }}
               className="w-3.5 h-3.5 accent-blue-500 cursor-pointer"
             />
             <label

--- a/src/extensions/Search/components/SearchResultItem.tsx
+++ b/src/extensions/Search/components/SearchResultItem.tsx
@@ -26,7 +26,7 @@ const SearchResultItem: React.FC<SearchResultItemProps> = ({
     <button
       ref={buttonRef}
       className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm hover:bg-bg-surface focus:bg-bg-surface focus:outline-none"
-      onClick={() => onSelect(result)}
+      onClick={() => { onSelect(result); }}
       onKeyDown={onKeyDown}
     >
       {isBoard && result.background ? (

--- a/src/extensions/TableView/TableHeader.tsx
+++ b/src/extensions/TableView/TableHeader.tsx
@@ -25,7 +25,7 @@ const TableHeader = ({ columns, sortState, onSort }: Props) => {
             scope="col"
             className={`px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-[0.05em] text-subtle select-none whitespace-nowrap${col.sortable ? ' cursor-pointer hover:text-base' : ''}`}
             style={col.width ? { width: col.width } : undefined}
-            onClick={col.sortable ? () => onSort(col.key) : undefined}
+            onClick={col.sortable ? () => { onSort(col.key); } : undefined}
             aria-sort={
               sortState.column === col.key
                 ? sortState.direction === 'asc'

--- a/src/extensions/TimelineView/TimelineZoomControl.tsx
+++ b/src/extensions/TimelineView/TimelineZoomControl.tsx
@@ -24,7 +24,7 @@ const TimelineZoomControl = ({ zoom, onZoomChange }: TimelineZoomControlProps) =
         <Button
           key={level}
           variant="ghost"
-          onClick={() => onZoomChange(level)}
+          onClick={() => { onZoomChange(level); }}
           aria-pressed={zoom === level}
           data-testid={`timeline-zoom-${level}`}
           className={`px-3 py-1 text-xs rounded-none ${


### PR DESCRIPTION
## Summary

Fixes 14 `@typescript-eslint/no-confusing-void-expression` findings across 14 files. Each `onClick`/`onChange`/`onSort`/`onZoomChange`/`onSelect`/`onDelete`/`onCategoryChange`/`toggleDomain`/`navigate`/`setAutomations` arrow shorthand returned a void expression; wrapping each in braces makes the arrow return `void` explicitly.

Behaviour-preserving: both forms return `undefined` in every case.

## Scope

- Rule family: `no-confusing-void-expression` (brace-wrapping)
- 14 files, 14 insertions / 14 deletions
- Files: AttachmentItem, IconPicker, Automation/reducers, CreateBoardModal, BoardViewTab, CardTile, CliDocsPage, McpDocsPage, PluginDocsPage, DiscoverPluginSearch, PluginAllowedDomainsPanel, SearchResultItem, TableHeader, TimelineZoomControl

## Verification

- Focused lint on all 14 touched files: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **147 errors — identical per-file counts to base** (pre-existing baseline, no new failures)
- `bun test`: **1444 tests, identical fail identities to base** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

All 14 are UI components/hooks with no dedicated executable UI/E2E coverage (no test references them). These are behaviour-preserving brace changes; UI coverage is recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.