### PR TITLE
lint: add braces to void-returning arrow shorthands (confusing-void batch 1)

### DIFF
--- a/src/extensions/Automation/components/AutomationPanel/ButtonsTab.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/ButtonsTab.tsx
@@ -122,7 +122,7 @@ const ButtonRow: FC<ButtonRowProps> = ({ boardId, automation, onEdited, onDelete
         {/* Edit */}
         <button
           type="button"
-          onClick={() => setShowBuilder(true)}
+          onClick={() => { setShowBuilder(true); }}
           className="flex-shrink-0 rounded p-1 text-muted hover:text-subtle opacity-0 group-hover:opacity-100 transition-opacity"
           aria-label={translations['automation.buttonsTab.row.editAriaLabel']}
         >
@@ -142,7 +142,7 @@ const ButtonRow: FC<ButtonRowProps> = ({ boardId, automation, onEdited, onDelete
             </button>
             <button
               type="button"
-              onClick={() => setConfirmDelete(false)}
+              onClick={() => { setConfirmDelete(false); }}
               className="text-xs rounded px-2 py-0.5 text-muted hover:text-subtle"
             >
               {translations['automation.buttonsTab.row.cancel']}
@@ -151,7 +151,7 @@ const ButtonRow: FC<ButtonRowProps> = ({ boardId, automation, onEdited, onDelete
         ) : (
           <button
             type="button"
-            onClick={() => setConfirmDelete(true)}
+            onClick={() => { setConfirmDelete(true); }}
             className="flex-shrink-0 rounded p-1 text-muted hover:text-danger opacity-0 group-hover:opacity-100 transition-opacity"
             aria-label={translations['automation.buttonsTab.row.deleteAriaLabel']}
           >
@@ -169,7 +169,7 @@ const ButtonRow: FC<ButtonRowProps> = ({ boardId, automation, onEdited, onDelete
             setShowBuilder(false);
             onEdited();
           }}
-          onClose={() => setShowBuilder(false)}
+          onClose={() => { setShowBuilder(false); }}
         />
       )}
       {showBuilder && automation.automationType === 'BOARD_BUTTON' && (
@@ -180,7 +180,7 @@ const ButtonRow: FC<ButtonRowProps> = ({ boardId, automation, onEdited, onDelete
             setShowBuilder(false);
             onEdited();
           }}
-          onClose={() => setShowBuilder(false)}
+          onClose={() => { setShowBuilder(false); }}
         />
       )}
     </>
@@ -204,7 +204,7 @@ const ButtonsTab: FC<Props> = ({ boardId, automations, onChanged }) => {
           </h3>
           <button
             type="button"
-            onClick={() => setShowCardBuilder(true)}
+            onClick={() => { setShowCardBuilder(true); }}
             className="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-blue-400 hover:bg-bg-surface hover:text-blue-300 transition-colors"
             aria-label={translations['automation.buttonsTab.cardButtons.addAriaLabel']}
           >
@@ -238,7 +238,7 @@ const ButtonsTab: FC<Props> = ({ boardId, automations, onChanged }) => {
           </h3>
           <button
             type="button"
-            onClick={() => setShowBoardBuilder(true)}
+            onClick={() => { setShowBoardBuilder(true); }}
             className="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-blue-400 hover:bg-bg-surface hover:text-blue-300 transition-colors"
             aria-label={translations['automation.buttonsTab.boardButtons.addAriaLabel']}
           >
@@ -272,7 +272,7 @@ const ButtonsTab: FC<Props> = ({ boardId, automations, onChanged }) => {
             setShowCardBuilder(false);
             onChanged();
           }}
-          onClose={() => setShowCardBuilder(false)}
+          onClose={() => { setShowCardBuilder(false); }}
         />
       )}
       {showBoardBuilder && (
@@ -282,7 +282,7 @@ const ButtonsTab: FC<Props> = ({ boardId, automations, onChanged }) => {
             setShowBoardBuilder(false);
             onChanged();
           }}
-          onClose={() => setShowBoardBuilder(false)}
+          onClose={() => { setShowBoardBuilder(false); }}
         />
       )}
     </div>

--- a/src/extensions/Automation/components/AutomationPanel/RuleBuilder/ActionConfig.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/RuleBuilder/ActionConfig.tsx
@@ -58,7 +58,7 @@ const ActionConfig = ({ actionType, config, onChange, boardId }: Props) => {
   useEffect(() => {
     apiClient
       .get(`/boards/${boardId}/lists`)
-      .then((res: any) => setBoardLists(res.data ?? []))
+      .then((res: any) => { setBoardLists(res.data ?? []); })
       .catch(() => {});
   }, [boardId]);
 
@@ -66,7 +66,7 @@ const ActionConfig = ({ actionType, config, onChange, boardId }: Props) => {
   useEffect(() => {
     apiClient
       .get(`/boards/${boardId}/workspace/boards`)
-      .then((res: any) => setWorkspaceBoards(res.data ?? []))
+      .then((res: any) => { setWorkspaceBoards(res.data ?? []); })
       .catch(() => {});
   }, [boardId]);
 
@@ -86,7 +86,7 @@ const ActionConfig = ({ actionType, config, onChange, boardId }: Props) => {
             }))
         );
       })
-      .catch(() => setCustomFields([]));
+      .catch(() => { setCustomFields([]); });
   }, [boardId]);
 
   // Whenever the user picks a target board, fetch its lists for the target-list-select field.
@@ -98,8 +98,8 @@ const ActionConfig = ({ actionType, config, onChange, boardId }: Props) => {
     }
     apiClient
       .get(`/boards/${selectedTargetBoardId}/lists`)
-      .then((res: any) => setTargetBoardLists(res.data ?? []))
-      .catch(() => setTargetBoardLists([]));
+      .then((res: any) => { setTargetBoardLists(res.data ?? []); })
+      .catch(() => { setTargetBoardLists([]); });
   }, [selectedTargetBoardId]);
 
   if (actionType.type === UPDATE_CUSTOM_FIELD_ACTION) {
@@ -152,7 +152,7 @@ const ActionConfig = ({ actionType, config, onChange, boardId }: Props) => {
             id="cfg-action-fieldId"
             className="w-full rounded-md border border-border bg-bg-overlay px-3 py-1.5 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
             value={selectedFieldId}
-            onChange={(e) => setField(e.target.value)}
+            onChange={(e) => { setField(e.target.value); }}
           >
             <option value="">{translations['automation.actionConfig.customField.selectFieldPlaceholder']}</option>
             {customFields.map((field) => (
@@ -179,7 +179,7 @@ const ActionConfig = ({ actionType, config, onChange, boardId }: Props) => {
                 className="w-full rounded-md border border-border bg-bg-overlay px-3 py-1.5 text-sm text-base placeholder:text-subtle focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder={translations['automation.actionConfig.customField.textPlaceholder']}
                 value={typeof config.valueText === 'string' ? config.valueText : ''}
-                onChange={(e) => setValue({ valueText: e.target.value })}
+                onChange={(e) => { setValue({ valueText: e.target.value }); }}
               />
             )}
 
@@ -201,7 +201,7 @@ const ActionConfig = ({ actionType, config, onChange, boardId }: Props) => {
                 type="date"
                 className="w-full rounded-md border border-border bg-bg-overlay px-3 py-1.5 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
                 value={typeof config.valueDate === 'string' ? config.valueDate.slice(0, 10) : ''}
-                onChange={(e) => setValue({ valueDate: e.target.value })}
+                onChange={(e) => { setValue({ valueDate: e.target.value }); }}
               />
             )}
 
@@ -209,7 +209,7 @@ const ActionConfig = ({ actionType, config, onChange, boardId }: Props) => {
               <select
                 className="w-full rounded-md border border-border bg-bg-overlay px-3 py-1.5 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
                 value={typeof config.valueCheckbox === 'boolean' ? String(config.valueCheckbox) : ''}
-                onChange={(e) => setValue({ valueCheckbox: e.target.value === 'true' })}
+                onChange={(e) => { setValue({ valueCheckbox: e.target.value === 'true' }); }}
               >
                 <option value="false">{translations['automation.actionConfig.customField.checkboxFalse']}</option>
                 <option value="true">{translations['automation.actionConfig.customField.checkboxTrue']}</option>
@@ -220,7 +220,7 @@ const ActionConfig = ({ actionType, config, onChange, boardId }: Props) => {
               <select
                 className="w-full rounded-md border border-border bg-bg-overlay px-3 py-1.5 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
                 value={typeof config.valueOptionId === 'string' ? config.valueOptionId : ''}
-                onChange={(e) => setValue({ valueOptionId: e.target.value })}
+                onChange={(e) => { setValue({ valueOptionId: e.target.value }); }}
               >
                 <option value="">{translations['automation.actionConfig.customField.selectOptionPlaceholder']}</option>
                 {(selectedField.options ?? []).map((option) => (

--- a/src/extensions/Automation/components/AutomationPanel/RuleBuilder/configFieldRenderer.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/RuleBuilder/configFieldRenderer.tsx
@@ -128,7 +128,7 @@ function renderListSelect(args: RenderArgs): JSX.Element {
   return (
     <div key={key}>
       <FieldLabel id={id} label={fieldDef.label} required={fieldDef.required} />
-      <select id={id} className={SELECT_CLASS} value={typeof value === 'string' ? value : ''} onChange={(e) => onChange(e.target.value || undefined)} required={fieldDef.required}>
+      <select id={id} className={SELECT_CLASS} value={typeof value === 'string' ? value : ''} onChange={(e) => { onChange(e.target.value || undefined); }} required={fieldDef.required}>
         <option value="">Any list…</option>
         {(boardLists ?? []).map((list) => <option key={list.id} value={list.id}>{list.title}</option>)}
       </select>
@@ -162,7 +162,7 @@ function renderListMultiSelect(args: RenderArgs): JSX.Element {
                 type="checkbox"
                 className="h-3.5 w-3.5 rounded border-border bg-bg-sunken text-blue-500 focus:ring-1 focus:ring-blue-500"
                 checked={selected.includes(list.id)}
-                onChange={() => toggle(list.id)}
+                onChange={() => { toggle(list.id); }}
               />
               {list.title}
             </label>
@@ -179,7 +179,7 @@ function renderBoardSelect(args: RenderArgs): JSX.Element {
   return (
     <div key={key}>
       <FieldLabel id={id} label={fieldDef.label} required={fieldDef.required} />
-      <select id={id} className={SELECT_CLASS} value={typeof value === 'string' ? value : ''} onChange={(e) => onChange(e.target.value || undefined)} required={fieldDef.required}>
+      <select id={id} className={SELECT_CLASS} value={typeof value === 'string' ? value : ''} onChange={(e) => { onChange(e.target.value || undefined); }} required={fieldDef.required}>
         <option value="">Select a board…</option>
         {(workspaceBoards ?? []).map((b) => <option key={b.id} value={b.id}>{b.title}</option>)}
       </select>
@@ -194,7 +194,7 @@ function renderTargetListSelect(args: RenderArgs): JSX.Element {
   return (
     <div key={key}>
       <FieldLabel id={id} label={fieldDef.label} required={fieldDef.required} />
-      <select id={id} className={SELECT_CLASS} value={typeof value === 'string' ? value : ''} onChange={(e) => onChange(e.target.value || undefined)} required={fieldDef.required} disabled={lists.length === 0}>
+      <select id={id} className={SELECT_CLASS} value={typeof value === 'string' ? value : ''} onChange={(e) => { onChange(e.target.value || undefined); }} required={fieldDef.required} disabled={lists.length === 0}>
         <option value="">{lists.length === 0 ? 'Select a board first…' : 'Select a list…'}</option>
         {lists.map((list) => <option key={list.id} value={list.id}>{list.title}</option>)}
       </select>
@@ -208,7 +208,7 @@ function renderEnumSelect(args: RenderArgs): JSX.Element {
   return (
     <div key={key}>
       <FieldLabel id={id} label={fieldDef.label} required={fieldDef.required} />
-      <select id={id} className={SELECT_CLASS} value={typeof value === 'string' ? value : ''} onChange={(e) => onChange(e.target.value)} required={fieldDef.required}>
+      <select id={id} className={SELECT_CLASS} value={typeof value === 'string' ? value : ''} onChange={(e) => { onChange(e.target.value); }} required={fieldDef.required}>
         <option value="">Choose…</option>
         {(fieldDef.options ?? []).map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
       </select>
@@ -221,7 +221,7 @@ function renderBoolean(args: RenderArgs): JSX.Element {
   const id = `cfg-${key}`;
   return (
     <div key={key} className="flex items-center gap-2">
-      <input id={id} type="checkbox" className="h-4 w-4 rounded border-border bg-bg-overlay text-blue-500 focus:ring-2 focus:ring-blue-500" checked={!!value} onChange={(e) => onChange(e.target.checked)} />
+      <input id={id} type="checkbox" className="h-4 w-4 rounded border-border bg-bg-overlay text-blue-500 focus:ring-2 focus:ring-blue-500" checked={!!value} onChange={(e) => { onChange(e.target.checked); }} />
       <label htmlFor={id} className="text-xs font-medium text-muted">{fieldDef.label}</label>
     </div>
   );
@@ -233,7 +233,7 @@ function renderNumber(args: RenderArgs): JSX.Element {
   return (
     <div key={key}>
       <FieldLabel id={id} label={fieldDef.label} required={fieldDef.required} />
-      <input id={id} type="number" className={SELECT_CLASS} value={typeof value === 'number' ? value : ''} onChange={(e) => onChange(Number(e.target.value))} required={fieldDef.required} />
+      <input id={id} type="number" className={SELECT_CLASS} value={typeof value === 'number' ? value : ''} onChange={(e) => { onChange(Number(e.target.value)); }} required={fieldDef.required} />
     </div>
   );
 }
@@ -244,7 +244,7 @@ function renderText(args: RenderArgs): JSX.Element {
   return (
     <div key={key}>
       <FieldLabel id={id} label={fieldDef.label} required={fieldDef.required} />
-      <input id={id} type="text" className={INPUT_CLASS} value={typeof value === 'string' ? value : ''} onChange={(e) => onChange(e.target.value)} required={fieldDef.required} />
+      <input id={id} type="text" className={INPUT_CLASS} value={typeof value === 'string' ? value : ''} onChange={(e) => { onChange(e.target.value); }} required={fieldDef.required} />
     </div>
   );
 }
@@ -253,7 +253,7 @@ function renderStringList(args: RenderArgs): JSX.Element {
   const { key, fieldDef } = args;
   const items: string[] = Array.isArray(args.value) ? (args.value as string[]) : [];
 
-  const update = (next: string[]) => args.onChange(next.length > 0 ? next : undefined);
+  const update = (next: string[]) => { args.onChange(next.length > 0 ? next : undefined); };
 
   return (
     <div key={key}>
@@ -278,7 +278,7 @@ function renderStringList(args: RenderArgs): JSX.Element {
             <button
               type="button"
               className="flex-shrink-0 rounded p-1 text-muted hover:text-danger hover:bg-bg-overlay transition-colors"
-              onClick={() => update(items.filter((_, i) => i !== idx))}
+              onClick={() => { update(items.filter((_, i) => i !== idx)); }}
               title="Remove item"
             >
               ×
@@ -288,7 +288,7 @@ function renderStringList(args: RenderArgs): JSX.Element {
         <button
           type="button"
           className="mt-0.5 self-start rounded border border-dashed border-border px-2 py-1 text-xs text-muted hover:border-border hover:text-subtle transition-colors"
-          onClick={() => update([...items, ''])}
+          onClick={() => { update([...items, '']); }}
         >
           + Add item
         </button>

--- a/src/extensions/Card/components/CardMetaStrip.tsx
+++ b/src/extensions/Card/components/CardMetaStrip.tsx
@@ -54,7 +54,7 @@ function usePopover() {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
     document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
+    return () => { document.removeEventListener('keydown', onKey); };
   }, [open]);
 
   return { open, setOpen, ref };
@@ -132,7 +132,7 @@ const ColorGrid = ({
           selected === c.hex ? 'ring-2 ring-bg-surface ring-offset-2 ring-offset-bg-base' : ''
         }`}
         style={{ backgroundColor: c.hex }}
-        onClick={() => onChange(c.hex)}
+        onClick={() => { onChange(c.hex); }}
         aria-label={c.name}
       />
     ))}
@@ -246,7 +246,7 @@ const LabelSection = ({
 
       {open && (
         <>
-          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} aria-hidden="true" />
+          <div className="fixed inset-0 z-10" onClick={() => { setOpen(false); }} aria-hidden="true" />
           <div
             className="absolute left-0 top-full mt-1 z-20 w-72 rounded-xl bg-bg-surface border border-border shadow-2xl overflow-hidden flex flex-col max-h-[min(28rem,80vh)]"
           >
@@ -266,7 +266,7 @@ const LabelSection = ({
               <button
                 type="button"
                 className="rounded p-0.5 text-subtle hover:text-base"
-                onClick={() => setOpen(false)}
+                onClick={() => { setOpen(false); }}
                 aria-label="Close"
               >
                 ✕
@@ -280,7 +280,7 @@ const LabelSection = ({
                   className="w-full bg-bg-overlay border border-border rounded-lg px-2.5 py-1.5 text-sm text-base placeholder:text-subtle focus:outline-none focus:ring-2 focus:ring-primary mb-1"
                   placeholder="Search labels..."
                   value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
+                  onChange={(e) => { setSearchQuery(e.target.value); }}
                   autoFocus
                 />
                 {filteredLabels.length === 0 && (
@@ -312,7 +312,7 @@ const LabelSection = ({
                       <button
                         type="button"
                         className="flex-shrink-0 rounded p-1 text-subtle hover:bg-bg-overlay hover:text-base transition-colors"
-                        onClick={() => openEdit(label)}
+                        onClick={() => { openEdit(label); }}
                         aria-label={`Edit ${label.name}`}
                       >
                         <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -350,7 +350,7 @@ const LabelSection = ({
                     className="w-full bg-bg-overlay border border-border rounded-lg px-2.5 py-1.5 text-sm text-base placeholder:text-subtle focus:outline-none focus:ring-2 focus:ring-primary"
                     placeholder="Label name"
                     value={formName}
-                    onChange={(e) => setFormName(e.target.value)}
+                    onChange={(e) => { setFormName(e.target.value); }}
                     onKeyDown={(e) => { if (e.key === 'Enter') { void (view === 'create' ? handleCreate() : handleSaveEdit()); } }}
                     autoFocus
                   />
@@ -450,7 +450,7 @@ const MemberSection = ({
       )}
       {!disabled && (
         <PillButton
-          onClick={() => setOpen((v) => !v)}
+          onClick={() => { setOpen((v) => !v); }}
           aria-label="Assign members"
           aria-expanded={open}
           aria-haspopup="dialog"
@@ -462,7 +462,7 @@ const MemberSection = ({
 
       {open && (
         <>
-          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} aria-hidden="true" />
+          <div className="fixed inset-0 z-10" onClick={() => { setOpen(false); }} aria-hidden="true" />
           <div className="absolute left-0 top-full mt-1 z-20 w-56 rounded-xl bg-bg-surface border border-border shadow-2xl p-2 space-y-1">
             {boardMembers.length === 0 && (
               <p className="text-xs text-subtle px-2 py-1">No board members</p>
@@ -592,7 +592,7 @@ const DatesButton = ({
       <button
         type="button"
         className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs transition-colors disabled:opacity-40 disabled:pointer-events-none ${pillClass}`}
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => { setOpen((v) => !v); }}
         disabled={disabled}
         aria-label="Dates"
         aria-expanded={open}
@@ -604,7 +604,7 @@ const DatesButton = ({
 
       {open && (
         <>
-          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} aria-hidden="true" />
+          <div className="fixed inset-0 z-10" onClick={() => { setOpen(false); }} aria-hidden="true" />
           <div className="absolute left-0 top-full mt-1 z-20">
             <CardDatesPicker
               startDate={startDate}
@@ -612,7 +612,7 @@ const DatesButton = ({
               disabled={disabled}
               onSave={handleSave}
               onRemove={handleRemove}
-              onClose={() => setOpen(false)}
+              onClose={() => { setOpen(false); }}
             />
           </div>
         </>
@@ -663,7 +663,7 @@ const MoneyButton = ({
       <button
         type="button"
         className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs transition-colors disabled:opacity-40 disabled:pointer-events-none ${pillClass}`}
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => { setOpen((v) => !v); }}
         disabled={disabled}
         aria-label="Card pricing"
         aria-expanded={open}
@@ -675,7 +675,7 @@ const MoneyButton = ({
 
       {open && (
         <>
-          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} aria-hidden="true" />
+          <div className="fixed inset-0 z-10" onClick={() => { setOpen(false); }} aria-hidden="true" />
           <div className="absolute left-0 top-full mt-1 z-20 w-56 rounded-xl bg-bg-surface border border-border shadow-2xl p-3">
             <CardValue
               amount={amount}

--- a/src/extensions/Plugins/modals/EditPluginModal.tsx
+++ b/src/extensions/Plugins/modals/EditPluginModal.tsx
@@ -191,7 +191,7 @@ const EditPluginModal = ({ open, plugin, isSubmitting, serverError, onClose, onS
               className={inputCls(errors.name)}
               placeholder={translations['plugins.editModal.placeholder.pluginName']}
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => { setName(e.target.value); }}
               disabled={isSubmitting}
             />,
             errors.name,
@@ -203,7 +203,7 @@ const EditPluginModal = ({ open, plugin, isSubmitting, serverError, onClose, onS
               rows={3}
               placeholder={translations['plugins.editModal.placeholder.description']}
               value={description}
-              onChange={(e) => setDescription(e.target.value)}
+              onChange={(e) => { setDescription(e.target.value); }}
               disabled={isSubmitting}
             />,
             errors.description,
@@ -214,7 +214,7 @@ const EditPluginModal = ({ open, plugin, isSubmitting, serverError, onClose, onS
               className={inputCls(errors.connectorUrl)}
               placeholder={translations['plugins.editModal.placeholder.connectorUrl']}
               value={connectorUrl}
-              onChange={(e) => setConnectorUrl(e.target.value)}
+              onChange={(e) => { setConnectorUrl(e.target.value); }}
               disabled={isSubmitting}
             />,
             errors.connectorUrl,
@@ -225,7 +225,7 @@ const EditPluginModal = ({ open, plugin, isSubmitting, serverError, onClose, onS
               className={inputCls()}
               placeholder={translations['plugins.editModal.placeholder.manifestUrl']}
               value={manifestUrl}
-              onChange={(e) => setManifestUrl(e.target.value)}
+              onChange={(e) => { setManifestUrl(e.target.value); }}
               disabled={isSubmitting}
             />,
           )}
@@ -236,7 +236,7 @@ const EditPluginModal = ({ open, plugin, isSubmitting, serverError, onClose, onS
                 className={`${inputCls()} flex-1`}
                 placeholder={translations['plugins.editModal.placeholder.iconUrl']}
                 value={iconUrl}
-                onChange={(e) => setIconUrl(e.target.value)}
+                onChange={(e) => { setIconUrl(e.target.value); }}
                 disabled={isSubmitting}
               />
               {iconUrl && (
@@ -255,7 +255,7 @@ const EditPluginModal = ({ open, plugin, isSubmitting, serverError, onClose, onS
               className={inputCls(errors.author)}
               placeholder={translations['plugins.editModal.placeholder.author']}
               value={author}
-              onChange={(e) => setAuthor(e.target.value)}
+              onChange={(e) => { setAuthor(e.target.value); }}
               disabled={isSubmitting}
             />,
             errors.author,
@@ -267,7 +267,7 @@ const EditPluginModal = ({ open, plugin, isSubmitting, serverError, onClose, onS
               className={inputCls(errors.authorEmail)}
               placeholder={translations['plugins.editModal.placeholder.authorEmail']}
               value={authorEmail}
-              onChange={(e) => setAuthorEmail(e.target.value)}
+              onChange={(e) => { setAuthorEmail(e.target.value); }}
               disabled={isSubmitting}
             />,
             errors.authorEmail,
@@ -279,7 +279,7 @@ const EditPluginModal = ({ open, plugin, isSubmitting, serverError, onClose, onS
               className={inputCls(errors.supportEmail)}
               placeholder={translations['plugins.editModal.placeholder.supportEmail']}
               value={supportEmail}
-              onChange={(e) => setSupportEmail(e.target.value)}
+              onChange={(e) => { setSupportEmail(e.target.value); }}
               disabled={isSubmitting}
             />,
             errors.supportEmail,
@@ -294,7 +294,7 @@ const EditPluginModal = ({ open, plugin, isSubmitting, serverError, onClose, onS
                     <IconButton
                       icon={<span aria-hidden className="leading-none">×</span>}
                       aria-label={`Remove ${tag}`}
-                      onClick={() => removeCategory(tag)}
+                      onClick={() => { removeCategory(tag); }}
                       className="h-auto w-auto p-0 hover:text-base"
                     />
                   </span>
@@ -304,7 +304,7 @@ const EditPluginModal = ({ open, plugin, isSubmitting, serverError, onClose, onS
                 className={inputCls()}
                 placeholder={translations['plugins.editModal.placeholder.categories']}
                 value={categoryInput}
-                onChange={(e) => setCategoryInput(e.target.value)}
+                onChange={(e) => { setCategoryInput(e.target.value); }}
                 onKeyDown={handleCategoryKeyDown}
                 onBlur={() => { if (categoryInput.trim()) addCategory(categoryInput); }}
                 disabled={isSubmitting}
@@ -324,7 +324,7 @@ const EditPluginModal = ({ open, plugin, isSubmitting, serverError, onClose, onS
                     <IconButton
                       icon={<span aria-hidden className="leading-none">×</span>}
                       aria-label={`Remove ${domain}`}
-                      onClick={() => removeDomain(domain)}
+                      onClick={() => { removeDomain(domain); }}
                       className="h-auto w-auto p-0 hover:text-base"
                     />
                   </span>
@@ -334,7 +334,7 @@ const EditPluginModal = ({ open, plugin, isSubmitting, serverError, onClose, onS
                 className={inputCls(errors.whitelistedDomains)}
                 placeholder={translations['plugins.editModal.placeholder.whitelistedDomains']}
                 value={domainInput}
-                onChange={(e) => setDomainInput(e.target.value)}
+                onChange={(e) => { setDomainInput(e.target.value); }}
                 onKeyDown={handleDomainKeyDown}
                 onBlur={() => { if (domainInput.trim()) addDomain(domainInput); }}
                 disabled={isSubmitting}
@@ -348,7 +348,7 @@ const EditPluginModal = ({ open, plugin, isSubmitting, serverError, onClose, onS
               type="checkbox"
               id="editIsPublic"
               checked={isPublic}
-              onChange={(e) => setIsPublic(e.target.checked)}
+              onChange={(e) => { setIsPublic(e.target.checked); }}
               disabled={isSubmitting}
               className="w-4 h-4 accent-blue-500"
             />


### PR DESCRIPTION
## Summary

Fixes 57 `@typescript-eslint/no-confusing-void-expression` findings across 5 files. Arrow-function shorthands returning a void expression (`() => void fn()`) are converted to block-body form (`() => { void fn(); }`). Behaviour-identical: void returns are discarded either way.

## Scope

- Rule family: `@typescript-eslint/no-confusing-void-expression`
- 5 files, 57 insertions / 57 deletions
- Files: CardMetaStrip.tsx (14), EditPluginModal.tsx (13), configFieldRenderer.tsx (11), ActionConfig.tsx (10), ButtonsTab.tsx (9)

## Verification

- Focused lint on all 5 touched files: **0 `no-confusing-void-expression` findings** (exit 0)
- `bun run typecheck`: exit 2, **146 errors — identical to current main baseline** (no new failures)
- `bun test`: **1444 tests, identical fail identities to current main** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

All touched files are UI components with no dedicated executable UI/E2E coverage — recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched. No unrelated files in the diff.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.