### PR TITLE
lint: await mock.module calls in tests (floating-promises batch 1)

### DIFF
--- a/server/extensions/activity/mods/__tests__/createActivityEvent.test.ts
+++ b/server/extensions/activity/mods/__tests__/createActivityEvent.test.ts
@@ -13,31 +13,31 @@ const mapActivityToNotificationMock = mock(() => Promise.resolve());
 const getActiveWebhooksForEventMock = mock(async () => []);
 const dispatchWebhookMock = mock(() => Promise.resolve());
 
-mock.module('../write', () => ({
+await mock.module('../write', () => ({
   writeActivity: writeActivityMock,
 }));
 
-mock.module('../../events/publishCardActivityEvent', () => ({
+await mock.module('../../events/publishCardActivityEvent', () => ({
   publishCardActivityEvent: publishCardActivityEventMock,
 }));
 
-mock.module('../mapActivityToNotification', () => ({
+await mock.module('../mapActivityToNotification', () => ({
   mapActivityToNotification: mapActivityToNotificationMock,
 }));
 
-mock.module('../../../common/db', () => ({
+await mock.module('../../../common/db', () => ({
   db: mock(() => ({})),
 }));
 
-mock.module('../../../config/env', () => ({
+await mock.module('../../../config/env', () => ({
   env: { WEBHOOKS_ENABLED: false },
 }));
 
-mock.module('../../webhooks/mods/registry', () => ({
+await mock.module('../../webhooks/mods/registry', () => ({
   getActiveWebhooksForEvent: getActiveWebhooksForEventMock,
 }));
 
-mock.module('../../webhooks/mods/dispatch', () => ({
+await mock.module('../../webhooks/mods/dispatch', () => ({
   dispatchWebhook: dispatchWebhookMock,
 }));
 

--- a/server/extensions/presence/mods/expiryJob.test.ts
+++ b/server/extensions/presence/mods/expiryJob.test.ts
@@ -4,7 +4,7 @@ import { runExpiryCheck, setActiveBoardIds } from './expiryJob';
 
 // Mock the cache module
 const cacheKeys: Record<string, string[]> = {};
-mock.module('../../../mods/cache/index', () => ({
+await mock.module('../../../mods/cache/index', () => ({
   cache: {
     keys: async (pattern: string) => {
       // Pattern is "presence:<boardId>:*" — return stored keys
@@ -20,14 +20,14 @@ mock.module('../../../mods/cache/index', () => ({
 
 // Mock broadcastPresenceUpdate
 const broadcasts: Array<{ boardId: string; action: string; userId: string }> = [];
-mock.module('../api/presenceUpdate', () => ({
+await mock.module('../api/presenceUpdate', () => ({
   broadcastPresenceUpdate: async (args: { boardId: string; action: string; userId: string }) => {
     broadcasts.push(args);
   },
 }));
 
 // Mock db (not used by expiryJob directly — broadcastPresenceUpdate is mocked)
-mock.module('../../../common/db', () => ({ db: () => {} }));
+await mock.module('../../../common/db', () => ({ db: () => {} }));
 
 describe('runExpiryCheck', () => {
   beforeEach(() => {

--- a/server/extensions/stateTransitions/__tests__/getRules.test.ts
+++ b/server/extensions/stateTransitions/__tests__/getRules.test.ts
@@ -105,28 +105,28 @@ function resetStore(): DataStore {
   };
 }
 
-mock.module('../../../config/featureFlags', () => ({
+await mock.module('../../../config/featureFlags', () => ({
   featureFlags: {
     STATE_TRANSITIONS_ENABLED: true,
   },
 }));
 
-mock.module('../../../common/db', () => ({
+await mock.module('../../../common/db', () => ({
   db: ((tableName: keyof DataStore) => new QueryBuilder(dataStore, tableName)) as unknown as typeof import('../../../common/db').db,
 }));
 
-mock.module('../../auth/middlewares/authentication', () => ({
+await mock.module('../../auth/middlewares/authentication', () => ({
   authenticate: async (req: Request & { currentUser?: { id: string; email: string } }) => {
     req.currentUser = { id: 'user-1', email: 'user@example.com' };
     return null;
   },
 }));
 
-mock.module('../../../middlewares/permissionManager', () => ({
+await mock.module('../../../middlewares/permissionManager', () => ({
   requireWorkspaceMembership: async () => null,
 }));
 
-mock.module('../../../common/uuid', () => ({
+await mock.module('../../../common/uuid', () => ({
   generateId: () => 'state-transition-1',
 }));
 

--- a/server/extensions/stateTransitions/__tests__/put.test.ts
+++ b/server/extensions/stateTransitions/__tests__/put.test.ts
@@ -107,24 +107,24 @@ function resetStore(): DataStore {
   };
 }
 
-mock.module('../../../config/featureFlags', () => ({
+await mock.module('../../../config/featureFlags', () => ({
   featureFlags: {
     STATE_TRANSITIONS_ENABLED: true,
   },
 }));
 
-mock.module('../../../common/db', () => ({
+await mock.module('../../../common/db', () => ({
   db: ((tableName: keyof DataStore) => new QueryBuilder(dataStore, tableName)) as unknown as typeof import('../../../common/db').db,
 }));
 
-mock.module('../../auth/middlewares/authentication', () => ({
+await mock.module('../../auth/middlewares/authentication', () => ({
   authenticate: async (req: Request & { currentUser?: { id: string; email: string } }) => {
     req.currentUser = { id: 'user-admin', email: 'admin@example.com' };
     return null;
   },
 }));
 
-mock.module('../../board/middlewares/requireBoardWritable', () => ({
+await mock.module('../../board/middlewares/requireBoardWritable', () => ({
   requireBoardWritable: async (
     req: Request & { board?: { id: string; workspace_id: string } },
     boardId: string,
@@ -138,18 +138,18 @@ mock.module('../../board/middlewares/requireBoardWritable', () => ({
   },
 }));
 
-mock.module('../../../middlewares/permissionManager', () => ({
+await mock.module('../../../middlewares/permissionManager', () => ({
   requireWorkspaceMembership: async () => null,
   requireRole: () => null,
 }));
 
-mock.module('../../../mods/pubsub/publisher', () => ({
+await mock.module('../../../mods/pubsub/publisher', () => ({
   publisher: {
     publish: publishMock,
   },
 }));
 
-mock.module('../../../common/uuid', () => ({
+await mock.module('../../../common/uuid', () => ({
   generateId: () => 'state-transition-1',
 }));
 

--- a/server/extensions/stateTransitions/api/__tests__/copy.test.ts
+++ b/server/extensions/stateTransitions/api/__tests__/copy.test.ts
@@ -155,7 +155,7 @@ function resetStore(): DataStore {
   };
 }
 
-mock.module('../../../../config/featureFlags', () => ({
+await mock.module('../../../../config/featureFlags', () => ({
   featureFlags: {
     get STATE_TRANSITIONS_ENABLED() {
       return stateTransitionsEnabled;
@@ -163,18 +163,18 @@ mock.module('../../../../config/featureFlags', () => ({
   },
 }));
 
-mock.module('../../../../common/db', () => ({
+await mock.module('../../../../common/db', () => ({
   db: ((tableName: keyof DataStore) => new QueryBuilder(dataStore, tableName)) as unknown as typeof import('../../../../common/db').db,
 }));
 
-mock.module('../../../auth/middlewares/authentication', () => ({
+await mock.module('../../../auth/middlewares/authentication', () => ({
   authenticate: async (req: Request & { currentUser?: { id: string; email: string } }) => {
     req.currentUser = { id: currentUserId, email: 'admin@example.com' };
     return null;
   },
 }));
 
-mock.module('../../../../common/uuid', () => ({
+await mock.module('../../../../common/uuid', () => ({
   generateId: () => 'generated-st-id',
 }));
 

--- a/server/extensions/stateTransitions/api/__tests__/get.test.ts
+++ b/server/extensions/stateTransitions/api/__tests__/get.test.ts
@@ -109,7 +109,7 @@ function resetStore(): DataStore {
   };
 }
 
-mock.module('../../../../config/featureFlags', () => ({
+await mock.module('../../../../config/featureFlags', () => ({
   featureFlags: {
     get STATE_TRANSITIONS_ENABLED() {
       return stateTransitionsEnabled;
@@ -117,22 +117,22 @@ mock.module('../../../../config/featureFlags', () => ({
   },
 }));
 
-mock.module('../../../../common/db', () => ({
+await mock.module('../../../../common/db', () => ({
   db: ((tableName: keyof DataStore) => new QueryBuilder(dataStore, tableName)) as unknown as typeof import('../../../../common/db').db,
 }));
 
-mock.module('../../../auth/middlewares/authentication', () => ({
+await mock.module('../../../auth/middlewares/authentication', () => ({
   authenticate: async (req: Request & { currentUser?: { id: string; email: string } }) => {
     req.currentUser = { id: 'user-1', email: 'user@example.com' };
     return null;
   },
 }));
 
-mock.module('../../../../middlewares/permissionManager', () => ({
+await mock.module('../../../../middlewares/permissionManager', () => ({
   requireWorkspaceMembership: async () => null,
 }));
 
-mock.module('../../../../common/uuid', () => ({
+await mock.module('../../../../common/uuid', () => ({
   generateId: () => 'state-transition-generated',
 }));
 

--- a/server/extensions/stateTransitions/api/__tests__/getRules.test.ts
+++ b/server/extensions/stateTransitions/api/__tests__/getRules.test.ts
@@ -112,7 +112,7 @@ function resetStore(): DataStore {
   };
 }
 
-mock.module('../../../../config/featureFlags', () => ({
+await mock.module('../../../../config/featureFlags', () => ({
   featureFlags: {
     get STATE_TRANSITIONS_ENABLED() {
       return stateTransitionsEnabled;
@@ -120,22 +120,22 @@ mock.module('../../../../config/featureFlags', () => ({
   },
 }));
 
-mock.module('../../../../common/db', () => ({
+await mock.module('../../../../common/db', () => ({
   db: ((tableName: keyof DataStore) => new QueryBuilder(dataStore, tableName)) as unknown as typeof import('../../../../common/db').db,
 }));
 
-mock.module('../../../auth/middlewares/authentication', () => ({
+await mock.module('../../../auth/middlewares/authentication', () => ({
   authenticate: async (req: Request & { currentUser?: { id: string; email: string } }) => {
     req.currentUser = { id: 'user-1', email: 'user@example.com' };
     return null;
   },
 }));
 
-mock.module('../../../../middlewares/permissionManager', () => ({
+await mock.module('../../../../middlewares/permissionManager', () => ({
   requireWorkspaceMembership: async () => workspaceMembershipError,
 }));
 
-mock.module('../../../../common/uuid', () => ({
+await mock.module('../../../../common/uuid', () => ({
   generateId: () => 'state-transition-1',
 }));
 

--- a/server/extensions/stateTransitions/api/__tests__/index.test.ts
+++ b/server/extensions/stateTransitions/api/__tests__/index.test.ts
@@ -7,7 +7,7 @@ const getCalls: string[] = [];
 const putCalls: string[] = [];
 const rulesCalls: string[] = [];
 
-mock.module('../../../../config/featureFlags', () => ({
+await mock.module('../../../../config/featureFlags', () => ({
   featureFlags: {
     get STATE_TRANSITIONS_ENABLED() {
       return stateTransitionsEnabled;
@@ -15,29 +15,29 @@ mock.module('../../../../config/featureFlags', () => ({
   },
 }));
 
-mock.module('../../../../middlewares/boardVisibility', () => ({
+await mock.module('../../../../middlewares/boardVisibility', () => ({
   applyBoardVisibility: async () => visibilityError,
 }));
 
-mock.module('../../../../common/ids/resolveEntityId', () => ({
+await mock.module('../../../../common/ids/resolveEntityId', () => ({
   resolveBoardId: async () => resolvedBoardId,
 }));
 
-mock.module('../get', () => ({
+await mock.module('../get', () => ({
   handleGetStateTransitions: async (_req: Request, boardId: string) => {
     getCalls.push(boardId);
     return Response.json({ data: { boardId } }, { status: 200 });
   },
 }));
 
-mock.module('../put', () => ({
+await mock.module('../put', () => ({
   handlePutStateTransitions: async (_req: Request, boardId: string) => {
     putCalls.push(boardId);
     return Response.json({ data: { boardId } }, { status: 200 });
   },
 }));
 
-mock.module('../getRules', () => ({
+await mock.module('../getRules', () => ({
   handleGetStateTransitionRules: async (_req: Request, boardId: string) => {
     rulesCalls.push(boardId);
     return Response.json({ data: { boardId, rules: [] } }, { status: 200 });

--- a/server/extensions/stateTransitions/api/__tests__/put_list_sync.test.ts
+++ b/server/extensions/stateTransitions/api/__tests__/put_list_sync.test.ts
@@ -121,24 +121,24 @@ function resetStore(): DataStore {
   };
 }
 
-mock.module('../../../../config/featureFlags', () => ({
+await mock.module('../../../../config/featureFlags', () => ({
   featureFlags: {
     STATE_TRANSITIONS_ENABLED: true,
   },
 }));
 
-mock.module('../../../../common/db', () => ({
+await mock.module('../../../../common/db', () => ({
   db: ((tableName: keyof DataStore) => new QueryBuilder(dataStore, tableName)) as unknown as typeof import('../../../../common/db').db,
 }));
 
-mock.module('../../../auth/middlewares/authentication', () => ({
+await mock.module('../../../auth/middlewares/authentication', () => ({
   authenticate: async (req: Request & { currentUser?: { id: string; email: string } }) => {
     req.currentUser = { id: 'actor-1', email: 'actor@example.com' };
     return null;
   },
 }));
 
-mock.module('../../../board/middlewares/requireBoardWritable', () => ({
+await mock.module('../../../board/middlewares/requireBoardWritable', () => ({
   requireBoardWritable: async (
     req: Request & { board?: { id: string; workspace_id: string } },
     boardId: string,
@@ -148,12 +148,12 @@ mock.module('../../../board/middlewares/requireBoardWritable', () => ({
   },
 }));
 
-mock.module('../../../../middlewares/permissionManager', () => ({
+await mock.module('../../../../middlewares/permissionManager', () => ({
   requireWorkspaceMembership: async () => null,
   requireRole: () => null,
 }));
 
-mock.module('../../../../mods/pubsub/publisher', () => ({
+await mock.module('../../../../mods/pubsub/publisher', () => ({
   publisher: {
     publish: async () => null,
   },

--- a/server/extensions/stateTransitions/api/__tests__/put_sync_hooks.test.ts
+++ b/server/extensions/stateTransitions/api/__tests__/put_sync_hooks.test.ts
@@ -134,7 +134,7 @@ function resetStore(): DataStore {
   };
 }
 
-mock.module('../../../../config/featureFlags', () => ({
+await mock.module('../../../../config/featureFlags', () => ({
   featureFlags: {
     get STATE_TRANSITIONS_ENABLED() {
       return stateTransitionsEnabled;
@@ -142,18 +142,18 @@ mock.module('../../../../config/featureFlags', () => ({
   },
 }));
 
-mock.module('../../../../common/db', () => ({
+await mock.module('../../../../common/db', () => ({
   db: ((tableName: keyof DataStore) => new QueryBuilder(dataStore, tableName)) as unknown as typeof import('../../../../common/db').db,
 }));
 
-mock.module('../../../auth/middlewares/authentication', () => ({
+await mock.module('../../../auth/middlewares/authentication', () => ({
   authenticate: async (req: Request & { currentUser?: { id: string; email: string } }) => {
     req.currentUser = { id: 'user-admin', email: 'admin@example.com' };
     return null;
   },
 }));
 
-mock.module('../../../board/middlewares/requireBoardWritable', () => ({
+await mock.module('../../../board/middlewares/requireBoardWritable', () => ({
   requireBoardWritable: async (
     req: Request & { board?: { id: string; workspace_id: string } },
     boardId: string,
@@ -163,12 +163,12 @@ mock.module('../../../board/middlewares/requireBoardWritable', () => ({
   },
 }));
 
-mock.module('../../../../middlewares/permissionManager', () => ({
+await mock.module('../../../../middlewares/permissionManager', () => ({
   requireWorkspaceMembership: async () => null,
   requireRole: () => null,
 }));
 
-mock.module('../../../../mods/pubsub/publisher', () => ({
+await mock.module('../../../../mods/pubsub/publisher', () => ({
   publisher: {
     publish: publishMock,
   },

--- a/server/extensions/stateTransitions/common/__tests__/integration_list_sync.test.ts
+++ b/server/extensions/stateTransitions/common/__tests__/integration_list_sync.test.ts
@@ -152,38 +152,38 @@ function resetStore(): DataStore {
   };
 }
 
-mock.module('../../../../common/db', () => ({
+await mock.module('../../../../common/db', () => ({
   db: ((tableName: keyof DataStore) => new QueryBuilder(dataStore, tableName)) as unknown as typeof import('../../../../common/db').db,
 }));
 
-mock.module('../../../auth/middlewares/authentication', () => ({
+await mock.module('../../../auth/middlewares/authentication', () => ({
   authenticate: async (req: Request & { currentUser?: { id: string; email: string } }) => {
     req.currentUser = { id: 'user-1', email: 'user@example.com' };
     return null;
   },
 }));
 
-mock.module('../../../../middlewares/permissionManager', () => ({
+await mock.module('../../../../middlewares/permissionManager', () => ({
   requireWorkspaceMembership: async () => null,
   requireRole: () => null,
 }));
 
-mock.module('../../../board/middlewares/requireBoardWritable', () => ({
+await mock.module('../../../board/middlewares/requireBoardWritable', () => ({
   requireBoardWritable: async (req: Request & { board?: { id: string; workspace_id: string } }, boardId: string) => {
     req.board = { id: boardId, workspace_id: 'ws-1' };
     return null;
   },
 }));
 
-mock.module('../../../../mods/events/write', () => ({
+await mock.module('../../../../mods/events/write', () => ({
   writeEvent: async () => null,
 }));
 
-mock.module('../../../../common/sanitize', () => ({
+await mock.module('../../../../common/sanitize', () => ({
   sanitizeText: (value: string) => value,
 }));
 
-mock.module('../../../../config/featureFlags', () => ({
+await mock.module('../../../../config/featureFlags', () => ({
   featureFlags: {
     STATE_TRANSITIONS_ENABLED: true,
   },

--- a/server/extensions/stateTransitions/enforcement/__tests__/rules.test.ts
+++ b/server/extensions/stateTransitions/enforcement/__tests__/rules.test.ts
@@ -111,7 +111,7 @@ function resetStore(): DataStore {
   };
 }
 
-mock.module('../../../../common/db', () => ({
+await mock.module('../../../../common/db', () => ({
   db: ((tableName: keyof DataStore) => new QueryBuilder(dataStore, tableName)) as unknown as typeof import('../../../../common/db').db,
 }));
 


### PR DESCRIPTION
## Summary

Fixes 62 `@typescript-eslint/no-floating-promises` findings across 12 test files. Bun's `mock.module()` returns a promise that must be awaited at module scope. Each `mock.module(...)` call is prefixed with `await` so the mock is correctly registered before tests run.

Behaviour-preserving: the mock is now correctly awaited before the test suite executes.

## Scope

- Rule family: `@typescript-eslint/no-floating-promises`
- 12 test files, 62 insertions / 62 deletions
- Files: stateTransitions `__tests__` (put, getRules), stateTransitions `api/__tests__` (get, getRules, copy, index, put_list_sync, put_sync_hooks), stateTransitions `common/__tests__` (integration_list_sync), stateTransitions `enforcement/__tests__` (rules), activity `mods/__tests__` (createActivityEvent), presence `mods` (expiryJob)

## Verification

- Focused lint on all 12 touched files: **0 findings** (exit 0)
- `bun run typecheck`: exit 2, **146 errors — identical to current main baseline** (no new failures)
- `bun test`: **1444 tests, identical fail identities to current main** (pre-existing 180 fail / 30 errors baseline, no new failures)
- Focused tests on all 12 touched test files: pass (or identical pre-existing baseline failures, verified against base main)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

All touched files are server test files — they are their own executable coverage and pass.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.