### PR TITLE
lint: wrap promise-returning handlers in void (misused-promises batch 1)

### DIFF
--- a/server/extensions/automation/scheduler/listener.ts
+++ b/server/extensions/automation/scheduler/listener.ts
@@ -32,7 +32,8 @@ async function connect(): Promise<void> {
 
     console.info('[automation-listener] connected, listening on automation_tick');
 
-    client.on('notification', async (msg) => {
+    client.on('notification', (msg) => {
+      void (async () => {
       if (msg.channel !== 'automation_tick') return;
       try {
         const { type, automationId, boardId, cardId } = JSON.parse(msg.payload ?? '{}');
@@ -41,12 +42,15 @@ async function connect(): Promise<void> {
       } catch (err) {
         console.error('[automation-listener] notification parse/execute error', err);
       }
+      })();
     });
 
-    client.on('error', async (err) => {
+    client.on('error', (err) => {
+      void (async () => {
       console.error('[automation-listener] client error, scheduling reconnect', err);
       await client.end().catch(() => {});
       scheduleReconnect();
+      })();
     });
   } catch (err) {
     console.error('[automation-listener] connect failed, scheduling reconnect', err);

--- a/server/extensions/plugins/sdk/jh-instance.ts
+++ b/server/extensions/plugins/sdk/jh-instance.ts
@@ -220,7 +220,8 @@ type CapabilityHandler = (t: FrameContext, options?: unknown) => unknown | Promi
 
 const capabilityHandlers = new Map<string, CapabilityHandler>();
 
-window.addEventListener('message', async (event: MessageEvent) => {
+window.addEventListener('message', (event: MessageEvent) => {
+  void (async () => {
   const data = event.data as PostMessageRequest & { capability?: string; options?: unknown };
   if (!data || !data.jhSdk || data.type !== 'CAPABILITY_INVOKE') return;
 
@@ -244,11 +245,13 @@ window.addEventListener('message', async (event: MessageEvent) => {
       '*',
     );
   }
+  })();
 });
 
 // Handle BUTTON_CLICKED — host dispatches this when a button registered by a plugin is clicked.
 // Look up the callback by its opaque ID and invoke it with a fresh FrameContext.
-window.addEventListener('message', async (event: MessageEvent) => {
+window.addEventListener('message', (event: MessageEvent) => {
+  void (async () => {
   const data = event.data as PostMessageRequest & { payload?: { callbackId?: string; args?: Record<string, unknown> } };
   if (!data || !data.jhSdk || data.type !== 'BUTTON_CLICKED') return;
 
@@ -265,6 +268,7 @@ window.addEventListener('message', async (event: MessageEvent) => {
     // Swallow errors so a broken plugin callback can't crash the SDK
     console.error('[jhInstance] BUTTON_CLICKED callback error:', err);
   }
+  })();
 });
 
 // ────────────────────────────────────────────────────────────────────

--- a/src/extensions/ApiToken/containers/ApiTokenPage/ApiTokenPage.tsx
+++ b/src/extensions/ApiToken/containers/ApiTokenPage/ApiTokenPage.tsx
@@ -124,7 +124,7 @@ export default function ApiTokenPage() {
 
       {showGenerate && (
         <GenerateTokenModal
-          onSubmit={handleGenerate}
+          onSubmit={(body) => void handleGenerate(body)}
           onCancel={() => setShowGenerate(false)}
           isLoading={isCreating}
         />
@@ -140,7 +140,7 @@ export default function ApiTokenPage() {
       {revokeTarget && (
         <RevokeTokenDialog
           tokenName={revokeTarget.name}
-          onConfirm={handleRevoke}
+          onConfirm={() => void handleRevoke()}
           onCancel={() => setRevokeTarget(null)}
           isLoading={isRevoking}
         />

--- a/src/extensions/Attachment/components/AttachmentSection.tsx
+++ b/src/extensions/Attachment/components/AttachmentSection.tsx
@@ -65,7 +65,7 @@ export function AttachmentSection({ cardId, authToken, apiBase = '' }: Props): R
     <section style={{ marginTop: 16 }}>
       <h4 style={{ fontSize: 14, marginBottom: 8 }}>{translations['attachment.section.title']}</h4>
       {attachments.map((a) => (
-        <AttachmentItem key={a.id} attachment={a} onDelete={handleDelete} onDownload={handleDownload} />
+        <AttachmentItem key={a.id} attachment={a} onDelete={(id) => void handleDelete(id)} onDownload={(id) => void handleDownload(id)} />
       ))}
       <AttachmentUploader cardId={cardId} onUploadComplete={handleUploadComplete} />
       <button

--- a/src/extensions/Attachments/components/AttachmentPanel.tsx
+++ b/src/extensions/Attachments/components/AttachmentPanel.tsx
@@ -278,7 +278,8 @@ export function AttachmentPanel({ cardId, canWrite = true, insertMarkdownRef, on
     if (!internal) return;
 
     setDetectingCard(true);
-    detectTimerRef.current = setTimeout(async () => {
+    detectTimerRef.current = setTimeout(() => {
+      void (async () => {
       try {
         const res = await fetchCardPreview({ cardId: internal.cardId });
         const card: CardPreview = {
@@ -298,6 +299,7 @@ export function AttachmentPanel({ cardId, canWrite = true, insertMarkdownRef, on
       } finally {
         setDetectingCard(false);
       }
+      })();
     }, 400);
   };
 
@@ -359,7 +361,7 @@ export function AttachmentPanel({ cardId, canWrite = true, insertMarkdownRef, on
         ]}
       >
       {/* Invisible paste listener — only active when the user can write */}
-      <PasteListener enabled={canWrite} onFiles={upload} onLink={handlePasteLink} />
+      <PasteListener enabled={canWrite} onFiles={upload} onLink={(url) => void handlePasteLink(url)} />
 
       {/* Hidden file input — accept covers all server-allowed types; server re-validates */}
       {canWrite && (
@@ -445,8 +447,8 @@ export function AttachmentPanel({ cardId, canWrite = true, insertMarkdownRef, on
             key={attachment.id}
             attachment={attachment}
             uploadProgress={progressForAttachment(attachment.id)}
-            onDelete={handleDelete}
-            onRename={handleRename}
+            onDelete={(id) => void handleDelete(id)}
+            onRename={(id, alias) => void handleRename(id, alias)}
             {...(insertMarkdownRef ? { onInsertComment: handleInsertComment } : {})}
           />
         ))}
@@ -467,7 +469,7 @@ export function AttachmentPanel({ cardId, canWrite = true, insertMarkdownRef, on
                   card={attachment.referenced_card}
                   cardUrl={attachment.view_url ?? attachment.external_url ?? ''}
                   canWrite={canWrite}
-                  onDelete={handleDelete}
+                  onDelete={(id) => void handleDelete(id)}
                 />
               ) : null,
             )}
@@ -487,7 +489,7 @@ export function AttachmentPanel({ cardId, canWrite = true, insertMarkdownRef, on
                 key={attachment.id}
                 attachment={attachment}
                 canWrite={canWrite}
-                onDelete={handleDelete}
+                onDelete={(id) => void handleDelete(id)}
                 onRename={(id: string, alias: string) => { void handleRename(id, alias); }}
                 onUpdateUrl={(id: string, url: string) => { void handleUpdateUrl(id, url); }}
               />
@@ -503,7 +505,7 @@ export function AttachmentPanel({ cardId, canWrite = true, insertMarkdownRef, on
         <div className="mt-3 pb-4">
           {showLinkForm ? (
             <form
-              onSubmit={handleLinkSubmit}
+              onSubmit={(e) => void handleLinkSubmit(e)}
               className="space-y-2"
               data-testid="link-form"
             >

--- a/src/extensions/Automation/components/AutomationPanel/AutomationList.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/AutomationList.tsx
@@ -109,7 +109,7 @@ const AutomationRow = ({ boardId, automation, onEdit, onDeleted, onToggled }: Ro
           className={`rounded p-1 transition-colors ${
             toggling ? 'opacity-50 cursor-not-allowed' : 'hover:bg-bg-overlay'
           } ${automation.isEnabled ? 'text-emerald-400' : 'text-muted'}`}
-          onClick={handleToggle}
+          onClick={() => void handleToggle()}
           disabled={toggling}
           aria-label={automation.isEnabled ? translations['automation.list.row.disableAriaLabel'] : translations['automation.list.row.enableAriaLabel']}
           title={automation.isEnabled ? translations['automation.list.row.disableTitle'] : translations['automation.list.row.enableTitle']}
@@ -138,7 +138,7 @@ const AutomationRow = ({ boardId, automation, onEdit, onDeleted, onToggled }: Ro
               ? 'bg-danger text-white hover:opacity-90' // [theme-exception] text-white on danger active state
               : 'text-muted hover:bg-bg-overlay hover:text-danger'
           } ${deleting ? 'opacity-50 cursor-not-allowed' : ''}`}
-          onClick={handleDelete}
+          onClick={() => void handleDelete()}
           disabled={deleting}
           aria-label={confirmDelete ? translations['automation.list.row.confirmDeleteAriaLabel'] : translations['automation.list.row.deleteAriaLabel']}
           title={confirmDelete ? translations['automation.list.row.confirmDeleteTitle'] : translations['automation.list.row.deleteTitle']}

--- a/src/extensions/Automation/components/AutomationPanel/ButtonsTab.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/ButtonsTab.tsx
@@ -107,7 +107,7 @@ const ButtonRow: FC<ButtonRowProps> = ({ boardId, automation, onEdited, onDelete
         <button
           type="button"
           disabled={toggling}
-          onClick={handleToggle}
+          onClick={() => void handleToggle()}
           className="flex-shrink-0 rounded p-1 text-muted hover:text-subtle disabled:opacity-50 transition-colors"
           aria-label={automation.isEnabled ? translations['automation.buttonsTab.row.disableAriaLabel'] : translations['automation.buttonsTab.row.enableAriaLabel']}
           title={automation.isEnabled ? translations['automation.buttonsTab.row.enableTitle'] : translations['automation.buttonsTab.row.disableTitle']}
@@ -135,7 +135,7 @@ const ButtonRow: FC<ButtonRowProps> = ({ boardId, automation, onEdited, onDelete
             <button
               type="button"
               disabled={deleting}
-              onClick={handleDelete}
+              onClick={() => void handleDelete()}
               className="text-xs rounded px-2 py-0.5 bg-danger text-white hover:opacity-90 disabled:opacity-50 transition-colors" // [theme-exception] text-white on danger button
             >
               {deleting ? translations['automation.buttonsTab.row.deleting'] : translations['automation.buttonsTab.row.delete']}

--- a/src/extensions/Automation/components/AutomationPanel/index.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/index.tsx
@@ -139,7 +139,7 @@ const AutomationPanel = ({ boardId, isOpen, activeTab, onClose, onTabChange }: P
                   <p className="text-sm text-danger">{error}</p>
                   <button
                     className="mt-2 text-xs text-blue-400 hover:underline"
-                    onClick={loadAutomations}
+                    onClick={() => void loadAutomations()}
                   >
                     {translations['automation.panel.retry']}
                   </button>
@@ -152,7 +152,7 @@ const AutomationPanel = ({ boardId, isOpen, activeTab, onClose, onTabChange }: P
                   initialAutomation={editingRule}
                   onSaved={() => {
                     setEditingRule(null);
-                    loadAutomations();
+                    void loadAutomations();
                   }}
                   onCancel={() => setEditingRule(null)}
                 />
@@ -163,7 +163,7 @@ const AutomationPanel = ({ boardId, isOpen, activeTab, onClose, onTabChange }: P
                   boardId={boardId}
                   onSaved={() => {
                     setEditingRule(null);
-                    loadAutomations();
+                    void loadAutomations();
                   }}
                   onCancel={() => setEditingRule(null)}
                 />
@@ -177,7 +177,7 @@ const AutomationPanel = ({ boardId, isOpen, activeTab, onClose, onTabChange }: P
                   automations={automations}
                   onCreateRule={() => setEditingRule(undefined)}
                   onEditRule={(a) => setEditingRule(a)}
-                  onChanged={loadAutomations}
+                  onChanged={() => void loadAutomations()}
                 />
               )}
             </>
@@ -186,14 +186,14 @@ const AutomationPanel = ({ boardId, isOpen, activeTab, onClose, onTabChange }: P
             <ButtonsTab
               boardId={boardId}
               automations={automations}
-              onChanged={loadAutomations}
+              onChanged={() => void loadAutomations()}
             />
           )}
           {activeTab === 'schedule' && (
             <SchedulePanel
               boardId={boardId}
               automations={automations}
-              onChanged={loadAutomations}
+              onChanged={() => void loadAutomations()}
             />
           )}
           {activeTab === 'log' && <LogPanel boardId={boardId} automations={automations} />}

--- a/src/extensions/Board/components/BoardMembersPanel/GuestsTab.tsx
+++ b/src/extensions/Board/components/BoardMembersPanel/GuestsTab.tsx
@@ -85,7 +85,7 @@ const GuestsTab = ({ boardId, isAdmin }: Props) => {
           <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted">
             Invite guest by email
           </p>
-          <form onSubmit={handleInvite} className="flex gap-2">
+          <form onSubmit={(e) => void handleInvite(e)} className="flex gap-2">
             <input
               type="email"
               value={email}
@@ -208,7 +208,7 @@ const GuestsTab = ({ boardId, isAdmin }: Props) => {
                     {isAdmin && (
                       <button
                         type="button"
-                        onClick={() => handleRevoke(guest)}
+                        onClick={() => void handleRevoke(guest)}
                         className="rounded px-2 py-1 text-xs text-muted hover:bg-bg-overlay hover:text-danger transition-colors"
                         aria-label={`Remove guest ${guest.name ?? guest.email}`}
                       >

--- a/src/extensions/Board/components/BoardMembersPanel/index.tsx
+++ b/src/extensions/Board/components/BoardMembersPanel/index.tsx
@@ -232,7 +232,7 @@ const BoardMembersPanel = ({ onClose, isGuest = false }: Props) => {
                   <button
                     type="button"
                     disabled={isJoining}
-                    onClick={handleJoin}
+                    onClick={() => void handleJoin()}
                     className="rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-inverse hover:bg-primary-hover disabled:opacity-50"
                   >
                     {isJoining ? 'Joining…' : 'Join this board'}
@@ -262,8 +262,8 @@ const BoardMembersPanel = ({ onClose, isGuest = false }: Props) => {
                           member={member}
                           isLastAdmin={isThisLastAdmin}
                           canEdit={isAdmin}
-                          onRoleChange={handleRoleChange}
-                          onRemove={handleRemove}
+                          onRoleChange={(userId, role) => void handleRoleChange(userId, role)}
+                          onRemove={(userId) => void handleRemove(userId)}
                         />
                       );
                     })}

--- a/src/extensions/CalendarView/CalendarView.tsx
+++ b/src/extensions/CalendarView/CalendarView.tsx
@@ -125,7 +125,7 @@ const CalendarView = ({ cards, lists: _lists, onCardClick, addToast }: Props) =>
           onPrev={handleMonthPrev}
           onNext={handleMonthNext}
           onCardClick={onCardClick}
-          onCardDrop={handleCardDrop}
+          onCardDrop={(cardId, newDate) => void handleCardDrop(cardId, newDate)}
         />
       )}
 
@@ -137,7 +137,7 @@ const CalendarView = ({ cards, lists: _lists, onCardClick, addToast }: Props) =>
           onPrev={handleWeekPrev}
           onNext={handleWeekNext}
           onCardClick={onCardClick}
-          onCardDrop={handleCardDrop}
+          onCardDrop={(cardId, newDate) => void handleCardDrop(cardId, newDate)}
         />
       )}
     </div>

--- a/src/extensions/Card/components/CardLabels.tsx
+++ b/src/extensions/Card/components/CardLabels.tsx
@@ -75,7 +75,7 @@ const CardLabels = ({
           <LabelChip
             key={label.id}
             label={label}
-            onRemove={disabled ? undefined : () => onDetach(label.id)}
+            onRemove={disabled ? undefined : () => void onDetach(label.id)}
           />
         ))}
       </div>
@@ -137,7 +137,7 @@ const CardLabels = ({
                     variant="primary"
                     type="button"
                     className="w-full py-1.5 rounded-lg text-sm"
-                    onClick={handleCreate}
+                    onClick={() => void handleCreate()}
                     disabled={creating}
                   >
                     {creating ? 'Creating…' : `Create "${newLabelName.trim()}"`}
@@ -153,7 +153,7 @@ const CardLabels = ({
                         key={label.id}
                         type="button"
                         className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm text-base hover:bg-bg-overlay transition-colors"
-                        onClick={() => handleToggle(label)}
+                        onClick={() => void handleToggle(label)}
                       >
                         <span
                           className="h-3 w-3 rounded-full flex-shrink-0"
@@ -174,7 +174,7 @@ const CardLabels = ({
                         key={label.id}
                         type="button"
                         className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm text-base hover:bg-bg-overlay transition-colors"
-                        onClick={() => handleToggle(label)}
+                        onClick={() => void handleToggle(label)}
                       >
                         <span
                           className="h-3 w-3 rounded-full flex-shrink-0"

--- a/src/extensions/Card/components/ChecklistItem.tsx
+++ b/src/extensions/Card/components/ChecklistItem.tsx
@@ -381,7 +381,7 @@ export const ChecklistItem = ({
       <input
         type="checkbox"
         checked={item.checked}
-        onChange={(e) => onToggle(item.id, e.target.checked)}
+        onChange={(e) => void onToggle(item.id, e.target.checked)}
         disabled={disabled}
         className="mt-0.5 h-4 w-4 rounded border-border-strong text-blue-500 bg-bg-surface"
         aria-label={`Toggle: ${item.title}`}
@@ -397,7 +397,7 @@ export const ChecklistItem = ({
             e.target.style.height = 'auto';
             e.target.style.height = `${e.target.scrollHeight}px`;
           }}
-          onBlur={submitRename}
+          onBlur={() => void submitRename()}
           onPaste={handleEditPaste}
           // [why] Stop pointer propagation so dnd-kit's row-level listener doesn't
           // capture the pointer-down and turn text selection into an item drag.

--- a/src/extensions/CustomFields/BoardCustomFieldsPanel.tsx
+++ b/src/extensions/CustomFields/BoardCustomFieldsPanel.tsx
@@ -209,9 +209,9 @@ const BoardCustomFieldsPanel = () => {
                   value={renameValue}
                   autoFocus
                   onChange={(e) => setRenameValue(e.target.value)}
-                  onBlur={() => commitRename(field)}
+                  onBlur={() => void commitRename(field)}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter') commitRename(field);
+                    if (e.key === 'Enter') void commitRename(field);
                     if (e.key === 'Escape') setRenamingId(null);
                   }}
                   className="flex-1 bg-bg-overlay border border-border rounded px-2 py-0.5 text-sm text-base focus:outline-none focus:ring-1 focus:ring-primary"
@@ -236,7 +236,7 @@ const BoardCustomFieldsPanel = () => {
               {/* Delete */}
               <button
                 type="button"
-                onClick={() => handleDelete(field)}
+                onClick={() => void handleDelete(field)}
                 disabled={busy}
                 className="text-muted hover:text-danger transition-colors text-xs"
                 aria-label={`Delete field ${field.name}`}
@@ -250,7 +250,7 @@ const BoardCustomFieldsPanel = () => {
               <input
                 type="checkbox"
                 checked={field.show_on_card}
-                onChange={() => handleToggleShowOnCard(field)}
+                onChange={() => void handleToggleShowOnCard(field)}
                 disabled={busy}
                 className="accent-blue-500"
                 aria-label={translations['CustomFields.showOnCardLabel']}
@@ -282,7 +282,7 @@ const BoardCustomFieldsPanel = () => {
                     <div className="flex gap-2 pt-1">
                       <button
                         type="button"
-                        onClick={() => commitOptions(field)}
+                        onClick={() => void commitOptions(field)}
                         disabled={busy}
                         className="flex-1 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white text-xs rounded py-1 transition-colors" // [theme-exception] text-white on bg-blue-600 button
                       >
@@ -362,7 +362,7 @@ const BoardCustomFieldsPanel = () => {
           <div className="flex gap-2">
             <button
               type="button"
-              onClick={handleCreate}
+              onClick={() => void handleCreate()}
               disabled={creating || !newField.name.trim()}
               className="flex-1 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white text-xs rounded py-1 transition-colors" // [theme-exception] text-white on bg-blue-600 button
             >

--- a/src/extensions/CustomFields/CustomFieldValueEditor.tsx
+++ b/src/extensions/CustomFields/CustomFieldValueEditor.tsx
@@ -118,7 +118,7 @@ const CustomFieldValueEditor = ({
           <button
             type="button"
             className="text-xs text-muted hover:text-danger transition-colors flex-shrink-0"
-            onClick={handleClear}
+            onClick={() => void handleClear()}
             aria-label={`Clear ${field.name}`}
           >
             ✕
@@ -156,7 +156,7 @@ const CustomFieldValueEditor = ({
           <button
             type="button"
             className="text-xs text-muted hover:text-danger transition-colors flex-shrink-0"
-            onClick={handleClear}
+            onClick={() => void handleClear()}
             aria-label={`Clear ${field.name}`}
           >
             ✕
@@ -188,7 +188,7 @@ const CustomFieldValueEditor = ({
           <button
             type="button"
             className="text-xs text-muted hover:text-danger transition-colors"
-            onClick={handleClear}
+            onClick={() => void handleClear()}
           >
             {translations['CustomFieldValue.clearDate']}
           </button>
@@ -257,7 +257,7 @@ const CustomFieldValueEditor = ({
           <button
             type="button"
             className="text-xs text-muted hover:text-danger transition-colors flex-shrink-0"
-            onClick={handleClear}
+            onClick={() => void handleClear()}
             aria-label={`Clear ${field.name}`}
           >
             ✕

--- a/src/extensions/Notifications/NotificationPreferences/NotificationPreferencesPanel.tsx
+++ b/src/extensions/Notifications/NotificationPreferences/NotificationPreferencesPanel.tsx
@@ -126,14 +126,14 @@ const NotificationPreferencesPanel = () => {
                   <td className="py-3 text-center">
                     <ToggleSwitch
                       enabled={inAppChecked}
-                      onChange={(next) => handleToggle(type, 'in_app_enabled', next)}
+                      onChange={(next) => void handleToggle(type, 'in_app_enabled', next)}
                       ariaLabel={`${NOTIFICATION_TYPE_LABELS[type]} — ${translations['NotificationPreferences.columnInApp']}`}
                     />
                   </td>
                   <td className="py-3 text-center">
                     <ToggleSwitch
                       enabled={emailChecked && emailEnabled}
-                      onChange={(next) => handleToggle(type, 'email_enabled', next)}
+                      onChange={(next) => void handleToggle(type, 'email_enabled', next)}
                       disabled={!emailEnabled}
                       ariaLabel={`${NOTIFICATION_TYPE_LABELS[type]} — ${translations['NotificationPreferences.columnEmail']}`}
                       disabledTooltip={translations['NotificationPreferences.emailDisabledTooltip']}

--- a/src/extensions/Plugins/containers/PluginDashboardPage/PluginDashboardPage.tsx
+++ b/src/extensions/Plugins/containers/PluginDashboardPage/PluginDashboardPage.tsx
@@ -268,7 +268,7 @@ const PluginDashboardPage = () => {
                   <EnabledPluginRow
                     key={bp.id}
                     boardPlugin={bp}
-                    onDisable={disablePlugin}
+                    onDisable={(bp) => void disablePlugin(bp)}
                     onSettings={handleSettings}
                   />
                 ))}
@@ -312,7 +312,7 @@ const PluginDashboardPage = () => {
                   <DiscoverPluginRow
                     key={plugin.id}
                     plugin={plugin}
-                    onEnable={enablePlugin}
+                    onEnable={(plugin) => void enablePlugin(plugin)}
                   />
                 ))}
               </div>

--- a/src/extensions/Plugins/containers/PluginRegistryPage/PluginRegistryPage.tsx
+++ b/src/extensions/Plugins/containers/PluginRegistryPage/PluginRegistryPage.tsx
@@ -261,8 +261,8 @@ const PluginRegistryPage = () => {
           deactivatingId={deactivatingId}
           reactivatingId={reactivatingId}
           onEdit={setEditingPlugin}
-          onDeactivate={handleDeactivate}
-          onReactivate={handleReactivate}
+          onDeactivate={(id) => void handleDeactivate(id)}
+          onReactivate={(id) => void handleReactivate(id)}
         />
       )}
 
@@ -276,7 +276,7 @@ const PluginRegistryPage = () => {
           setEditingPlugin(null);
           setEditServerError(null);
         }}
-        onSubmit={handleEditSubmit}
+        onSubmit={(pluginId, body) => void handleEditSubmit(pluginId, body)}
       />
 
       {/* Register plugin modal — step 1: fill in the form */}
@@ -285,7 +285,7 @@ const PluginRegistryPage = () => {
         isSubmitting={isSubmittingRegister}
         serverError={registerServerError}
         onClose={() => setRegisterOpen(false)}
-        onSubmit={handleRegisterSubmit}
+        onSubmit={(body) => void handleRegisterSubmit(body)}
       />
 
       {/* API key reveal modal — step 2: shown once after successful registration */}

--- a/src/extensions/Workspace/containers/WorkspaceDashboard/index.tsx
+++ b/src/extensions/Workspace/containers/WorkspaceDashboard/index.tsx
@@ -96,11 +96,11 @@ const WorkspaceDashboard = () => {
             <BoardCard
               board={board}
               onClick={() => navigate(boardPath(board))}
-              onArchive={() => handleArchive(board.id)}
-              onDelete={() => handleDelete(board.id)}
-              onDuplicate={() => handleDuplicate(board.id)}
-              onStar={() => handleStar(board.id)}
-              onUnstar={() => handleUnstar(board.id)}
+              onArchive={() => void handleArchive(board.id)}
+              onDelete={() => void handleDelete(board.id)}
+              onDuplicate={() => void handleDuplicate(board.id)}
+              onStar={() => void handleStar(board.id)}
+              onUnstar={() => void handleUnstar(board.id)}
             />
           </div>
         ))}


### PR DESCRIPTION
## Summary

Fixes 53 `@typescript-eslint/no-misused-promises` findings across 19 files. Promise-returning event handlers / prop callbacks that expect a void return are wrapped in `void` so the return value is explicitly discarded, satisfying the void-return contract while preserving fire-and-forget behaviour. Event-listener callbacks use the idiomatic `void (async () => { ... })()` IIFE.

Corrected PluginDashboardPage `onDisable` to pass the `BoardPlugin` arg (matching the `EnabledPluginRow` prop type and the `useBoardPlugins` hook signature).

Behaviour-preserving: the handler still runs fire-and-forget exactly as before.

## Scope

- Rule family: `@typescript-eslint/no-misused-promises`
- 19 files, 70 insertions / 60 deletions
- Files: AttachmentPanel, BoardCustomFieldsPanel, AutomationPanel/index, CardLabels, CustomFieldValueEditor, PluginRegistryPage, WorkspaceDashboard/index, BoardMembersPanel/index, automation/scheduler/listener, plugins/sdk/jh-instance, ApiTokenPage, AttachmentSection, AutomationList, ButtonsTab, GuestsTab, CalendarView, ChecklistItem, NotificationPreferencesPanel, PluginDashboardPage

## Verification

- Focused lint on all 19 touched files: **0 `no-misused-promises` findings** (exit 0)
- `bun run typecheck`: exit 2, **146 errors — identical to current main baseline** (no new failures)
- `bun test`: **1444 tests, identical fail identities to current main** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

All touched files are UI components / server handlers with no dedicated executable UI/E2E coverage — recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.