### PR TITLE
lint: add braces to void-returning arrow handlers (batch 3)

### DIFF
--- a/src/common/components/Toast.tsx
+++ b/src/common/components/Toast.tsx
@@ -20,8 +20,8 @@ interface Props {
 const Toast = ({ toast, onDismiss }: Props) => {
   useEffect(() => {
     const ms = toast.durationMs ?? (toast.variant === 'error' ? 6000 : 4000);
-    const timer = setTimeout(() => onDismiss(toast.id), ms);
-    return () => clearTimeout(timer);
+    const timer = setTimeout(() => { onDismiss(toast.id); }, ms);
+    return () => { clearTimeout(timer); };
   }, [toast, onDismiss]);
 
   const borderClass =
@@ -54,7 +54,7 @@ const Toast = ({ toast, onDismiss }: Props) => {
       <p className="flex-1 text-sm text-base">{toast.message}</p>
       <button
         className="ml-auto shrink-0 text-subtle hover:text-muted transition-colors"
-        onClick={() => onDismiss(toast.id)}
+        onClick={() => { onDismiss(toast.id); }}
         aria-label={translations['Common.dismissNotification']}
       >
         <XMarkIcon className="h-4 w-4" aria-hidden="true" />

--- a/src/extensions/ApiToken/containers/ApiTokenPage/GenerateTokenModal.tsx
+++ b/src/extensions/ApiToken/containers/ApiTokenPage/GenerateTokenModal.tsx
@@ -38,7 +38,7 @@ export default function GenerateTokenModal({ onSubmit, onCancel, isLoading }: Pr
             <input
               type="text"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => { setName(e.target.value); }}
               placeholder={translations['GenerateTokenModal.namePlaceholder']}
               required
               className="w-full rounded-lg bg-bg-overlay px-3 py-2 text-sm text-base border border-border focus:outline-none focus:ring-2 focus:ring-primary placeholder:text-subtle"
@@ -53,7 +53,7 @@ export default function GenerateTokenModal({ onSubmit, onCancel, isLoading }: Pr
                 type="checkbox"
                 id="no-expiry"
                 checked={noExpiry}
-                onChange={(e) => setNoExpiry(e.target.checked)}
+                onChange={(e) => { setNoExpiry(e.target.checked); }}
                 className="h-4 w-4 rounded border-border bg-bg-base text-blue-600"
               />
               <label htmlFor="no-expiry" className="text-sm text-subtle">
@@ -64,7 +64,7 @@ export default function GenerateTokenModal({ onSubmit, onCancel, isLoading }: Pr
               <input
                 type="date"
                 value={expiresAt}
-                onChange={(e) => setExpiresAt(e.target.value)}
+                onChange={(e) => { setExpiresAt(e.target.value); }}
                 min={new Date().toISOString().split('T')[0]}
                 className="w-full rounded-lg bg-bg-overlay px-3 py-2 text-sm text-base border border-border focus:outline-none focus:ring-2 focus:ring-primary"
               />

--- a/src/extensions/Automation/components/AutomationPanel/RuleBuilder/ActionPicker.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/RuleBuilder/ActionPicker.tsx
@@ -19,9 +19,9 @@ const ActionPicker = ({ onSelect, onCancel }: Props) => {
 
   useEffect(() => {
     getActionTypes()
-      .then((res) => setActionTypes(res.data))
-      .catch(() => setError(translations['automation.actionPicker.error.loadFailed']))
-      .finally(() => setLoading(false));
+      .then((res) => { setActionTypes(res.data); })
+      .catch(() => { setError(translations['automation.actionPicker.error.loadFailed']); })
+      .finally(() => { setLoading(false); });
   }, []);
 
   const filtered = query
@@ -49,7 +49,7 @@ const ActionPicker = ({ onSelect, onCancel }: Props) => {
           className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted focus:outline-none"
           placeholder={translations['automation.actionPicker.searchPlaceholder']}
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => { setQuery(e.target.value); }}
           autoFocus
         />
       </div>
@@ -75,7 +75,7 @@ const ActionPicker = ({ onSelect, onCancel }: Props) => {
                   role="option"
                   aria-selected={false}
                   className="flex w-full items-center gap-2 px-3 py-2 text-sm text-foreground transition-colors hover:bg-bg-overlay"
-                  onClick={() => onSelect(t)}
+                  onClick={() => { onSelect(t); }}
                 >
                   <PlayIcon className="h-4 w-4 shrink-0 text-muted" aria-hidden="true" />
                   {t.label}

--- a/src/extensions/Automation/components/AutomationPanel/RuleBuilder/TriggerPicker.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/RuleBuilder/TriggerPicker.tsx
@@ -20,9 +20,9 @@ const TriggerPicker = ({ selectedType, onSelect }: Props) => {
 
   useEffect(() => {
     getTriggerTypes()
-      .then((res) => setTriggerTypes(res.data))
-      .catch(() => setError(translations['automation.triggerPicker.error.loadFailed']))
-      .finally(() => setLoading(false));
+      .then((res) => { setTriggerTypes(res.data); })
+      .catch(() => { setError(translations['automation.triggerPicker.error.loadFailed']); })
+      .finally(() => { setLoading(false); });
   }, []);
 
   const filtered = query
@@ -40,7 +40,7 @@ const TriggerPicker = ({ selectedType, onSelect }: Props) => {
       <button
         type="button"
         className="flex w-full items-center gap-2 rounded-md border border-border bg-bg-surface px-3 py-2 text-sm text-foreground hover:border-border transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => { setOpen((o) => !o); }}
         aria-haspopup="listbox"
         aria-expanded={open}
       >
@@ -66,7 +66,7 @@ const TriggerPicker = ({ selectedType, onSelect }: Props) => {
               className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted focus:outline-none"
               placeholder={translations['automation.triggerPicker.searchPlaceholder']}
               value={query}
-              onChange={(e) => setQuery(e.target.value)}
+              onChange={(e) => { setQuery(e.target.value); }}
               autoFocus
             />
           </div>

--- a/src/extensions/Card/components/LinkInsertPopover.tsx
+++ b/src/extensions/Card/components/LinkInsertPopover.tsx
@@ -64,7 +64,7 @@ const LinkInsertPopover = ({ editor, onClose }: Props) => {
       }
     };
     // Defer so the same mousedown that opened us doesn't immediately close us
-    const timer = setTimeout(() => document.addEventListener('mousedown', handler), 0);
+    const timer = setTimeout(() => { document.addEventListener('mousedown', handler); }, 0);
     return () => {
       clearTimeout(timer);
       document.removeEventListener('mousedown', handler);
@@ -186,7 +186,7 @@ const LinkInsertPopover = ({ editor, onClose }: Props) => {
       ref={containerRef}
       className="absolute left-0 top-full z-50 mt-1 w-72 rounded-xl border border-border bg-bg-base p-4 shadow-2xl"
       // [why] Prevent mousedown inside the popover from blurring the editor
-      onMouseDown={(e) => e.stopPropagation()}
+      onMouseDown={(e) => { e.stopPropagation(); }}
     >
       <div className="mb-3">
         <label htmlFor="link-insert-url" className="mb-1 block text-xs font-semibold text-subtle">
@@ -197,7 +197,7 @@ const LinkInsertPopover = ({ editor, onClose }: Props) => {
           ref={urlInputRef}
           type="url"
           value={url}
-          onChange={(e) => setUrl(e.target.value)}
+          onChange={(e) => { setUrl(e.target.value); }}
           onKeyDown={handleKeyDown}
           placeholder="Paste a link"
           className={inputCls}
@@ -212,7 +212,7 @@ const LinkInsertPopover = ({ editor, onClose }: Props) => {
           id="link-insert-display"
           type="text"
           value={displayText}
-          onChange={(e) => setDisplayText(e.target.value)}
+          onChange={(e) => { setDisplayText(e.target.value); }}
           onKeyDown={handleKeyDown}
           placeholder="Text to display"
           className={inputCls}

--- a/src/extensions/Comment/components/EmojiPickerPopover.tsx
+++ b/src/extensions/Comment/components/EmojiPickerPopover.tsx
@@ -75,7 +75,7 @@ const EmojiPickerPopover = ({ anchorRef, onSelect, onClose }: Props) => {
       }
     };
     document.addEventListener('mousedown', handleMouseDown);
-    return () => document.removeEventListener('mousedown', handleMouseDown);
+    return () => { document.removeEventListener('mousedown', handleMouseDown); };
   }, [anchorRef, onClose]);
 
   // Close on Escape key
@@ -84,7 +84,7 @@ const EmojiPickerPopover = ({ anchorRef, onSelect, onClose }: Props) => {
       if (e.key === 'Escape') onClose();
     };
     document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    return () => { document.removeEventListener('keydown', handleKeyDown); };
   }, [onClose]);
 
   // Position on mount and whenever viewport/scroll context changes.
@@ -93,7 +93,7 @@ const EmojiPickerPopover = ({ anchorRef, onSelect, onClose }: Props) => {
   }, [updatePosition]);
 
   useEffect(() => {
-    const onReposition = () => updatePosition();
+    const onReposition = () => { updatePosition(); };
     window.addEventListener('resize', onReposition);
     // capture=true catches scroll from nested containers (e.g. modal body)
     window.addEventListener('scroll', onReposition, true);

--- a/src/extensions/List/components/ListColumn.tsx
+++ b/src/extensions/List/components/ListColumn.tsx
@@ -36,14 +36,14 @@ const ListColumn = ({
       <div {...dragHandleProps} className="cursor-grab active:cursor-grabbing">
         <ListHeader
           list={list}
-          onRename={(title) => onRename(list.id, title)}
+          onRename={(title) => { onRename(list.id, title); }}
           onAddCard={() => {}}
           onCopyList={() => {}}
           onMoveList={() => {}}
           onMoveAllCards={() => {}}
-          onArchive={() => onArchive(list.id)}
+          onArchive={() => { onArchive(list.id); }}
           onArchiveAllCards={() => {}}
-          onDelete={() => onDelete(list.id)}
+          onDelete={() => { onDelete(list.id); }}
           onChangeListColor={() => {}}
           availableLists={[]}
           onSortBy={(sortBy) => {

--- a/src/extensions/List/components/ListHeader.tsx
+++ b/src/extensions/List/components/ListHeader.tsx
@@ -344,7 +344,7 @@ const ListHeader = ({
                       className={`relative h-5 rounded ${selected ? 'ring-2 ring-offset-1 ring-indigo-500 ring-offset-bg-surface' : ''}`}
                       style={{ backgroundColor: color }}
                       aria-label={`Set list color ${color}`}
-                      onClick={() => onChangeListColor(color)}
+                      onClick={() => { onChangeListColor(color); }}
                     >
                       {selected ? <span className="absolute inset-0 grid place-items-center text-[10px] font-bold text-white">✓</span> : null}
                     </button>
@@ -354,7 +354,7 @@ const ListHeader = ({
               <Button
                 variant="ghost"
                 className="mt-2 w-full justify-start px-2 py-1 text-xs rounded"
-                onClick={() => onChangeListColor(null)}
+                onClick={() => { onChangeListColor(null); }}
               >
                 Remove color
               </Button>
@@ -407,7 +407,7 @@ const ListHeader = ({
                   <Button
                     variant="ghost"
                     className="h-7 w-7 rounded p-0 text-subtle"
-                    onClick={() => setSortMenuOpen(false)}
+                    onClick={() => { setSortMenuOpen(false); }}
                     aria-label="Close sort menu"
                   >
                     ×
@@ -439,7 +439,7 @@ const ListHeader = ({
                   <Button
                     variant="ghost"
                     className="h-7 w-7 rounded p-0 text-subtle"
-                    onClick={() => setMoveCardsMenuOpen(false)}
+                    onClick={() => { setMoveCardsMenuOpen(false); }}
                     aria-label="Close move cards menu"
                   >
                     ×
@@ -475,7 +475,7 @@ const ListHeader = ({
                   <Button
                     variant="ghost"
                     className="h-7 w-7 rounded p-0 text-subtle"
-                    onClick={() => setMoveListMenuOpen(false)}
+                    onClick={() => { setMoveListMenuOpen(false); }}
                     aria-label="Close move list menu"
                   >
                     ×

--- a/src/extensions/Mention/MentionList.tsx
+++ b/src/extensions/Mention/MentionList.tsx
@@ -26,7 +26,7 @@ const MentionList = forwardRef<MentionListHandle, Props>(({ items, command }, re
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   // Reset selection whenever the suggestion list changes
-  useEffect(() => setSelectedIndex(0), [items]);
+  useEffect(() => { setSelectedIndex(0); }, [items]);
 
   const selectItem = (index: number) => {
     const item = items[index];
@@ -67,8 +67,8 @@ const MentionList = forwardRef<MentionListHandle, Props>(({ items, command }, re
             name={item.name}
             avatarUrl={item.avatar_url}
             highlighted={i === selectedIndex}
-            onSelect={() => selectItem(i)}
-            onMouseEnter={() => setSelectedIndex(i)}
+            onSelect={() => { selectItem(i); }}
+            onMouseEnter={() => { setSelectedIndex(i); }}
           />
         </li>
       ))}

--- a/src/extensions/Plugins/modals/PluginModal.tsx
+++ b/src/extensions/Plugins/modals/PluginModal.tsx
@@ -37,7 +37,7 @@ const PluginModal = ({ modal, onClose }: Props) => {
       if (e.key === 'Escape') onClose();
     };
     window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
+    return () => { window.removeEventListener('keydown', handler); };
   }, [modal.open, onClose]);
 
   if (!modal.open) return null;
@@ -57,8 +57,8 @@ const PluginModal = ({ modal, onClose }: Props) => {
       // clicks inside this overlay as "outside" clicks on the card dialog, which would
       // close the card detail view and break the two-modal separation.
       style={{ zIndex: 9999, pointerEvents: 'auto' }}
-      onPointerDown={(e) => e.stopPropagation()}
-      onMouseDown={(e) => e.stopPropagation()}
+      onPointerDown={(e) => { e.stopPropagation(); }}
+      onMouseDown={(e) => { e.stopPropagation(); }}
       role="dialog"
       aria-modal="true"
       aria-label={modal.title || translations['plugins.modal.defaultTitle']}

--- a/src/extensions/Realtime/client/socket.ts
+++ b/src/extensions/Realtime/client/socket.ts
@@ -151,10 +151,10 @@ class RealtimeSocket {
       for (const activeBoardId of this.boardRefCounts.keys()) {
         this.send({ type: 'subscribe', board_id: activeBoardId });
       }
-      this.openHandlers.forEach((h) => h());
+      this.openHandlers.forEach((h) => { h(); });
       // Notify that polling is no longer needed now that WS is back
       if (wasPolling) {
-        this.pollingInactiveHandlers.forEach((h) => h());
+        this.pollingInactiveHandlers.forEach((h) => { h(); });
       }
     });
 
@@ -182,11 +182,11 @@ class RealtimeSocket {
         return;
       }
       this.failedAttempts++;
-      this.closeHandlers.forEach((h) => h());
+      this.closeHandlers.forEach((h) => { h(); });
       if (!this.intentionalClose && this.connectionRefCount > 0) {
         // Activate polling fallback once threshold is reached
         if (this.failedAttempts === POLLING_FALLBACK_THRESHOLD) {
-          this.pollingActiveHandlers.forEach((h) => h());
+          this.pollingActiveHandlers.forEach((h) => { h(); });
         }
         this._scheduleReconnect();
       }

--- a/src/extensions/UserProfile/containers/EditProfilePage/EditProfilePage.tsx
+++ b/src/extensions/UserProfile/containers/EditProfilePage/EditProfilePage.tsx
@@ -52,7 +52,7 @@ const EditProfilePage = () => {
         <div className="flex items-center gap-3">
           <button
             className="text-subtle hover:text-base transition-colors text-sm"
-            onClick={() => navigate(-1)}
+            onClick={() => { navigate(-1); }}
           >
             {translations['UserProfile.backButton']}
           </button>
@@ -66,7 +66,7 @@ const EditProfilePage = () => {
             aria-selected={activeTab === 'profile'}
             aria-controls="tab-panel-profile"
             className={tabClass('profile')}
-            onClick={() => switchTab('profile')}
+            onClick={() => { switchTab('profile'); }}
           >
             {translations['UserProfile.tabProfile']}
           </button>
@@ -75,7 +75,7 @@ const EditProfilePage = () => {
             aria-selected={activeTab === 'notifications'}
             aria-controls="tab-panel-notifications"
             className={tabClass('notifications')}
-            onClick={() => switchTab('notifications')}
+            onClick={() => { switchTab('notifications'); }}
           >
             {translations['UserProfile.tabNotifications']}
           </button>
@@ -95,7 +95,7 @@ const EditProfilePage = () => {
             <section>
               <ChangeEmailForm
                 currentEmail={displayEmail}
-                onSuccess={(newEmail) => setDisplayEmail(newEmail)}
+                onSuccess={(newEmail) => { setDisplayEmail(newEmail); }}
               />
             </section>
           </div>

--- a/src/extensions/Workspace/containers/WorkspaceListPage/WorkspaceListPage.tsx
+++ b/src/extensions/Workspace/containers/WorkspaceListPage/WorkspaceListPage.tsx
@@ -43,7 +43,7 @@ export default function WorkspaceListPage() {
         <Button
           variant="primary"
           size="md"
-          onClick={() => setShowCreateModal(true)}
+          onClick={() => { setShowCreateModal(true); }}
         >
           {translations['WorkspaceListPage.newButton']}
         </Button>
@@ -62,7 +62,7 @@ export default function WorkspaceListPage() {
           <Button
             variant="primary"
             size="md"
-            onClick={() => setShowCreateModal(true)}
+            onClick={() => { setShowCreateModal(true); }}
           >
             {translations['WorkspaceListPage.emptyAction']}
           </Button>
@@ -72,7 +72,7 @@ export default function WorkspaceListPage() {
           {workspaces.map((ws) => (
             <div
               key={ws.id}
-              onClick={() => handleOpen(ws.id)}
+              onClick={() => { handleOpen(ws.id); }}
               className="cursor-pointer rounded-xl border border-border bg-bg-surface p-5 transition-colors hover:border-slate-400 dark:hover:border-slate-600"
             >
               <BuildingOfficeIcon className="mb-3 h-8 w-8 text-subtle" aria-hidden="true" />


### PR DESCRIPTION
## Summary

Fixes 48 `@typescript-eslint/no-confusing-void-expression` findings across 13 files. Each `onClick`/`onChange`/`onSelect`/`onMouseEnter`/`onRename`/`onArchive`/`onDelete`/`onDoneChange`/`onValueChange`/`onSuccess`/`onCancel`/`setOpen`/`setQuery`/`setName`/`setNoExpiry`/`setExpiresAt`/`setSelectedIndex`/`setShowCreateModal`/`setUrl`/`setDisplayText`/`setSortMenuOpen`/`setMoveCardsMenuOpen`/`setMoveListMenuOpen`/`setActionTypes`/`setError`/`setLoading`/`setTriggerTypes`/`navigate`/`switchTab`/`stopPropagation`/`removeEventListener`/`clearTimeout`/`clearInterval`/`forEach` arrow shorthand returned a void expression; wrapping each in braces makes the arrow return `void` explicitly.

Behaviour-preserving: both forms return `undefined` in every case.

## Scope

- Rule family: `no-confusing-void-expression` (brace-wrapping)
- 13 files, 48 insertions / 48 deletions
- Files: Toast, GenerateTokenModal, ActionPicker, TriggerPicker, LinkInsertPopover, EmojiPickerPopover, ListColumn, ListHeader, MentionList, PluginModal, socket, EditProfilePage, WorkspaceListPage

## Verification

- Focused lint on all 13 touched files: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **147 errors — identical per-file counts to base** (pre-existing baseline, no new failures)
- `bun test`: **1444 tests, identical fail identities to base** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

All 13 are UI components/hooks with no dedicated executable UI/E2E coverage (no test references them). These are behaviour-preserving brace changes; UI coverage is recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.