### PR TITLE
lint: remove unused imports/vars/params (no-unused-vars batch 1)

### DIFF
--- a/cli/apiClient.ts
+++ b/cli/apiClient.ts
@@ -25,7 +25,7 @@ export async function call<T>({
       },
       body: body !== undefined ? JSON.stringify(body) : undefined,
     });
-  } catch (err) {
+  } catch {
     console.error(`Error: Unable to connect to ${config.apiUrl}. Check your network or CHIMEDECK_API_URL.`);
     process.exit(1);
   }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -6,7 +6,6 @@
 
 import minimist from 'minimist';
 import { resolveConfig } from './config';
-import { print } from './output';
 import { runMoveCard } from './commands/moveCard';
 import { runComment } from './commands/comment';
 import { runCreateCard } from './commands/createCard';

--- a/db/migrations/0001_init.ts
+++ b/db/migrations/0001_init.ts
@@ -1,5 +1,3 @@
-import type { Knex } from 'knex';
-
 // Baseline migration — establishes migration history. No schema changes.
-export async function up(_knex: Knex): Promise<void> {}
-export async function down(_knex: Knex): Promise<void> {}
+export async function up(): Promise<void> {}
+export async function down(): Promise<void> {}

--- a/db/migrations/0041_migrate_guest_board_members.ts
+++ b/db/migrations/0041_migrate_guest_board_members.ts
@@ -36,7 +36,7 @@ export async function up(knex: Knex): Promise<void> {
   }
 }
 
-export async function down(knex: Knex): Promise<void> {
+export async function down(): Promise<void> {
   // Down is intentionally a no-op: restoring stale board_members rows would
   // re-introduce the original bug and the original data is gone.
 }

--- a/server/extensions/attachment/__tests__/orphanCleanup.test.ts
+++ b/server/extensions/attachment/__tests__/orphanCleanup.test.ts
@@ -1,6 +1,6 @@
 // Unit tests for orphan cleanup TTL logic.
 // We test the TTL boundary condition without hitting a real database.
-import { describe, expect, test, mock, beforeEach } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 
 const ORPHAN_TTL_MS = 60 * 60 * 1000; // 1 hour — must match orphanCleanup.ts
 

--- a/server/extensions/presence/mods/expiryJob.ts
+++ b/server/extensions/presence/mods/expiryJob.ts
@@ -5,7 +5,6 @@
 // WHY: the TTL-based expiry in Redis/node-cache removes the key silently;
 // this job detects the expiry and broadcasts a leave event to all board subscribers.
 import { cache } from '../../../mods/cache/index';
-import { db } from '../../../common/db';
 import { broadcastPresenceUpdate } from '../api/presenceUpdate';
 
 // Board IDs that currently have at least one subscribed WS client.

--- a/server/mods/events/snapshot/policy.test.ts
+++ b/server/mods/events/snapshot/policy.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 
 describe('checkAndWriteSnapshot (policy)', () => {
   it('exports checkAndWriteSnapshot function', async () => {

--- a/src/extensions/Automation/api.ts
+++ b/src/extensions/Automation/api.ts
@@ -10,7 +10,6 @@ import type {
   CardButtonRunResult,
   BoardButtonRunResult,
   PaginatedRunLogs,
-  AutomationQuota,
 } from './types';
 
 type Api = typeof apiClient;

--- a/src/extensions/Automation/components/LogPanel/AutomationRunsPanel.tsx
+++ b/src/extensions/Automation/components/LogPanel/AutomationRunsPanel.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import type { FC } from 'react';
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
-import type { AutomationRunLog, PaginatedRunLogs } from '../../types';
+import type { PaginatedRunLogs } from '../../types';
 import { getAutomationRuns } from '../../api';
 import Button from '../../../../common/components/Button';
 import RunLogTable from './RunLogTable';

--- a/src/extensions/Card/components/ChecklistSection.tsx
+++ b/src/extensions/Card/components/ChecklistSection.tsx
@@ -10,56 +10,7 @@ import { ChecklistItem } from './ChecklistItem';
 import { ChecklistProgress } from './ChecklistProgress';
 import type { Attachment } from '../../Attachments/types';
 
-const LOW_SENTINEL = '';
-const HIGH_SENTINEL = '~';
-const BASE = 95;
 const NUMERIC_POSITION_PATTERN = /^-?\d+(?:\.\d+)?$/;
-
-const toDigit = (char: string): number => (char.codePointAt(0) ?? 32) - 32;
-const toChar = (digit: number): string => String.fromCodePoint(digit + 32);
-
-const toDigits = (value: string): number[] => Array.from(value).map(toDigit);
-const fromDigits = (digits: number[]): string => digits.map(toChar).join('');
-
-const compareDigits = (left: number[], right: number[]): number => {
-  const maxLength = Math.max(left.length, right.length);
-  for (let index = 0; index < maxLength; index += 1) {
-    const leftDigit = left[index] ?? 0;
-    const rightDigit = right[index] ?? BASE - 1;
-    if (leftDigit < rightDigit) return -1;
-    if (leftDigit > rightDigit) return 1;
-  }
-  return 0;
-};
-
-const betweenPositions = (left: string, right: string): string => {
-  if (left === right) return `${left}O`;
-
-  const leftDigits = left === LOW_SENTINEL ? [] : toDigits(left);
-  const rightDigits = right === HIGH_SENTINEL ? [] : toDigits(right);
-
-  if (left !== LOW_SENTINEL && right !== HIGH_SENTINEL && compareDigits(leftDigits, rightDigits) >= 0) {
-    return `${left}O`;
-  }
-
-  const output: number[] = [];
-  let index = 0;
-
-  for (;;) {
-    const leftDigit = leftDigits[index] ?? 0;
-    const rightDigit = rightDigits[index] ?? (BASE - 1);
-
-    if (rightDigit - leftDigit > 1) {
-      output.push(Math.floor((leftDigit + rightDigit) / 2));
-      break;
-    }
-
-    output.push(leftDigit);
-    index += 1;
-  }
-
-  return fromDigits(output);
-};
 
 const compareChecklistItemPosition = (left: string, right: string): number => {
   if (left === right) return 0;

--- a/tests/e2e/attachments/attachmentPanel.spec.ts
+++ b/tests/e2e/attachments/attachmentPanel.spec.ts
@@ -24,14 +24,13 @@ test.describe('Attachment Panel', () => {
 
   test('Drag-and-drop file upload', async ({ page }) => {
     // Simulate drag-and-drop
-    const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
     await page.setInputFiles('input[type="file"]', 'tests/e2e/attachments/fixtures/sample.pdf');
     // The overlay and upload assertions would go here
     await expect(page.locator('[data-testid="attachment-list"] >> text=sample.pdf')).toBeVisible();
     await expect(page.locator('text=Ready')).toBeVisible({ timeout: 10000 });
   });
 
-  test('Paste screenshot (clipboard)', async ({ page }) => {
+  test('Paste screenshot (clipboard)', async () => {
     // This requires Playwright's clipboard API and a test image
     // Skipping actual clipboard paste for now
     expect(true).toBe(true);

--- a/tests/e2e/list-management.spec.ts
+++ b/tests/e2e/list-management.spec.ts
@@ -146,7 +146,7 @@ test.describe('List Management', () => {
 
   // ── UI: Create list via board UI ──────────────────────────────────────────────
 
-  test('Test 6 — UI: Add list button creates a new list on the board', async ({ request, page }) => {
+  test('Test 6 — UI: Add list button creates a new list on the board', async ({ page }) => {
     if (!token) test.skip(true, 'Server not running — skipping');
 
     await page.goto(UI_URL);

--- a/tests/e2e/search-filters.spec.ts
+++ b/tests/e2e/search-filters.spec.ts
@@ -114,7 +114,7 @@ test.describe('Search Filters', () => {
     expect(res.status()).toBe(401);
   });
 
-  test('Test 5 — UI search box filters visible cards by keyword', async ({ request, page }) => {
+  test('Test 5 — UI search box filters visible cards by keyword', async ({ page }) => {
     if (!token) test.skip(true, 'Server not running — skipping');
 
     await page.goto(UI_URL);
@@ -148,7 +148,7 @@ test.describe('Search Filters', () => {
     }
   });
 
-  test('Test 6 — UI type filter toggle shows only matching result type', async ({ request, page }) => {
+  test('Test 6 — UI type filter toggle shows only matching result type', async ({ page }) => {
     if (!token) test.skip(true, 'Server not running — skipping');
 
     await page.goto(UI_URL);

--- a/tests/integration/apiToken/apiToken.test.ts
+++ b/tests/integration/apiToken/apiToken.test.ts
@@ -61,13 +61,6 @@ describe('generateApiToken', () => {
   });
 
   it('hash is deterministic for a given raw token', async () => {
-    const { raw } = await generateApiToken();
-    // Recompute hash independently using Web Crypto
-    const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(raw));
-    const expected = Array.from(new Uint8Array(hashBuffer))
-      .map((b) => b.toString(16).padStart(2, '0'))
-      .join('');
-
     // Generate a new token and verify its hash matches our independent computation
     const token2 = await generateApiToken();
     const hashBuffer2 = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token2.raw));

--- a/tests/integration/attachments/thumbnails.test.ts
+++ b/tests/integration/attachments/thumbnails.test.ts
@@ -4,7 +4,7 @@
 // Strategy: handler and module-level tests that exercise logic directly.
 // Thumbnail generation with real S3 requires LocalStack — those tests verify the
 // function's guard conditions without needing a real bucket.
-import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 import { generateThumbnail } from '../../../server/extensions/attachment/workers/thumbnail';
 import { handleListAttachments } from '../../../server/extensions/attachment/api/list';
 import { issueAccessToken } from '../../../server/extensions/auth/mods/token/issue';

--- a/tests/integration/auth/emailDomainRestriction.test.ts
+++ b/tests/integration/auth/emailDomainRestriction.test.ts
@@ -1,8 +1,7 @@
 // tests/integration/auth/emailDomainRestriction.test.ts
 // Verifies that email domain restriction is enforced on registration and email change.
-import { describe, it, expect, beforeEach } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 import { extractDomain, isEmailDomainAllowed } from '../../../server/extensions/auth/common/emailDomain';
-import { env } from '../../../server/config/env';
 
 // ---------------------------------------------------------------------------
 // Unit tests for helpers
@@ -63,7 +62,6 @@ describe('isEmailDomainAllowed — multiple allowed domains', () => {
 // ---------------------------------------------------------------------------
 
 import { handleRegister } from '../../../server/extensions/auth/api/register';
-import { handleChangeEmail } from '../../../server/extensions/auth/api/changeEmail';
 
 // We stub db and other side-effects by testing only the domain-guard early return.
 // The guard fires BEFORE any database access, so we can invoke the handler with

--- a/tests/integration/automation/actions.test.ts
+++ b/tests/integration/automation/actions.test.ts
@@ -3,7 +3,7 @@
 // Tests list action handlers: sortByDueDate, sortByName, archiveAllCards, moveAllCards.
 // Card action handler tests verify registry completeness.
 
-import { describe, it, expect, beforeAll } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 
 // Import actions index to register all handlers before testing.
 import '../../../server/extensions/automation/engine/actions/index';

--- a/tests/integration/automation/triggers.test.ts
+++ b/tests/integration/automation/triggers.test.ts
@@ -2,7 +2,7 @@
 // Integration tests for the 13 card trigger handlers (Sprint 62).
 // Tests positive (should fire) and negative (should not fire) cases for each.
 
-import { describe, it, expect, beforeAll } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 
 // Import triggers index to register all handlers before testing.
 import '../../../server/extensions/automation/engine/triggers/index';

--- a/tests/integration/board/starFollow.test.ts
+++ b/tests/integration/board/starFollow.test.ts
@@ -8,11 +8,6 @@ import { describe, it, expect } from 'bun:test';
 import { handleStarBoard, handleUnstarBoard } from '../../../server/extensions/board/api/star';
 import { handleFollowBoard, handleUnfollowBoard } from '../../../server/extensions/board/api/follow';
 import { handleGetMeStarredBoards } from '../../../server/extensions/board/api/me-starred-boards';
-import { issueAccessToken } from '../../../server/extensions/auth/mods/token/issue';
-
-async function makeToken(userId = 'user-1', email = 'user@test.com'): Promise<string> {
-  return issueAccessToken({ sub: userId, email });
-}
 
 function makeRequest(method: string, authHeader?: string): Request {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };

--- a/tests/integration/notifications/boardActivityNotifications.test.ts
+++ b/tests/integration/notifications/boardActivityNotifications.test.ts
@@ -4,7 +4,7 @@
 // Strategy: unit-level tests that exercise handleBoardActivityNotification.
 // DB and publishToUser are mocked so no real postgres or WS connections are needed.
 // Preference guard behaviour is verified via a mock db that returns specific rows.
-import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 import { handleBoardActivityNotification } from '../../../server/extensions/notifications/mods/boardActivityDispatch';
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/notifications/emailNotifications.test.ts
+++ b/tests/integration/notifications/emailNotifications.test.ts
@@ -4,7 +4,7 @@
 // Strategy: unit-level tests that exercise the dispatchNotificationEmail helper
 // and boardActivityDispatch logic. SES is mocked via module spy so no real AWS
 // calls are made. DB-dependent scenarios are covered by mocking the db module.
-import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 import { dispatchNotificationEmail } from '../../../server/extensions/notifications/mods/emailDispatch';
 import { handleBoardActivityNotification } from '../../../server/extensions/notifications/mods/boardActivityDispatch';
 

--- a/tests/integration/rateLimiter.test.ts
+++ b/tests/integration/rateLimiter.test.ts
@@ -12,7 +12,7 @@ function makeClient(initialCount = 0): RateLimiterClient & { count: number } {
   let count = initialCount;
   return {
     count,
-    async eval(_script: string, _numkeys: number, _key: string, _ttl: string): Promise<number> {
+    async eval(): Promise<number> {
       count += 1;
       this.count = count;
       return count;
@@ -51,12 +51,6 @@ describe('applyRateLimit – RATE_LIMIT_ENABLED=true simulation', () => {
     // so we test the Lua-evaluation logic via buildRateLimiterKey + direct checks.
 
     // Simulate a client that returns count = 601 (above the read limit of 600).
-    const highCountClient: RateLimiterClient = {
-      async eval(): Promise<number> {
-        return 601;
-      },
-    };
-
     // Directly exercise the rate-limiter logic with RATE_LIMIT_ENABLED treated as true
     // by constructing a test that checks the internal helper behaviour.
     // The public function checks env.RATE_LIMIT_ENABLED, so we verify the key format.

--- a/tests/integration/webhooks/api-crud.test.ts
+++ b/tests/integration/webhooks/api-crud.test.ts
@@ -8,7 +8,6 @@ import { describe, expect, it } from 'bun:test';
 import { isEndpointAllowed } from '../../../server/extensions/webhooks/api/ssrfGuard';
 import {
   WEBHOOK_EVENT_TYPES,
-  type WebhookEventType,
 } from '../../../server/extensions/webhooks/common/eventTypes';
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/webhooks/ui-crud.test.ts
+++ b/tests/integration/webhooks/ui-crud.test.ts
@@ -209,7 +209,7 @@ describe('UI CRUD — modal exclusivity', () => {
 
 describe('UI CRUD — delete API payload', () => {
   it('deleteWebhook is called with the webhook id', () => {
-    const deleteWebhook = mock((_id: string) => Promise.resolve({ data: undefined }));
+    const deleteWebhook = mock(() => Promise.resolve({ data: undefined }));
 
     deleteWebhook(FIXTURE_WEBHOOK.id);
 
@@ -223,7 +223,7 @@ describe('UI CRUD — delete API payload', () => {
 
 describe('UI CRUD — update API payload', () => {
   it('updateWebhook payload includes id and changed fields', () => {
-    const updateWebhook = mock((_payload: Record<string, unknown>) =>
+    const updateWebhook = mock(() =>
       Promise.resolve({ data: {} })
     );
 

--- a/tests/unit/server/extensions/webhooks/mods/dispatch.test.ts
+++ b/tests/unit/server/extensions/webhooks/mods/dispatch.test.ts
@@ -17,13 +17,13 @@ function makeKnex({
   const knex = (table: string) => {
     if (table === 'webhook_deliveries') {
       return {
-        insert: (_row: unknown) => ({
-          returning: (_col: string) =>
+        insert: () => ({
+          returning: () =>
             insertShouldReject
               ? Promise.reject(new Error('DB insert failed'))
               : Promise.resolve([{ id: deliveryId }]),
         }),
-        where: (_cond: unknown) => ({
+        where: () => ({
           update: (data: Record<string, unknown>) => {
             updates.push(data);
             return updateShouldReject

--- a/tests/unit/webhooks/DeleteWebhookDialog.test.tsx
+++ b/tests/unit/webhooks/DeleteWebhookDialog.test.tsx
@@ -104,7 +104,7 @@ describe('DeleteWebhookDialog — cancel action', () => {
   });
 
   it('does not call deleteWebhook when cancel is clicked', () => {
-    const deleteWebhook = mock((_id: string) => Promise.resolve({ data: undefined }));
+    const deleteWebhook = mock(() => Promise.resolve({ data: undefined }));
     const onClose = mock(() => {});
 
     // Simulate cancel — only onClose fires, deleteWebhook is never called.


### PR DESCRIPTION
## Summary

Fixes 40 `@typescript-eslint/no-unused-vars` findings across 26 files. Each fix is a pure dead-code removal:
- **Unused imports** removed (e.g. `AutomationQuota`, `AutomationRunLog`, `WebhookEventType`, `db`, `print`, `mock`, `beforeEach`, `afterEach`, `beforeAll`, `issueAccessToken`).
- **Unused local variables/consts** removed (e.g. `betweenPositions` + its now-orphaned helper functions in ChecklistSection, `expected` in apiToken.test, `highCountClient` in rateLimiter, `makeToken` in starFollow).
- **Unused function parameters** removed. Note: `eslint.config.js` sets `argsIgnorePattern: '^_'` only for `typeCheckedFiles` (src/**, server/**); the `tests/` and `db/migrations/` files are outside that scope, so underscore-prefixing does NOT silence the rule there — the correct fix for those was removing the unused param (TS allows fewer params than the signature declares).

Behaviour-preserving: pure dead-code removal, no logic, auth, API contract, UI flow, or response-shape change.

## Scope

- Rule family: `@typescript-eslint/no-unused-vars`
- 26 files, 24 insertions / 100 deletions
- Files: cli/apiClient, cli/index, db/migrations/0001_init, db/migrations/0041_migrate_guest_board_members, orphanCleanup.test, expiryJob, policy.test, Automation/api, AutomationRunsPanel, ChecklistSection, attachmentPanel.spec, list-management.spec, search-filters.spec, apiToken.test, thumbnails.test, emailDomainRestriction.test, actions.test, triggers.test, starFollow.test, boardActivityNotifications.test, emailNotifications.test, rateLimiter.test, api-crud.test, ui-crud.test, dispatch.test, DeleteWebhookDialog.test

## Verification

- Focused lint on all 26 touched files: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **146 errors — DOWN from 147** (one pre-existing error in Automation/api.ts removed with the unused import; no new failures)
- `bun test`: **1444 tests, identical fail identities to base** (pre-existing 180 fail / 30 errors baseline, no new failures)
- Focused tests on all touched test files: pass (or identical pre-existing baseline failures, verified against base main)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

Most touched files are tests (which are their own executable coverage) and CLI/migration files. The 2 UI components (AutomationRunsPanel, ChecklistSection) have no dedicated executable UI/E2E coverage — recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.