### PR TITLE
lint: add braces to void-returning arrow handlers (batch 2)

### DIFF
--- a/src/common/components/MentionInput/MentionSuggestions.tsx
+++ b/src/common/components/MentionInput/MentionSuggestions.tsx
@@ -37,8 +37,8 @@ const MentionSuggestions = ({
             name={s.name}
             avatarUrl={s.avatar_url}
             highlighted={i === highlightedIndex}
-            onSelect={() => onSelect(s)}
-            onMouseEnter={() => onHighlight(i)}
+            onSelect={() => { onSelect(s); }}
+            onMouseEnter={() => { onHighlight(i); }}
           />
         </li>
       ))}

--- a/src/extensions/Attachments/components/CardAttachmentPreview.tsx
+++ b/src/extensions/Attachments/components/CardAttachmentPreview.tsx
@@ -119,7 +119,7 @@ export function CardAttachmentPreview({ attachmentId, card, cardUrl, canWrite, o
                       </button>
                       <button
                         type="button"
-                        onClick={() => setConfirmDelete(false)}
+                        onClick={() => { setConfirmDelete(false); }}
                         className="text-[11px] text-muted hover:text-subtle"
                       >
                         {translations['attachments.item.delete.no']}
@@ -129,7 +129,7 @@ export function CardAttachmentPreview({ attachmentId, card, cardUrl, canWrite, o
                 ) : (
                   <button
                     type="button"
-                    onClick={() => setConfirmDelete(true)}
+                    onClick={() => { setConfirmDelete(true); }}
                     className="w-full text-left px-3 py-1.5 text-xs text-danger hover:bg-bg-overlay hover:text-danger"
                   >
                     Remove

--- a/src/extensions/Automation/components/SchedulePanel/ScheduleList.tsx
+++ b/src/extensions/Automation/components/SchedulePanel/ScheduleList.tsx
@@ -49,7 +49,7 @@ const ScheduleList: FC<Props> = ({
                 key={a.id}
                 boardId={boardId}
                 automation={a}
-                onEdit={() => onEdit(a)}
+                onEdit={() => { onEdit(a); }}
                 onDeleted={onChanged}
                 onToggled={onChanged}
               />
@@ -82,7 +82,7 @@ const ScheduleList: FC<Props> = ({
                 key={a.id}
                 boardId={boardId}
                 automation={a}
-                onEdit={() => onEdit(a)}
+                onEdit={() => { onEdit(a); }}
                 onDeleted={onChanged}
                 onToggled={onChanged}
               />

--- a/src/extensions/Card/components/CardChecklist.tsx
+++ b/src/extensions/Card/components/CardChecklist.tsx
@@ -526,8 +526,8 @@ const CardChecklist = ({
                 boardMembers={boardMembers}
                 onRenameChecklist={onRenameChecklist}
                 onDeleteChecklist={onDeleteChecklist}
-                onMoveUp={() => handleMoveUp(index)}
-                onMoveDown={() => handleMoveDown(index)}
+                onMoveUp={() => { handleMoveUp(index); }}
+                onMoveDown={() => { handleMoveDown(index); }}
                 onItemAdd={onItemAdd}
                 onItemToggle={onItemToggle}
                 onItemRename={onItemRename}

--- a/src/extensions/Card/components/CardDueDate.tsx
+++ b/src/extensions/Card/components/CardDueDate.tsx
@@ -45,7 +45,7 @@ const CardDueDate = ({ dueDate, dueComplete, onChange, onDoneChange, disabled, l
           <button
             type="button"
             className={`flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border-2 transition-colors ${checkboxBg} ${disabled ? 'opacity-50 pointer-events-none' : ''}`}
-            onClick={() => onDoneChange(!dueComplete)}
+            onClick={() => { onDoneChange(!dueComplete); }}
             aria-label={dueComplete ? 'Mark as not done' : 'Mark as done'}
             disabled={disabled}
           >
@@ -70,7 +70,7 @@ const CardDueDate = ({ dueDate, dueComplete, onChange, onDoneChange, disabled, l
         <button
           type="button"
           className="text-xs text-muted hover:text-base transition-colors"
-          onClick={() => onChange(null)}
+          onClick={() => { onChange(null); }}
         >
           Clear
         </button>

--- a/src/extensions/Card/components/CardMembers.tsx
+++ b/src/extensions/Card/components/CardMembers.tsx
@@ -63,7 +63,7 @@ const CardMembers = ({ members, boardMembers, cardId, currentUserId, onAssign, o
           <button
             type="button"
             className="text-xs text-muted hover:text-base flex items-center gap-1 transition-colors"
-            onClick={() => setPickerOpen((v) => !v)}
+            onClick={() => { setPickerOpen((v) => !v); }}
             aria-haspopup="true"
             aria-expanded={pickerOpen}
           >
@@ -74,7 +74,7 @@ const CardMembers = ({ members, boardMembers, cardId, currentUserId, onAssign, o
             <>
               <div
                 className="fixed inset-0 z-10"
-                onClick={() => setPickerOpen(false)}
+                onClick={() => { setPickerOpen(false); }}
                 aria-hidden="true"
               />
               <div className="absolute left-0 top-6 z-20 w-56 rounded-xl bg-bg-surface border border-border shadow-2xl p-2 space-y-1">

--- a/src/extensions/Card/components/CardTitle.tsx
+++ b/src/extensions/Card/components/CardTitle.tsx
@@ -33,7 +33,7 @@ const CardTitle = ({ title, onSave, disabled }: Props) => {
         ref={inputRef}
         className="text-xl font-bold text-base bg-bg-overlay focus:outline-none focus:ring-2 focus:ring-primary rounded px-2 py-1 w-full"
         value={draft}
-        onChange={(e) => setDraft(e.target.value)}
+        onChange={(e) => { setDraft(e.target.value); }}
         onBlur={commit}
         onKeyDown={(e) => {
           if (e.key === 'Enter') { e.preventDefault(); commit(); }
@@ -51,7 +51,7 @@ const CardTitle = ({ title, onSave, disabled }: Props) => {
       className={`text-xl font-bold text-base rounded px-2 py-1 w-full cursor-text hover:bg-bg-overlay/50 transition-colors${
         disabled ? ' cursor-default pointer-events-none' : ''
       }`}
-      onClick={() => !disabled && setEditing(true)}
+      onClick={() => { if (!disabled) setEditing(true); }}
       onKeyDown={(e) => { if (e.key === 'Enter') setEditing(true); }}
       role={disabled ? undefined : 'button'}
       tabIndex={disabled ? undefined : 0}

--- a/src/extensions/Card/components/ResizablePanels.tsx
+++ b/src/extensions/Card/components/ResizablePanels.tsx
@@ -45,9 +45,9 @@ export default function ResizablePanels({ left, right, className = '' }: Resizab
 
   // Update mobile breakpoint on resize
   useEffect(() => {
-    const onResize = () => setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    const onResize = () => { setIsMobile(window.innerWidth < MOBILE_BREAKPOINT); };
     window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
+    return () => { window.removeEventListener('resize', onResize); };
   }, []);
 
   const clampRatio = useCallback((rawRatio: number, containerWidth: number): number => {

--- a/src/extensions/Comment/components/CardAssetPicker.tsx
+++ b/src/extensions/Comment/components/CardAssetPicker.tsx
@@ -31,7 +31,7 @@ export function CardAssetPicker({ attachments, onUploadNew, onInsert, onClose }:
       }
     };
     document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    return () => { document.removeEventListener('mousedown', handler); };
   }, [onClose]);
 
   // Close on Escape
@@ -40,7 +40,7 @@ export function CardAssetPicker({ attachments, onUploadNew, onInsert, onClose }:
       if (e.key === 'Escape') onClose();
     };
     document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
+    return () => { document.removeEventListener('keydown', handler); };
   }, [onClose]);
 
   return (

--- a/src/extensions/CustomFields/CustomFieldsSection.tsx
+++ b/src/extensions/CustomFields/CustomFieldsSection.tsx
@@ -37,7 +37,7 @@ const CustomFieldsSection = ({ boardId, cardId, disabled = false }: Props) => {
     });
 
     observer.observe(gridRef.current);
-    return () => observer.disconnect();
+    return () => { observer.disconnect(); };
   }, [fieldsLoading, valuesLoading, fields.length]);
 
   const handleValueChange = useCallback(
@@ -89,7 +89,7 @@ const CustomFieldsSection = ({ boardId, cardId, disabled = false }: Props) => {
                 field={field}
                 value={value}
                 disabled={disabled}
-                onValueChange={(updated) => handleValueChange(field.id, updated)}
+                onValueChange={(updated) => { handleValueChange(field.id, updated); }}
               />
             </div>
           );

--- a/src/extensions/HealthCheck/hooks/useHealthCheckAutoRefresh.ts
+++ b/src/extensions/HealthCheck/hooks/useHealthCheckAutoRefresh.ts
@@ -45,7 +45,7 @@ export function useHealthCheckAutoRefresh({ onRefresh, enabled = true }: Options
       isVisibleRef.current = !document.hidden;
     }
     document.addEventListener('visibilitychange', handleVisibilityChange);
-    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+    return () => { document.removeEventListener('visibilitychange', handleVisibilityChange); };
   }, []);
 
   // Ref-based countdown so we can reset from triggerRefresh without
@@ -72,7 +72,7 @@ export function useHealthCheckAutoRefresh({ onRefresh, enabled = true }: Options
       }
     }, TICK_MS);
 
-    return () => clearInterval(id);
+    return () => { clearInterval(id); };
   }, [enabled, doRefresh]);
 
   const triggerRefresh = useCallback(() => {

--- a/src/extensions/List/components/AddListButton.tsx
+++ b/src/extensions/List/components/AddListButton.tsx
@@ -22,7 +22,7 @@ const AddListButton = ({ onAdd }: Props) => {
     return (
       <button
         className="flex h-10 w-64 shrink-0 items-center gap-2 rounded-lg bg-bg-surface/70 px-3 text-sm font-medium text-muted shadow hover:bg-bg-surface hover:text-base"
-        onClick={() => setOpen(true)}
+        onClick={() => { setOpen(true); }}
         aria-label="Add a list"
       >
         + Add a list
@@ -40,7 +40,7 @@ const AddListButton = ({ onAdd }: Props) => {
         type="text"
         placeholder="Enter list title…"
         value={title}
-        onChange={(e) => setTitle(e.target.value)}
+        onChange={(e) => { setTitle(e.target.value); }}
         className="rounded border border-border-strong px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
       />
       <div className="flex items-center gap-2">

--- a/src/extensions/Search/components/SearchModal.tsx
+++ b/src/extensions/Search/components/SearchModal.tsx
@@ -37,7 +37,7 @@ const SearchModal: React.FC<SearchModalProps> = ({
     if (isOpen) {
       document.addEventListener('keydown', handleKeyDown);
     }
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    return () => { document.removeEventListener('keydown', handleKeyDown); };
   }, [isOpen, handleKeyDown]);
 
   if (!isOpen) return null;
@@ -64,7 +64,7 @@ const SearchModal: React.FC<SearchModalProps> = ({
       {/* Panel — stop click from bubbling to backdrop */}
       <div
         className="w-full max-w-xl rounded-xl bg-bg-base shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
+        onClick={(e) => { e.stopPropagation(); }}
       >
         <div className="border-b border-border p-4">
           <SearchInput value={query} onChange={setQuery} autoFocus />


### PR DESCRIPTION
## Summary

Fixes 26 `@typescript-eslint/no-confusing-void-expression` findings across 13 files. Each `onClick`/`onChange`/`onSelect`/`onMouseEnter`/`onEdit`/`onMoveUp`/`onMoveDown`/`onDoneChange`/`onValueChange`/`setOpen`/`setPickerOpen`/`setConfirmDelete`/`setDraft`/`setEditing`/`setIsMobile`/`setTitle`/`stopPropagation`/`removeEventListener`/`clearInterval`/`observer.disconnect` arrow shorthand returned a void expression; wrapping each in braces makes the arrow return `void` explicitly.

Behaviour-preserving: both forms return `undefined` in every case.

## Scope

- Rule family: `no-confusing-void-expression` (brace-wrapping)
- 13 files, 26 insertions / 26 deletions
- Files: MentionSuggestions, CardAttachmentPreview, ScheduleList, CardChecklist, CardDueDate, CardMembers, CardTitle, ResizablePanels, CardAssetPicker, CustomFieldsSection, useHealthCheckAutoRefresh, AddListButton, SearchModal

## Verification

- Focused lint on all 13 touched files: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **147 errors — identical per-file counts to base** (pre-existing baseline, no new failures)
- `bun test`: **1444 tests, identical fail identities to base** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

All 13 are UI components/hooks with no dedicated executable UI/E2E coverage (no test references them). These are behaviour-preserving brace changes; UI coverage is recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.