### PR TITLE
lint: replace non-null assertions with guards (non-null-assertion batch 1)

### DIFF
--- a/server/extensions/apiToken/api/create.ts
+++ b/server/extensions/apiToken/api/create.ts
@@ -9,7 +9,14 @@ export async function handleCreateToken(req: Request): Promise<Response> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const currentUser = (req as AuthenticatedRequest).currentUser;
+  if (!currentUser) {
+    return Response.json(
+      { name: 'unauthorized', data: { message: 'Not authenticated' } },
+      { status: 401 },
+    );
+  }
+  const userId = currentUser.id;
 
   let body: { name?: string; expiresAt?: string | null };
   try {

--- a/server/extensions/healthCheck/common/validateUrl.ts
+++ b/server/extensions/healthCheck/common/validateUrl.ts
@@ -17,7 +17,7 @@ const PRIVATE_IPV4_RANGES = [
   // 10.0.0.0/8
   (parts: number[]) => parts[0] === 10,
   // 172.16.0.0/12
-  (parts: number[]) => parts[0] === 172 && parts[1]! >= 16 && parts[1]! <= 31,
+  (parts: number[]) => parts[0] === 172 && (parts[1] ?? -1) >= 16 && (parts[1] ?? -1) <= 31,
   // 192.168.0.0/16
   (parts: number[]) => parts[0] === 192 && parts[1] === 168,
   // 127.0.0.0/8 — loopback

--- a/server/extensions/mcp/http/index.ts
+++ b/server/extensions/mcp/http/index.ts
@@ -13,9 +13,18 @@ export async function mcpHttpHandler(req: Request): Promise<Response | null> {
   const authError = await authenticate(req as AuthenticatedRequest);
   if (authError) return authError;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const currentUser = (req as AuthenticatedRequest).currentUser;
+  if (!currentUser) {
+    return Response.json(
+      { name: 'unauthorized', data: { message: 'Not authenticated' } },
+      { status: 401 },
+    );
+  }
+  const userId = currentUser.id;
   // Extract the raw token so tools can make API calls as this user.
-  const token = req.headers.get('Authorization')!.slice(7);
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) throw new TypeError('Authorization header missing');
+  const token = authHeader.slice(7);
   const method = req.method.toUpperCase();
 
   // --- Initialize (POST, no session yet) ---

--- a/server/extensions/realtime/mods/rooms/subscribe.ts
+++ b/server/extensions/realtime/mods/rooms/subscribe.ts
@@ -13,14 +13,16 @@ export async function subscribeToBoard({
   ws: ServerWebSocket<WsData>;
   boardId: string;
 }): Promise<void> {
-  if (!rooms.has(boardId)) {
+  let room = rooms.get(boardId);
+  if (!room) {
     // [why] Only create the room registry after the pubsub subscription succeeds.
     // This avoids a half-initialized room if subscribeBoard throws.
     await subscriber.subscribeBoard(boardId);
-    rooms.set(boardId, new Set());
+    room = new Set();
+    rooms.set(boardId, room);
   }
 
-  rooms.get(boardId)!.add(ws);
+  room.add(ws);
   ws.data.subscribedBoards.add(boardId);
 
   const key = `presence:${boardId}:${ws.data.userId}`;

--- a/server/extensions/realtime/userChannel.ts
+++ b/server/extensions/realtime/userChannel.ts
@@ -20,10 +20,12 @@ const subscribedUsers = new Set<string>();
 /** Register a connected WebSocket under its authenticated userId. */
 export function registerUserSocket(ws: ServerWebSocket<WsData>): void {
   const { userId } = ws.data;
-  if (!userSockets.has(userId)) {
-    userSockets.set(userId, new Set());
+  let sockets = userSockets.get(userId);
+  if (!sockets) {
+    sockets = new Set();
+    userSockets.set(userId, sockets);
   }
-  userSockets.get(userId)!.add(ws);
+  sockets.add(ws);
 }
 
 /** Deregister a WebSocket from its userId entry (on close). */

--- a/server/extensions/stateTransitions/common/__tests__/errors.test.ts
+++ b/server/extensions/stateTransitions/common/__tests__/errors.test.ts
@@ -36,7 +36,9 @@ describe('stateTransitions errors', () => {
       allowedNextStates: allowed,
     });
 
-    allowed[0]!.name = 'MUTATED';
+    const first = allowed[0];
+    if (!first) throw new Error('expected allowed[0] to exist');
+    first.name = 'MUTATED';
 
     expect(error.name).toBe('StateTransitionForbiddenError');
     expect(error.allowedNextStates).toEqual([{ id: 'list-2', name: 'Doing' }]);

--- a/server/extensions/trelloCompat/middlewares/trelloAuth.ts
+++ b/server/extensions/trelloCompat/middlewares/trelloAuth.ts
@@ -33,6 +33,6 @@ export async function trelloAuth(req: Request): Promise<Response | null> {
     return TRELLO_UNAUTHORIZED();
   }
 
-  (req as AuthenticatedRequest).currentUser = (authReq as AuthenticatedRequest).currentUser!;
+  (req as AuthenticatedRequest).currentUser = user;
   return null;
 }

--- a/server/extensions/webhooks/api/create.ts
+++ b/server/extensions/webhooks/api/create.ts
@@ -28,7 +28,14 @@ export async function handleCreateWebhook(req: Request): Promise<Response> {
 
   const { label, endpointUrl, eventTypes } = body;
 
-  const userId = (req as AuthenticatedRequest).currentUser!.id;
+  const currentUser = (req as AuthenticatedRequest).currentUser;
+  if (!currentUser) {
+    return Response.json(
+      { name: 'unauthorized', data: { message: 'Not authenticated' } },
+      { status: 401 },
+    );
+  }
+  const userId = currentUser.id;
 
   if (!label || typeof label !== 'string' || label.trim() === '') {
     return Response.json(

--- a/server/mods/cache/adapters/redis.test.ts
+++ b/server/mods/cache/adapters/redis.test.ts
@@ -6,7 +6,8 @@ const describeIfRedis = REDIS_URL ? describe : describe.skip;
 
 describeIfRedis('RedisCacheAdapter', () => {
   it('implements CacheProvider interface', () => {
-    const adapter = new RedisCacheAdapter(REDIS_URL!);
+    if (!REDIS_URL) throw new Error('REDIS_URL not set');
+    const adapter = new RedisCacheAdapter(REDIS_URL);
     expect(typeof adapter.set).toBe('function');
     expect(typeof adapter.get).toBe('function');
     expect(typeof adapter.del).toBe('function');

--- a/src/extensions/Card/containers/CardModal/ActivityFeed.test.ts
+++ b/src/extensions/Card/containers/CardModal/ActivityFeed.test.ts
@@ -11,7 +11,8 @@ test('activity feed: newest item is first', async ({ page }) => {
   if (count >= 2) {
     const firstTs = await feedItems.nth(0).getAttribute('data-ts');
     const secondTs = await feedItems.nth(1).getAttribute('data-ts');
-    expect(new Date(firstTs!).getTime()).toBeGreaterThanOrEqual(new Date(secondTs!).getTime());
+    if (firstTs === null || secondTs === null) throw new Error('missing data-ts attribute');
+    expect(new Date(firstTs).getTime()).toBeGreaterThanOrEqual(new Date(secondTs).getTime());
   }
 });
 

--- a/src/extensions/OfflineDrafts/reconcile.ts
+++ b/src/extensions/OfflineDrafts/reconcile.ts
@@ -73,32 +73,36 @@ export function reconcileDrafts(
   }
 
   // Both sides have a draft — compare timestamps.
-  const localMs = new Date(local!.updatedAt).getTime();
-  const serverMs = new Date(server!.client_updated_at).getTime();
+  if (!local || !server) {
+    // Unreachable: all null cases returned above. Guard for the type system.
+    throw new Error('reconcileDrafts: expected both drafts to be present');
+  }
+  const localMs = new Date(local.updatedAt).getTime();
+  const serverMs = new Date(server.client_updated_at).getTime();
 
   // [why] Treat equal timestamps as a server win to avoid a pointless re-upload
   // and because the server's version has already been durably persisted.
   if (localMs > serverMs) {
     return {
-      contentMarkdown: local!.contentMarkdown,
-      intent: local!.intent,
-      updatedAt: local!.updatedAt,
+      contentMarkdown: local.contentMarkdown,
+      intent: local.intent,
+      updatedAt: local.updatedAt,
       source: 'local',
       // [why] Server lost — if server had a pending intent, surface it so callers can
       // warn the user that a cross-device pending action may need attention.
-      loserPendingIntent: isPendingIntent(server!.intent) ? server!.intent : null,
+      loserPendingIntent: isPendingIntent(server.intent) ? server.intent : null,
     };
   }
 
   return {
-    contentMarkdown: server!.content_markdown,
-    intent: server!.intent,
-    updatedAt: server!.client_updated_at,
+    contentMarkdown: server.content_markdown,
+    intent: server.intent,
+    updatedAt: server.client_updated_at,
     source: 'server',
     // [why] Local lost — if local had a pending action (save_pending / submit_pending),
     // the user's offline work was overwritten by a newer server draft. Surface this
     // so callers can show a conflict warning ("Retry Save" / "Retry Post").
-    loserPendingIntent: isPendingIntent(local!.intent) ? local!.intent : null,
+    loserPendingIntent: isPendingIntent(local.intent) ? local.intent : null,
   };
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,12 +17,12 @@ export default defineConfig({
     react(),
     // Upload source maps to Sentry during deploy builds only.
     // When sentryUploadEnabled is false the plugin is omitted entirely — no network calls.
-    ...(sentryUploadEnabled
+    ...(sentryUploadEnabled && sentryAuthToken && sentryOrg && sentryProject
       ? [
           sentryVitePlugin({
-            org: sentryOrg!,
-            project: sentryProject!,
-            authToken: sentryAuthToken!,
+            org: sentryOrg,
+            project: sentryProject,
+            authToken: sentryAuthToken,
             // Tie uploaded source maps to the same release tag used by the SDK at runtime.
             // Only set when a release identifier is available to avoid a blank tag.
             ...(sentryRelease ? { release: { name: sentryRelease } } : {}),


### PR DESCRIPTION
## Summary

Fixes 28 `@typescript-eslint/no-non-null-assertion` findings across 12 files. Each `!` is replaced with a behaviour-preserving guard:
- **`currentUser!.id`** (apiToken/create, mcp/http, webhooks/create): added `if (!currentUser) return 401` guard — the `authenticate` middleware guarantees `currentUser` is set when it returns no error, so this is unreachable but type-safe.
- **`rooms.get(boardId)!` / `userSockets.get(userId)!`** (subscribe, userChannel): refactored to capture the set in a local, guard on null, then use the local — same behaviour.
- **`parts[1]!`** (validateUrl): `(parts[1] ?? -1)` — undefined → -1 → comparison false, same as before.
- **`currentUser!`** (trelloAuth): replaced with the already-narrowed `user` local.
- **`local!` / `server!`** (reconcile): added an unreachable `throw` guard (equivalent to the `!` TypeError).
- **`allowed[0]!`** (errors.test): added a throw guard.
- **`sentryOrg!` / `sentryProject!` / `sentryAuthToken!`** (vite.config): added the guards to the `sentryUploadEnabled` condition so the plugin is only included when all three are set — safer, same normal-case behaviour.
- **`REDIS_URL!`** (redis.test): the test is `describe.skip`'d when REDIS_URL is unset, so the `!` is safe; replaced with a guard.

Behaviour-preserving: the `!` operator threw a TypeError on null; the guards throw/return equivalently.

## Scope

- Rule family: `@typescript-eslint/no-non-null-assertion`
- 12 files, 64 insertions / 29 deletions
- Files: apiToken/create, validateUrl, mcp/http, subscribe, userChannel, errors.test, trelloAuth, webhooks/create, redis.test, ActivityFeed.test, reconcile, vite.config

## Verification

- Focused lint on all 12 touched files: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **146 errors — identical to current main baseline** (no new failures)
- `bun test`: **1444 tests, identical fail identities to current main** (pre-existing 180 fail / 30 errors baseline, no new failures)
- Focused tests on touched test files: errors.test passes; redis.test is `describe.skip`'d (no REDIS_URL); ActivityFeed.test's 1 fail is pre-existing (verified identical on base main)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

Most touched files are server handlers/hooks with no dedicated executable UI/E2E coverage — recorded as **missing**, not claimed as passed. The 3 touched test files are their own executable coverage.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.