### PR TITLE
lint: coerce non-string values in template literals (restrict-template batch 1)

### DIFF
--- a/server/extensions/auth/mods/oauth/github.ts
+++ b/server/extensions/auth/mods/oauth/github.ts
@@ -88,7 +88,7 @@ export async function exchangeGitHubCode({
   }
 
   const profile: GitHubProfile = {
-    id: `github:${user.id}`,
+    id: `github:${String(user.id)}`,
     email,
     name: user.name ?? user.login ?? email,
   };

--- a/server/extensions/auth/mods/token/issue.ts
+++ b/server/extensions/auth/mods/token/issue.ts
@@ -15,6 +15,6 @@ export async function issueAccessToken({ sub, email }: AccessTokenPayload): Prom
     .setProtectedHeader({ alg: 'RS256' })
     .setSubject(sub)
     .setIssuedAt()
-    .setExpirationTime(`${jwtConfig.accessTokenTtlSeconds}s`)
+    .setExpirationTime(`${String(jwtConfig.accessTokenTtlSeconds)}s`)
     .sign(privateKey);
 }

--- a/server/extensions/webhooks/mods/sign.ts
+++ b/server/extensions/webhooks/mods/sign.ts
@@ -14,7 +14,7 @@ export function signPayload({
   timestamp: number;
   body: string;
 }): string {
-  const signedPayload = `${timestamp}.${body}`;
+  const signedPayload = `${String(timestamp)}.${body}`;
   return createHmac('sha256', secret).update(signedPayload).digest('hex');
 }
 
@@ -31,5 +31,5 @@ export function buildSignatureHeader({
 }): string {
   const timestamp = Math.floor(Date.now() / 1000);
   const sig = signPayload({ secret, timestamp, body });
-  return `t=${timestamp},v0=${sig}`;
+  return `t=${String(timestamp)},v0=${sig}`;
 }

--- a/server/middlewares/rateLimiter.ts
+++ b/server/middlewares/rateLimiter.ts
@@ -69,7 +69,7 @@ export function buildRateLimiterKey(
 ): string {
   const identifier = userId ?? ip;
   const epoch = windowEpoch();
-  return `rl:${identifier}:${routeClass}:${epoch}`;
+  return `rl:${identifier}:${routeClass}:${String(epoch)}`;
 }
 
 export async function applyRateLimit(

--- a/server/mods/logger.ts
+++ b/server/mods/logger.ts
@@ -3,5 +3,5 @@ export function logRequest(req: Request, status: number, durationMs: number): vo
   const method = req.method;
   const url = new URL(req.url).pathname;
   const ts = new Date().toISOString();
-  console.info(`[${ts}] ${method} ${url} → ${status} (${durationMs}ms)`);
+  console.info(`[${ts}] ${method} ${url} → ${String(status)} (${String(durationMs)}ms)`);
 }

--- a/src/extensions/Automation/components/LogPanel/RunCountChip.tsx
+++ b/src/extensions/Automation/components/LogPanel/RunCountChip.tsx
@@ -17,8 +17,8 @@ const RunCountChip: FC<Props> = ({ count }) => {
   return (
     <span
       className={`inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-medium tabular-nums ${colourClass}`}
-      aria-label={`${count} run${count !== 1 ? 's' : ''}`}
-      title={`${count} run${count !== 1 ? 's' : ''}`}
+      aria-label={`${String(count)} run${count !== 1 ? 's' : ''}`}
+      title={`${String(count)} run${count !== 1 ? 's' : ''}`}
     >
       {label}
     </span>

--- a/src/extensions/Automation/utils/scheduleSummary.ts
+++ b/src/extensions/Automation/utils/scheduleSummary.ts
@@ -35,7 +35,7 @@ const MONTH_NAMES = [
 function ordinal(n: number): string {
   const s = ['th', 'st', 'nd', 'rd'];
   const v = n % 100;
-  return `${n}${s[(v - 20) % 10] ?? s[v] ?? s[0]}`;
+  return `${String(n)}${s[(v - 20) % 10] ?? s[v] ?? s[0] ?? ''}`;
 }
 
 function pad(n: number): string {
@@ -68,7 +68,7 @@ export function scheduleSummary(config: ScheduleConfig): string {
 
     case 'weekly': {
       const dayName = config.dayOfWeek !== undefined ? DAY_NAMES[config.dayOfWeek] : 'day';
-      return `Every ${dayName} at ${time}`;
+      return `Every ${dayName ?? ''} at ${time}`;
     }
 
     case 'monthly': {
@@ -82,10 +82,10 @@ export function scheduleSummary(config: ScheduleConfig): string {
     case 'yearly': {
       const monthName = config.month !== undefined ? MONTH_NAMES[config.month - 1] : 'year';
       if (config.dayOfMonth === 'last') {
-        return `Last day of ${monthName} every year at ${time}`;
+        return `Last day of ${monthName ?? ''} every year at ${time}`;
       }
       const day = config.dayOfMonth ?? 1;
-      return `${ordinal(day)} of ${monthName} every year at ${time}`;
+      return `${ordinal(day)} of ${monthName ?? ''} every year at ${time}`;
     }
 
     default:
@@ -117,5 +117,5 @@ export function dueDateSummary(config: DueDateConfig): string {
   const unitLabel = value === 1 ? unit.replace(/s$/, '') : unit;
   const direction = config.triggerMoment === 'before' ? 'before' : 'after';
 
-  return `${value} ${unitLabel} ${direction} due date`;
+  return `${String(value)} ${unitLabel} ${direction} due date`;
 }

--- a/src/extensions/Board/components/MemberAvatarStack.tsx
+++ b/src/extensions/Board/components/MemberAvatarStack.tsx
@@ -22,7 +22,7 @@ const MemberAvatarStack = ({ members, onOpenMembers, max = 5 }: Props) => {
       type="button"
       onClick={onOpenMembers}
       className="flex items-center rounded px-1 py-0.5 transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-blue-500"
-      aria-label={`Board members (${members.length}). Click to manage.`}
+      aria-label={`Board members (${String(members.length)}). Click to manage.`}
       title="Manage board members"
     >
       {members.length > 0 ? (

--- a/src/extensions/CalendarView/CalendarMonthGrid.tsx
+++ b/src/extensions/CalendarView/CalendarMonthGrid.tsx
@@ -45,7 +45,7 @@ const CalendarMonthGrid = ({
     const y = date.getFullYear();
     const m = String(date.getMonth() + 1).padStart(2, '0');
     const d = String(date.getDate()).padStart(2, '0');
-    return cardsByDay.get(`${y}-${m}-${d}`) ?? [];
+    return cardsByDay.get(`${String(y)}-${m}-${d}`) ?? [];
   }
 
   return (

--- a/src/extensions/CalendarView/CalendarWeekGrid.tsx
+++ b/src/extensions/CalendarView/CalendarWeekGrid.tsx
@@ -17,7 +17,7 @@ function toIsoDate(date: Date): string {
   const y = date.getFullYear();
   const m = String(date.getMonth() + 1).padStart(2, '0');
   const d = String(date.getDate()).padStart(2, '0');
-  return `${y}-${m}-${d}`;
+  return `${String(y)}-${m}-${d}`;
 }
 
 /** Format a week range label, e.g. "Mar 9 – Mar 15, 2026". */
@@ -30,9 +30,9 @@ function weekRangeLabel(weekStart: Date): string {
   const year = weekEnd.getFullYear();
 
   if (weekStart.getMonth() === weekEnd.getMonth()) {
-    return `${startMonth} ${weekStart.getDate()} – ${weekEnd.getDate()}, ${year}`;
+    return `${startMonth} ${String(weekStart.getDate())} – ${String(weekEnd.getDate())}, ${String(year)}`;
   }
-  return `${startMonth} ${weekStart.getDate()} – ${endMonth} ${weekEnd.getDate()}, ${year}`;
+  return `${startMonth} ${String(weekStart.getDate())} – ${endMonth} ${String(weekEnd.getDate())}, ${String(year)}`;
 }
 
 export interface CalendarWeekGridProps {

--- a/src/extensions/Card/components/CardLabelChips.tsx
+++ b/src/extensions/Card/components/CardLabelChips.tsx
@@ -6,7 +6,7 @@ function contrastText(bgHex: string): string {
   const hex = bgHex.trim().replace('#', '');
   const normalized =
     hex.length === 3
-      ? `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`
+      ? `${hex[0] ?? ''}${hex[0] ?? ''}${hex[1] ?? ''}${hex[1] ?? ''}${hex[2] ?? ''}${hex[2] ?? ''}`
       : hex;
   if (!/^[0-9a-fA-F]{6}$/.test(normalized)) return 'var(--text-inverse)';
   const r = Number.parseInt(normalized.slice(0, 2), 16) / 255;

--- a/src/extensions/Card/components/CardMoneyBadge.tsx
+++ b/src/extensions/Card/components/CardMoneyBadge.tsx
@@ -24,7 +24,7 @@ const CardMoneyBadge = ({ amount, currency }: Props) => {
     }).format(numericAmount);
   } catch {
     // Fallback if currency code is unrecognised at render time
-    formatted = `${currencyCode} ${numericAmount}`;
+    formatted = `${currencyCode} ${String(numericAmount)}`;
   }
 
   return (

--- a/src/extensions/Card/components/ChecklistProgress.tsx
+++ b/src/extensions/Card/components/ChecklistProgress.tsx
@@ -8,12 +8,12 @@ export const ChecklistProgress = ({ total, checked }: Props) => {
   const pct = total === 0 ? 0 : Math.round((checked / total) * 100);
 
   return (
-    <div className="flex items-center gap-2" aria-label={`Checklist progress: ${checked} of ${total}`}>
-      <span className="min-w-[2.5rem] text-right text-xs text-muted">{pct}%</span>
+    <div className="flex items-center gap-2" aria-label={`Checklist progress: ${String(checked)} of ${String(total)}`}>
+      <span className="min-w-[2.5rem] text-right text-xs text-muted">{String(pct)}%</span>
       <div className="h-2 flex-1 overflow-hidden rounded-full bg-bg-overlay">
         <div
           className="h-full rounded-full bg-green-500 transition-all"
-          style={{ width: `${pct}%` }}
+          style={{ width: `${String(pct)}%` }}
         />
       </div>
       <span className="text-xs text-muted">{checked}/{total}</span>

--- a/src/extensions/Card/components/LabelChip.tsx
+++ b/src/extensions/Card/components/LabelChip.tsx
@@ -7,7 +7,7 @@ export function contrastText(bgHex: string): string {
   const hex = bgHex.trim().replace('#', '');
   const normalized =
     hex.length === 3
-      ? `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`
+      ? `${hex[0] ?? ''}${hex[0] ?? ''}${hex[1] ?? ''}${hex[1] ?? ''}${hex[2] ?? ''}${hex[2] ?? ''}`
       : hex;
   if (!/^[0-9a-fA-F]{6}$/.test(normalized)) return 'var(--text-inverse)';
   const r = Number.parseInt(normalized.slice(0, 2), 16) / 255;

--- a/src/extensions/HealthCheck/components/HealthCheckCountdown.tsx
+++ b/src/extensions/HealthCheck/components/HealthCheckCountdown.tsx
@@ -12,10 +12,10 @@ interface Props {
 /** Formats raw seconds into a human-readable string: "45s" or "1m 05s". */
 function formatCountdown(seconds: number): string {
   if (seconds <= 0) return 'Refreshing…';
-  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 60) return `${String(seconds)}s`;
   const m = Math.floor(seconds / 60);
   const s = seconds % 60;
-  return `${m}m ${String(s).padStart(2, '0')}s`;
+  return `${String(m)}m ${String(s).padStart(2, '0')}s`;
 }
 
 /** Presentational countdown component for the auto-refresh timer. */
@@ -27,7 +27,7 @@ export function HealthCheckCountdown({
   const display = paused ? 'Paused' : formatCountdown(secondsRemaining);
   const progress = totalSeconds > 0 ? Math.max(0, secondsRemaining / totalSeconds) : 0;
   // Width of the progress bar as a percentage
-  const widthPct = `${Math.round(progress * 100)}%`;
+  const widthPct = `${String(Math.round(progress * 100))}%`;
 
   return (
     <span

--- a/src/extensions/Plugins/iframeHost/PluginIframeHost.tsx
+++ b/src/extensions/Plugins/iframeHost/PluginIframeHost.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 const PluginIframeHost = ({ boardPlugin, boardId }: Props) => {
   const { plugin } = boardPlugin;
-  const cacheBustRef = useRef<string>(`${Date.now()}`);
+  const cacheBustRef = useRef<string>(String(Date.now()));
 
   // Build the iframe src with required context params
   let src: string;

--- a/src/extensions/Realtime/__tests__/messageQueue.test.ts
+++ b/src/extensions/Realtime/__tests__/messageQueue.test.ts
@@ -46,13 +46,13 @@ describe('messageQueue', () => {
     expect(messageQueue.size()).toBe(0);
   });
 
-  it(`calls overflow handler and clears queue when enqueue exceeds ${MAX_QUEUE_SIZE}`, () => {
+  it(`calls overflow handler and clears queue when enqueue exceeds ${String(MAX_QUEUE_SIZE)}`, () => {
     let overflowBoardId: string | null = null;
     messageQueue.setOverflowHandler((bid) => { overflowBoardId = bid; });
 
     // Fill to max
     for (let i = 0; i < MAX_QUEUE_SIZE; i++) {
-      messageQueue.enqueue(makeMutation(`m${i}`));
+      messageQueue.enqueue(makeMutation(`m${String(i)}`));
     }
     expect(messageQueue.size()).toBe(MAX_QUEUE_SIZE);
 

--- a/src/extensions/Realtime/components/PresenceAvatars.tsx
+++ b/src/extensions/Realtime/components/PresenceAvatars.tsx
@@ -109,7 +109,7 @@ const PresenceAvatars: React.FC<PresenceAvatarsProps> = ({
         <div
           // [theme-exception] bg-bg-sunken/text-base overflow counter has no direct semantic equivalent — needs design input
           className="flex h-8 w-8 items-center justify-center rounded-full bg-bg-sunken text-xs font-semibold text-base ring-2 ring-white"
-          title={`${overflow} more active user${overflow > 1 ? 's' : ''}`}
+          title={`${String(overflow)} more active user${overflow > 1 ? 's' : ''}`}
         >
           +{overflow}
         </div>

--- a/src/extensions/TimelineView/TimelineHeader.tsx
+++ b/src/extensions/TimelineView/TimelineHeader.tsx
@@ -22,7 +22,7 @@ function toIsoDate(date: Date): string {
   const y = date.getFullYear();
   const m = String(date.getMonth() + 1).padStart(2, '0');
   const d = String(date.getDate()).padStart(2, '0');
-  return `${y}-${m}-${d}`;
+  return `${String(y)}-${m}-${d}`;
 }
 
 interface DateColumn {
@@ -50,7 +50,7 @@ function buildMonthBands(originDate: Date, totalDays: number, dayWidth: number):
     const daysInChunk = Math.min(daysLeft, totalDays - i);
     bands.push({
       dateKey: toIsoDate(d),
-      label: `${MONTH_SHORT[d.getMonth()]} ${d.getFullYear()}`,
+      label: `${MONTH_SHORT[d.getMonth()] ?? ''} ${String(d.getFullYear())}`,
       widthPx: daysInChunk * dayWidth,
     });
     i += daysInChunk;
@@ -94,11 +94,11 @@ function buildWeekColumns(
       toIsoDate(addDays(d, k)),
     ).includes(todayIso);
     // Show the week range: "Mar 10 – 16" or "Mar 29 – Apr 4" when spanning a month boundary.
-    const startLabel = `${MONTH_SHORT[d.getMonth()]} ${d.getDate()}`;
+    const startLabel = `${MONTH_SHORT[d.getMonth()] ?? ''} ${String(d.getDate())}`;
     const endLabel =
       endDate.getMonth() === d.getMonth()
         ? String(endDate.getDate())
-        : `${MONTH_SHORT[endDate.getMonth()]} ${endDate.getDate()}`;
+        : `${MONTH_SHORT[endDate.getMonth()] ?? ''} ${String(endDate.getDate())}`;
     cols.push({
       dateKey: toIsoDate(d),
       label: `${startLabel} – ${endLabel}`,
@@ -127,7 +127,7 @@ function buildMonthColumns(
       today.getMonth() === d.getMonth() && today.getFullYear() === d.getFullYear();
     cols.push({
       dateKey: toIsoDate(d),
-      label: `${MONTH_SHORT[d.getMonth()]} ${d.getFullYear()}`,
+      label: `${MONTH_SHORT[d.getMonth()] ?? ''} ${String(d.getFullYear())}`,
       widthPx: daysInChunk * dayWidth,
       isToday: isCurrentMonth,
     });

--- a/src/extensions/User/containers/ProfilePage/ProfilePage.duck.ts
+++ b/src/extensions/User/containers/ProfilePage/ProfilePage.duck.ts
@@ -132,7 +132,7 @@ const profileSlice = createSlice({
           // the old image and never refetches it. Append a timestamp to bust the cache
           // whenever a new avatar is uploaded.
           const url = action.payload.avatar_url;
-          state.user.avatar_url = `${url}${url.includes('?') ? '&' : '?'}v=${Date.now()}`;
+          state.user.avatar_url = `${url}${url.includes('?') ? '&' : '?'}v=${String(Date.now())}`;
         }
       })
       .addCase(uploadAvatarThunk.rejected, (state) => {


### PR DESCRIPTION
## Summary

Fixes 57 `@typescript-eslint/restrict-template-expressions` findings across 20 files. Each fix coerces an interpolated non-string value to string:
- **number / boolean / literal** → wrapped in `String(...)` (e.g. `` `${count}` `` → `` `${String(count)}` ``, `` `${Date.now()}` `` → `String(Date.now())`).
- **string | undefined** → appended `?? ''` (e.g. `` `${label}` `` → `` `${label ?? ''}` ``).

Behaviour-preserving: identical rendered output in every case.

## Scope

- Rule family: `@typescript-eslint/restrict-template-expressions`
- 20 files, 37 insertions / 37 deletions (57 findings; multiple findings per line collapse into single edits)
- Files: oauth/github, token/issue, webhooks/sign, rateLimiter, logger, RunCountChip, scheduleSummary, MemberAvatarStack, CalendarMonthGrid, CalendarWeekGrid, CardLabelChips, CardMoneyBadge, ChecklistProgress, LabelChip, HealthCheckCountdown, PluginIframeHost, messageQueue.test, PresenceAvatars, TimelineHeader, ProfilePage.duck

## Verification

- Focused lint on all 20 touched files: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **146 errors — identical to current main baseline** (no new failures)
- `bun test`: **1444 tests, identical fail identities to current main** (pre-existing 180 fail / 30 errors baseline, no new failures)
- Focused test on the touched test file (messageQueue.test): **passes**
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

Most touched files are UI components with no dedicated executable UI/E2E coverage — recorded as **missing**, not claimed as passed. The 1 touched test file (messageQueue.test) is its own executable coverage and passes.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.