### PR TITLE
lint: mark fire-and-forget promises void, remove redundant assertions (promise-safety batch 1)

### DIFF
--- a/server/extensions/customFields/api/index.ts
+++ b/server/extensions/customFields/api/index.ts
@@ -29,7 +29,7 @@ export async function customFieldsRouter(req: Request, pathname: string): Promis
         { status: 404 },
       );
     }
-    const fieldId = boardFieldsMatch[3] as string | undefined;
+    const fieldId = boardFieldsMatch[3];
 
     if (!fieldId) {
       if (req.method === 'GET') return handleListCustomFields(req, boardId);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,13 +12,13 @@ export default function App() {
   // Attempt token refresh on boot so authenticated users stay logged in after a page reload.
   // On failure, authDuck sets status to 'unauthenticated' — PrivateRoute handles the redirect.
   useEffect(() => {
-    dispatch(refreshTokenThunk());
+    void dispatch(refreshTokenThunk());
   }, [dispatch]);
 
   // Hydrate the in-memory mutation queue from IndexedDB on boot so pending
   // optimistic mutations survive a page reload and are replayed on next WS connect.
   useEffect(() => {
-    loadPersistedMutations().then((mutations) => {
+    void loadPersistedMutations().then((mutations) => {
       if (mutations.length > 0) {
         messageQueue.hydrate(mutations);
       }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,7 +5,7 @@ const config = {
   maxAttachmentSizeBytes:
     parseInt(import.meta.env['VITE_MAX_ATTACHMENT_SIZE_MB'] ?? '50', 10) * 1024 * 1024,
   /** Public base URL of this ChimeDeck instance, e.g. https://app.example.com */
-  appUrl: (import.meta.env['VITE_APP_URL'] as string | undefined) ?? '',
+  appUrl: import.meta.env['VITE_APP_URL'] ?? '',
   /** Set VITE_OAUTH_GOOGLE_ENABLED=true when OAUTH_GOOGLE_CLIENT_ID/SECRET are configured. */
   oauthGoogleEnabled: import.meta.env['VITE_OAUTH_GOOGLE_ENABLED'] === 'true',
   /** Set VITE_OAUTH_GITHUB_ENABLED=true when OAUTH_GITHUB_CLIENT_ID/SECRET are configured. */
@@ -19,11 +19,11 @@ const config = {
   /** Set VITE_SENTRY_CLIENT_ENABLED=true and provide VITE_SENTRY_CLIENT_DSN to activate capture. */
   sentryEnabled: import.meta.env['VITE_SENTRY_CLIENT_ENABLED'] === 'true',
   /** Sentry DSN for the React client. An empty string disables Sentry even when sentryEnabled=true. */
-  sentryDsn: (import.meta.env['VITE_SENTRY_CLIENT_DSN'] as string | undefined) ?? '',
+  sentryDsn: import.meta.env['VITE_SENTRY_CLIENT_DSN'] ?? '',
   /** Deployment environment tag sent to Sentry (e.g. "production", "staging", "development"). */
-  sentryEnv: (import.meta.env['VITE_SENTRY_ENV'] as string | undefined) ?? 'development',
+  sentryEnv: import.meta.env['VITE_SENTRY_ENV'] ?? 'development',
   /** Release identifier sent to Sentry, typically a git SHA or semver tag. */
-  sentryRelease: (import.meta.env['VITE_SENTRY_RELEASE'] as string | undefined) ?? '',
+  sentryRelease: import.meta.env['VITE_SENTRY_RELEASE'] ?? '',
   /** Set VITE_SENTRY_REPLAY_ENABLED=true to activate Session Replay (bandwidth-intensive). */
   sentryReplayEnabled: import.meta.env['VITE_SENTRY_REPLAY_ENABLED'] === 'true',
 

--- a/src/extensions/Auth/components/ResendVerificationButton.tsx
+++ b/src/extensions/Auth/components/ResendVerificationButton.tsx
@@ -9,7 +9,7 @@ export default function ResendVerificationButton() {
   const status = useAppSelector(selectResendStatus);
 
   const handleClick = () => {
-    dispatch(resendVerificationThunk());
+    void dispatch(resendVerificationThunk());
   };
 
   if (status === 'sent') {

--- a/src/extensions/Auth/components/VerificationPending.tsx
+++ b/src/extensions/Auth/components/VerificationPending.tsx
@@ -21,7 +21,7 @@ export default function VerificationPending({ email, onDismiss }: VerificationPe
   if (dismissed) return null;
 
   const handleResend = () => {
-    dispatch(resendVerificationThunk());
+    void dispatch(resendVerificationThunk());
   };
 
   const handleDismiss = () => {

--- a/src/extensions/Automation/components/SchedulePanel/ScheduleItem.tsx
+++ b/src/extensions/Automation/components/SchedulePanel/ScheduleItem.tsx
@@ -119,7 +119,7 @@ const ScheduleItem: FC<Props> = ({ boardId, automation, onEdit, onDeleted, onTog
       <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
         {/* Enable/disable toggle */}
         <button
-          onClick={handleToggle}
+          onClick={() => void handleToggle()}
           disabled={toggling}
           className="rounded p-1 text-muted hover:text-subtle hover:bg-bg-overlay transition-colors disabled:opacity-50"
           aria-label={automation.isEnabled ? translations['automation.scheduleItem.disableAriaLabel'] : translations['automation.scheduleItem.enableAriaLabel']}
@@ -144,7 +144,7 @@ const ScheduleItem: FC<Props> = ({ boardId, automation, onEdit, onDeleted, onTog
 
         {/* Delete */}
         <button
-          onClick={handleDelete}
+          onClick={() => void handleDelete()}
           disabled={deleting}
           className={`rounded p-1 transition-colors disabled:opacity-50 ${
             confirmDelete

--- a/src/extensions/Board/components/BoardDeleteDialog.tsx
+++ b/src/extensions/Board/components/BoardDeleteDialog.tsx
@@ -58,7 +58,7 @@ const BoardDeleteDialog = ({ boardTitle, listCount, cardCount, onConfirm, onCanc
           <Button type="button" variant="secondary" size="md" onClick={onCancel}>
             Cancel
           </Button>
-          <Button type="button" variant="danger" size="md" onClick={handleConfirm} disabled={busy}>
+          <Button type="button" variant="danger" size="md" onClick={() => void handleConfirm()} disabled={busy}>
             {busy ? 'Deleting…' : 'Delete board'}
           </Button>
         </div>

--- a/src/extensions/BoardViewSwitcher/hooks.ts
+++ b/src/extensions/BoardViewSwitcher/hooks.ts
@@ -19,14 +19,14 @@ export function useViewPreference({ boardId }: { boardId: string }) {
 
   // Load the persisted preference when the board mounts
   useEffect(() => {
-    if (boardId) dispatch(fetchViewPreference({ boardId }));
+    if (boardId) void dispatch(fetchViewPreference({ boardId }));
   }, [dispatch, boardId]);
 
   const switchView = useCallback(
     (viewType: ViewType) => {
       // Optimistic local update so the UI responds immediately
       dispatch(setActiveView(viewType));
-      dispatch(saveViewPreference({ boardId, viewType }));
+      void dispatch(saveViewPreference({ boardId, viewType }));
     },
     [dispatch, boardId],
   );

--- a/src/extensions/HealthCheck/hooks/useHealthCheckProbe.ts
+++ b/src/extensions/HealthCheck/hooks/useHealthCheckProbe.ts
@@ -35,7 +35,7 @@ export function useHealthCheckProbe({ boardId }: Options): Result {
 
   const probe = useCallback(
     (healthCheckId: string) => {
-      dispatch(probeSingleThunk({ boardId, healthCheckId }));
+      void dispatch(probeSingleThunk({ boardId, healthCheckId }));
     },
     [dispatch, boardId],
   );

--- a/src/extensions/List/components/ListDeleteDialog.tsx
+++ b/src/extensions/List/components/ListDeleteDialog.tsx
@@ -54,7 +54,7 @@ const ListDeleteDialog = ({ listTitle, cardCount, onConfirm, onCancel }: Props) 
           <Button type="button" variant="secondary" size="md" onClick={onCancel}>
             Cancel
           </Button>
-          <Button type="button" variant="danger" size="md" onClick={handleConfirm} disabled={busy}>
+          <Button type="button" variant="danger" size="md" onClick={() => void handleConfirm()} disabled={busy}>
             {busy ? 'Deleting…' : 'Delete list'}
           </Button>
         </div>

--- a/src/extensions/Plugins/iframeHost/PluginIframeContainer.tsx
+++ b/src/extensions/Plugins/iframeHost/PluginIframeContainer.tsx
@@ -102,7 +102,7 @@ const PluginIframeContainer = ({ boardId, children }: Props) => {
   // Load active plugins when the board opens; refresh whenever boardId changes.
   useEffect(() => {
     if (boardId) {
-      dispatch(fetchBoardPluginsThunk({ boardId }));
+      void dispatch(fetchBoardPluginsThunk({ boardId }));
     }
   }, [dispatch, boardId]);
 

--- a/src/extensions/StateTransitions/containers/StateTransitionsEditorPage.tsx
+++ b/src/extensions/StateTransitions/containers/StateTransitionsEditorPage.tsx
@@ -20,7 +20,7 @@ const StateTransitionsEditorPage = () => {
 
   useEffect(() => {
     if (!boardId) return;
-    dispatch(fetchBoardDataThunk({ boardId }));
+    void dispatch(fetchBoardDataThunk({ boardId }));
   }, [boardId, dispatch]);
 
   if (!boardId || boardStatus === 'loading') {

--- a/src/extensions/User/containers/ProfilePage/ProfilePage.tsx
+++ b/src/extensions/User/containers/ProfilePage/ProfilePage.tsx
@@ -32,7 +32,7 @@ export default function ProfilePage() {
   }, []);
 
   useEffect(() => {
-    dispatch(fetchProfileThunk());
+    void dispatch(fetchProfileThunk());
   }, [dispatch]);
 
   useEffect(() => {

--- a/src/extensions/Webhooks/containers/WebhooksRegisterPage/DeleteWebhookDialog.tsx
+++ b/src/extensions/Webhooks/containers/WebhooksRegisterPage/DeleteWebhookDialog.tsx
@@ -67,7 +67,7 @@ export default function DeleteWebhookDialog({ webhook, onClose, onDeleted }: Pro
             type="button"
             variant="danger"
             disabled={isLoading}
-            onClick={handleConfirm}
+            onClick={() => void handleConfirm()}
             data-testid="confirm-delete-button"
           >
             {translations['DeleteWebhookDialog.confirm']}

--- a/src/extensions/Workspace/components/WorkspaceSwitcher.tsx
+++ b/src/extensions/Workspace/components/WorkspaceSwitcher.tsx
@@ -21,7 +21,7 @@ const WorkspaceSwitcher = ({ onSwitch }: WorkspaceSwitcherProps) => {
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const workspaceId = e.target.value;
     if (workspaceId) {
-      dispatch(fetchWorkspace({ workspaceId }));
+      void dispatch(fetchWorkspace({ workspaceId }));
       onSwitch?.(workspaceId);
     }
   };


### PR DESCRIPTION
## Summary

Fixes 21 findings across 15 files across three tightly-related promise/type-safety rules:
- **`no-floating-promises`** (11): prefix fire-and-forget promise expressions with `void` (e.g. `void dispatch(refreshTokenThunk())`, `void loadPersistedMutations().then(...)`).
- **`no-misused-promises`** (5): wrap promise-returning event handlers in `void` (e.g. `onClick={() => void handleDelete()}`).
- **`no-unnecessary-type-assertion`** (5): remove redundant `as string | undefined` assertions where the `?? ''` fallback already handles undefined.

Behaviour-preserving: `void` explicitly marks intentionally-unhandled promises; removed assertions are type-identical.

## Scope

- 15 files, 21 insertions / 21 deletions
- Files: App, ResendVerificationButton, VerificationPending, BoardViewSwitcher/hooks, useHealthCheckProbe, PluginIframeContainer, StateTransitionsEditorPage, ProfilePage, WorkspaceSwitcher, ScheduleItem, BoardDeleteDialog, ListDeleteDialog, DeleteWebhookDialog, customFields/api, config

## Deliberately excluded (2 files)

`server/extensions/trelloCompat/api/members/index.ts` and `.../organizations/index.ts` have `no-unnecessary-type-assertion` findings, but removing those assertions **breaks the tsc build** (the ternary widens to `string`). This is a genuine eslint/tsc type-model conflict — eslint's parser thinks the assertion is redundant, but the real compiler proves it's necessary. Left unchanged to avoid introducing new build failures.

## Verification

- Focused lint on all 15 touched files: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **146 errors — identical to current main baseline** (no new failures)
- `bun test`: **1444 tests, identical fail identities to current main** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

All touched files are UI components/hooks with no dedicated executable UI/E2E coverage — recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.