### PR TITLE
lint: add braces to void-returning arrow shorthands (confusing-void batch 2)

### DIFF
--- a/src/common/components/CommandPalette.tsx
+++ b/src/common/components/CommandPalette.tsx
@@ -151,7 +151,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
     if (isOpen) {
       document.addEventListener('keydown', handleGlobalKeyDown);
     }
-    return () => document.removeEventListener('keydown', handleGlobalKeyDown);
+    return () => { document.removeEventListener('keydown', handleGlobalKeyDown); };
   }, [isOpen, handleGlobalKeyDown]);
 
   // Re-focus input when palette opens and reset query
@@ -241,7 +241,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
       {/* Panel */}
       <div
         className="w-full max-w-xl overflow-hidden rounded-xl bg-bg-surface shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
+        onClick={(e) => { e.stopPropagation(); }}
       >
         {/* Search input */}
         <div className="flex items-center gap-3 border-b border-border px-4 py-3">
@@ -250,7 +250,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
             ref={inputRef}
             type="text"
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onChange={(e) => { setQuery(e.target.value); }}
             onKeyDown={handleInputKeyDown}
             placeholder={scopeMeta.placeholder}
             className="flex-1 bg-transparent text-sm text-base placeholder:text-subtle outline-none"
@@ -270,8 +270,8 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
               ref={(el) => { scopeTabRefs.current[idx] = el; }}
               role="tab"
               aria-selected={scope === s.value}
-              onClick={() => changeScope(s.value)}
-              onKeyDown={(e) => handleTabKeyDown(e, idx)}
+              onClick={() => { changeScope(s.value); }}
+              onKeyDown={(e) => { handleTabKeyDown(e, idx); }}
               className={`rounded-full px-3 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
                 scope === s.value
                   ? 'bg-primary text-inverse'
@@ -331,7 +331,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
                         result={r}
                         onSelect={handleSelect}
                         buttonRef={(el) => { resultRefs.current[flatIdx] = el; }}
-                        onKeyDown={(e) => handleResultKeyDown(e, flatIdx)}
+                        onKeyDown={(e) => { handleResultKeyDown(e, flatIdx); }}
                       />
                     );
                   })}
@@ -350,7 +350,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
                         result={r}
                         onSelect={handleSelect}
                         buttonRef={(el) => { resultRefs.current[flatIdx] = el; }}
-                        onKeyDown={(e) => handleResultKeyDown(e, flatIdx)}
+                        onKeyDown={(e) => { handleResultKeyDown(e, flatIdx); }}
                       />
                     );
                   })}
@@ -368,7 +368,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
                   result={r}
                   onSelect={handleSelect}
                   buttonRef={(el) => { resultRefs.current[idx] = el; }}
-                  onKeyDown={(e) => handleResultKeyDown(e, idx)}
+                  onKeyDown={(e) => { handleResultKeyDown(e, idx); }}
                 />
               ))}
             </section>

--- a/src/extensions/AdminInvite/InviteExternalUserModal.tsx
+++ b/src/extensions/AdminInvite/InviteExternalUserModal.tsx
@@ -181,7 +181,7 @@ export default function InviteExternalUserModal() {
               loginUrl={loginUrl}
               emailSent={emailSentFromStore}
               emailVerifiedAt={emailVerifiedAt}
-              onDone={() => handleOpenChange(false)}
+              onDone={() => { handleOpenChange(false); }}
             />
           ) : (
             // ── Invite form ─────────────────────────────────────────────────
@@ -209,7 +209,7 @@ export default function InviteExternalUserModal() {
                     id="invite-email"
                     type="email"
                     value={email}
-                    onChange={(e) => setEmail(e.target.value)}
+                    onChange={(e) => { setEmail(e.target.value); }}
                     placeholder={translations['AdminInvite.emailPlaceholder']}
                     required
                     autoFocus
@@ -235,7 +235,7 @@ export default function InviteExternalUserModal() {
                     id="invite-display-name"
                     type="text"
                     value={displayName}
-                    onChange={(e) => setDisplayName(e.target.value)}
+                    onChange={(e) => { setDisplayName(e.target.value); }}
                     placeholder={translations['AdminInvite.displayNamePlaceholder']}
                     required
                     className="w-full rounded-lg border border-border bg-bg-overlay px-3 py-2 text-sm text-base placeholder:text-subtle focus:outline-none focus:ring-2 focus:ring-primary"
@@ -262,7 +262,7 @@ export default function InviteExternalUserModal() {
                         name="password-mode"
                         value="auto"
                         checked={passwordMode === 'auto'}
-                        onChange={() => setPasswordMode('auto')}
+                        onChange={() => { setPasswordMode('auto'); }}
                         className="accent-indigo-500"
                       />
                       {translations['AdminInvite.passwordModeAuto']}
@@ -273,7 +273,7 @@ export default function InviteExternalUserModal() {
                         name="password-mode"
                         value="manual"
                         checked={passwordMode === 'manual'}
-                        onChange={() => setPasswordMode('manual')}
+                        onChange={() => { setPasswordMode('manual'); }}
                         className="accent-indigo-500"
                       />
                       {translations['AdminInvite.passwordModeManual']}
@@ -294,7 +294,7 @@ export default function InviteExternalUserModal() {
                       id="invite-password"
                       type="password"
                       value={password}
-                      onChange={(e) => setPassword(e.target.value)}
+                      onChange={(e) => { setPassword(e.target.value); }}
                       placeholder="••••••••"
                       className="w-full rounded-lg border border-border bg-bg-overlay px-3 py-2 text-sm text-base placeholder:text-subtle focus:outline-none focus:ring-2 focus:ring-primary"
                       aria-describedby="invite-password-strength"
@@ -330,7 +330,7 @@ export default function InviteExternalUserModal() {
                       <input
                         type="checkbox"
                         checked={sendEmail}
-                        onChange={(e) => setSendEmail(e.target.checked)}
+                        onChange={(e) => { setSendEmail(e.target.checked); }}
                         className="h-4 w-4 rounded border-slate-600 accent-indigo-500"
                       />
                       {translations['AdminInvite.sendEmailToggle']}
@@ -345,7 +345,7 @@ export default function InviteExternalUserModal() {
                       <input
                         type="checkbox"
                         checked={autoVerifyEmail}
-                        onChange={(e) => setAutoVerifyEmail(e.target.checked)}
+                        onChange={(e) => { setAutoVerifyEmail(e.target.checked); }}
                         className="h-4 w-4 rounded border-slate-600 accent-indigo-500"
                         data-testid="auto-verify-email-checkbox"
                       />

--- a/src/extensions/Auth/components/SignupForm.tsx
+++ b/src/extensions/Auth/components/SignupForm.tsx
@@ -83,8 +83,8 @@ export default function SignupForm({ onSubmit, isLoading, apiError }: SignupForm
             type="text"
             autoComplete="name"
             value={name}
-            onChange={(e) => setName(e.target.value)}
-            onBlur={() => setErrors((prev) => ({ ...prev, name: validateName(name) }))}
+            onChange={(e) => { setName(e.target.value); }}
+            onBlur={() => { setErrors((prev) => ({ ...prev, name: validateName(name) })); }}
             placeholder="Jane Smith"
             className={`w-full bg-bg-overlay border ${errors.name ? 'border-danger' : 'border-border'} text-base placeholder:text-subtle rounded-lg px-4 py-2.5 focus:outline-none focus:ring-2 focus:ring-primary`}
           />
@@ -101,8 +101,8 @@ export default function SignupForm({ onSubmit, isLoading, apiError }: SignupForm
             type="email"
             autoComplete="email"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            onBlur={() => setErrors((prev) => ({ ...prev, email: validateEmail(email) }))}
+            onChange={(e) => { setEmail(e.target.value); }}
+            onBlur={() => { setErrors((prev) => ({ ...prev, email: validateEmail(email) })); }}
             placeholder="you@example.com"
             className={`w-full bg-bg-overlay border ${errors.email ? 'border-danger' : 'border-border'} text-base placeholder:text-subtle rounded-lg px-4 py-2.5 focus:outline-none focus:ring-2 focus:ring-primary`}
           />
@@ -115,8 +115,8 @@ export default function SignupForm({ onSubmit, isLoading, apiError }: SignupForm
           label={translations.fields.password}
           autoComplete="new-password"
           value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          onBlur={() => setErrors((prev) => ({ ...prev, password: validatePassword(password) }))}
+          onChange={(e) => { setPassword(e.target.value); }}
+          onBlur={() => { setErrors((prev) => ({ ...prev, password: validatePassword(password) })); }}
           placeholder="Min. 8 characters"
           error={errors.password}
         />
@@ -127,8 +127,8 @@ export default function SignupForm({ onSubmit, isLoading, apiError }: SignupForm
           label={translations.fields.confirmPassword}
           autoComplete="new-password"
           value={confirm}
-          onChange={(e) => setConfirm(e.target.value)}
-          onBlur={() => setErrors((prev) => ({ ...prev, confirm: validateConfirm(confirm, password) }))}
+          onChange={(e) => { setConfirm(e.target.value); }}
+          onBlur={() => { setErrors((prev) => ({ ...prev, confirm: validateConfirm(confirm, password) })); }}
           placeholder="Repeat your password"
           error={errors.confirm}
         />

--- a/src/extensions/Automation/components/AutomationPanel/RuleBuilder/ActionList.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/RuleBuilder/ActionList.tsx
@@ -39,7 +39,7 @@ const ActionList = ({ actions, onChange, boardId }: Props) => {
   useEffect(() => {
     apiClient
       .get(`/boards/${boardId}/workspace/boards`)
-      .then((res: any) => setWorkspaceBoards(res.data ?? []))
+      .then((res: any) => { setWorkspaceBoards(res.data ?? []); })
       .catch(() => {});
   }, [boardId]);
 
@@ -67,7 +67,7 @@ const ActionList = ({ actions, onChange, boardId }: Props) => {
         }
         setCustomFieldsById(map);
       })
-      .catch(() => setCustomFieldsById({}));
+      .catch(() => { setCustomFieldsById({}); });
   }, [boardId]);
   // Track which action is being configured (by local id).
   const [configuringId, setConfiguringId] = useState<string | null>(null);
@@ -130,8 +130,8 @@ const ActionList = ({ actions, onChange, boardId }: Props) => {
               <div key={action.id}>
                 <ActionItem
                   item={action}
-                  onDelete={() => handleDelete(action.id)}
-                  onConfigChange={(cfg) => handleConfigChange(action.id, cfg)}
+                  onDelete={() => { handleDelete(action.id); }}
+                  onConfigChange={(cfg) => { handleConfigChange(action.id, cfg); }}
                   workspaceBoards={workspaceBoards}
                   customFieldsById={customFieldsById}
                 />
@@ -142,7 +142,7 @@ const ActionList = ({ actions, onChange, boardId }: Props) => {
                     <ActionConfig
                       actionType={meta}
                       config={action.config}
-                      onChange={(cfg) => handleConfigChange(action.id, cfg)}
+                      onChange={(cfg) => { handleConfigChange(action.id, cfg); }}
                       boardId={boardId}
                     />
                   ) : null;
@@ -155,9 +155,9 @@ const ActionList = ({ actions, onChange, boardId }: Props) => {
                     <button
                       type="button"
                       className="mt-0.5 ml-9 text-xs text-blue-400 hover:underline"
-                      onClick={() =>
-                        setConfiguringId((prev) => (prev === action.id ? null : action.id))
-                      }
+                      onClick={() => {
+                        setConfiguringId((prev) => (prev === action.id ? null : action.id));
+                      }}
                     >
                       {configuringId === action.id ? translations['automation.actionList.hideConfig'] : translations['automation.actionList.configure']}
                     </button>
@@ -172,7 +172,7 @@ const ActionList = ({ actions, onChange, boardId }: Props) => {
       {showPicker && (
         <ActionPicker
           onSelect={handlePickAction}
-          onCancel={() => setShowPicker(false)}
+          onCancel={() => { setShowPicker(false); }}
         />
       )}
 
@@ -180,7 +180,7 @@ const ActionList = ({ actions, onChange, boardId }: Props) => {
         <button
           type="button"
           className="flex items-center gap-1.5 rounded-md border border-dashed border-border px-3 py-2 text-sm text-muted transition-colors hover:border-border hover:text-subtle focus:outline-none focus:ring-2 focus:ring-blue-500"
-          onClick={() => setShowPicker(true)}
+          onClick={() => { setShowPicker(true); }}
         >
           <PlusIcon className="h-4 w-4" aria-hidden="true" />
           {translations['automation.actionList.addAction']}

--- a/src/extensions/Automation/components/SchedulePanel/builders/ScheduledCommandBuilder.tsx
+++ b/src/extensions/Automation/components/SchedulePanel/builders/ScheduledCommandBuilder.tsx
@@ -224,7 +224,7 @@ const ScheduledCommandBuilder: FC<Props> = ({
                     <button
                       key={f}
                       type="button"
-                      onClick={() => setFrequency(f)}
+                      onClick={() => { setFrequency(f); }}
                       className={`rounded-md py-2 text-xs font-medium capitalize transition-colors ${
                         frequency === f
                           ? 'bg-primary text-white' // [theme-exception] text-white on active-state primary button
@@ -249,7 +249,7 @@ const ScheduledCommandBuilder: FC<Props> = ({
                         key={d}
                         type="button"
                         title={DAY_OF_WEEK_FULL[i]}
-                        onClick={() => setDayOfWeek(i)}
+                        onClick={() => { setDayOfWeek(i); }}
                         className={`rounded py-1.5 text-xs font-medium transition-colors ${
                           dayOfWeek === i
                             ? 'bg-primary text-white' // [theme-exception] text-white on active-state primary button
@@ -272,9 +272,9 @@ const ScheduledCommandBuilder: FC<Props> = ({
                   <div className="flex gap-2 flex-wrap">
                     <select
                       value={dayOfMonth === 'last' ? 'last' : String(dayOfMonth)}
-                      onChange={(e) =>
-                        setDayOfMonth(e.target.value === 'last' ? 'last' : Number(e.target.value))
-                      }
+                      onChange={(e) => {
+                        setDayOfMonth(e.target.value === 'last' ? 'last' : Number(e.target.value));
+                      }}
                       className="rounded-md bg-bg-overlay border border-border px-3 py-2 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
                     >
                       {Array.from({ length: 31 }, (_, i) => i + 1).map((d) => (
@@ -296,7 +296,7 @@ const ScheduledCommandBuilder: FC<Props> = ({
                   </label>
                   <select
                     value={month}
-                    onChange={(e) => setMonth(Number(e.target.value))}
+                    onChange={(e) => { setMonth(Number(e.target.value)); }}
                     className="rounded-md bg-bg-overlay border border-border px-3 py-2 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
                   >
                     {[
@@ -320,7 +320,7 @@ const ScheduledCommandBuilder: FC<Props> = ({
                 <div className="flex items-center gap-2">
                   <select
                     value={hour}
-                    onChange={(e) => setHour(Number(e.target.value))}
+                    onChange={(e) => { setHour(Number(e.target.value)); }}
                     className="rounded-md bg-bg-overlay border border-border px-3 py-2 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
                     aria-label={translations['automation.scheduledBuilder.hourAriaLabel']}
                   >
@@ -333,7 +333,7 @@ const ScheduledCommandBuilder: FC<Props> = ({
                   <span className="text-muted font-bold">:</span>
                   <select
                     value={minute}
-                    onChange={(e) => setMinute(Number(e.target.value))}
+                    onChange={(e) => { setMinute(Number(e.target.value)); }}
                     className="rounded-md bg-bg-overlay border border-border px-3 py-2 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
                     aria-label={translations['automation.scheduledBuilder.minuteAriaLabel']}
                   >
@@ -382,7 +382,7 @@ const ScheduledCommandBuilder: FC<Props> = ({
                   id="schedule-name"
                   type="text"
                   value={commandName}
-                  onChange={(e) => setNameOverride(e.target.value)}
+                  onChange={(e) => { setNameOverride(e.target.value); }}
                   maxLength={120}
                   className="rounded-md bg-bg-overlay border border-border px-3 py-2 text-sm text-base placeholder:text-subtle focus:outline-none focus:ring-2 focus:ring-primary"
                   placeholder={translations['automation.scheduledBuilder.commandNamePlaceholder']}
@@ -405,7 +405,7 @@ const ScheduledCommandBuilder: FC<Props> = ({
         <div className="flex items-center justify-between border-t border-border px-5 py-4">
           <button
             type="button"
-            onClick={step === 1 ? onClose : () => setStep((s) => (s - 1) as 1 | 2 | 3)}
+            onClick={step === 1 ? onClose : () => { setStep((s) => (s - 1) as 1 | 2 | 3); }}
             className="flex items-center gap-1 rounded-md px-3 py-2 text-sm font-medium text-subtle bg-bg-surface hover:bg-bg-overlay transition-colors"
           >
             {step === 1 ? (
@@ -422,7 +422,7 @@ const ScheduledCommandBuilder: FC<Props> = ({
             <button
               type="button"
               disabled={step === 1 ? !canProceedStep1 : !canProceedStep2}
-              onClick={() => setStep((s) => (s + 1) as 2 | 3)}
+              onClick={() => { setStep((s) => (s + 1) as 2 | 3); }}
               className="flex items-center gap-1 rounded-md px-4 py-2 text-sm font-medium text-white bg-primary hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors" // [theme-exception] text-white on primary button
             >
               {translations['automation.scheduledBuilder.next']}

--- a/src/extensions/CustomFields/BoardCustomFieldsPanel.tsx
+++ b/src/extensions/CustomFields/BoardCustomFieldsPanel.tsx
@@ -55,12 +55,13 @@ const BoardCustomFieldsPanel = () => {
   // Per-field operation in-progress flag (keyed by field id).
   const [busyIds, setBusyIds] = useState<Set<string>>(new Set());
 
-  const setFieldBusy = (id: string, busy: boolean) =>
+  const setFieldBusy = (id: string, busy: boolean) => {
     setBusyIds((prev) => {
       const next = new Set(prev);
       busy ? next.add(id) : next.delete(id);
       return next;
     });
+  };
 
   // ─── Create ──────────────────────────────────────────────────────────────
 
@@ -208,7 +209,7 @@ const BoardCustomFieldsPanel = () => {
                   type="text"
                   value={renameValue}
                   autoFocus
-                  onChange={(e) => setRenameValue(e.target.value)}
+                  onChange={(e) => { setRenameValue(e.target.value); }}
                   onBlur={() => void commitRename(field)}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') void commitRename(field);
@@ -221,7 +222,7 @@ const BoardCustomFieldsPanel = () => {
                 <button
                   type="button"
                   className="flex-1 text-left text-sm text-base hover:text-base truncate"
-                  onClick={() => startRename(field)}
+                  onClick={() => { startRename(field); }}
                   aria-label={`Rename field ${field.name}`}
                   disabled={busy}
                 >
@@ -264,7 +265,7 @@ const BoardCustomFieldsPanel = () => {
                 {expandedOptionsId !== field.id && (
                   <button
                     type="button"
-                    onClick={() => openOptionsEditor(field)}
+                    onClick={() => { openOptionsEditor(field); }}
                     className="text-xs text-blue-400 hover:text-blue-300 transition-colors"
                     aria-label={`Edit options for ${field.name}`}
                     disabled={busy}
@@ -313,7 +314,7 @@ const BoardCustomFieldsPanel = () => {
           <input
             type="text"
             value={newField.name}
-            onChange={(e) => setNewField((f) => ({ ...f, name: e.target.value }))}
+            onChange={(e) => { setNewField((f) => ({ ...f, name: e.target.value })); }}
             placeholder={translations['CustomFields.fieldNamePlaceholder']}
             className="w-full bg-bg-overlay border border-border rounded px-2 py-1 text-sm text-base placeholder:text-subtle focus:outline-none focus:ring-1 focus:ring-primary"
             autoFocus
@@ -323,9 +324,9 @@ const BoardCustomFieldsPanel = () => {
           {/* Type selector */}
           <select
             value={newField.field_type}
-            onChange={(e) =>
-              setNewField((f) => ({ ...f, field_type: e.target.value as FieldType, options: [] }))
-            }
+            onChange={(e) => {
+              setNewField((f) => ({ ...f, field_type: e.target.value as FieldType, options: [] }));
+            }}
             className="w-full bg-bg-overlay border border-border rounded px-2 py-1 text-sm text-base focus:outline-none focus:ring-1 focus:ring-primary"
             aria-label={translations['CustomFields.typeLabel']}
           >
@@ -340,7 +341,7 @@ const BoardCustomFieldsPanel = () => {
           {newField.field_type === 'DROPDOWN' && (
             <DropdownFieldEditor
               options={newField.options}
-              onChange={(opts) => setNewField((f) => ({ ...f, options: opts }))}
+              onChange={(opts) => { setNewField((f) => ({ ...f, options: opts })); }}
             />
           )}
 
@@ -349,7 +350,7 @@ const BoardCustomFieldsPanel = () => {
             <input
               type="checkbox"
               checked={newField.show_on_card}
-              onChange={(e) => setNewField((f) => ({ ...f, show_on_card: e.target.checked }))}
+              onChange={(e) => { setNewField((f) => ({ ...f, show_on_card: e.target.checked })); }}
               className="accent-blue-500"
               aria-label={translations['CustomFields.showOnCardLabel']}
             />
@@ -381,7 +382,7 @@ const BoardCustomFieldsPanel = () => {
       ) : (
         <button
           type="button"
-          onClick={() => setShowForm(true)}
+          onClick={() => { setShowForm(true); }}
           className="w-full text-left text-xs text-blue-400 hover:text-blue-300 transition-colors py-1"
           aria-label={translations['CustomFields.ariaCreateField']}
         >

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -248,7 +248,7 @@ export default function Sidebar({ onClose }: SidebarProps = {}) {
             <div className="relative group">
               <Button
                 variant="ghost"
-                onClick={() => setSwitcherOpen((o) => !o)}
+                onClick={() => { setSwitcherOpen((o) => !o); }}
                 aria-label={translations['WorkspaceSwitcher.label']}
                 aria-expanded={switcherOpen}
                 className="flex w-full justify-center rounded-lg p-2 font-normal"
@@ -274,7 +274,7 @@ export default function Sidebar({ onClose }: SidebarProps = {}) {
             <div className="relative">
               <Button
                 variant="ghost"
-                onClick={() => setSwitcherOpen((o) => !o)}
+                onClick={() => { setSwitcherOpen((o) => !o); }}
                 aria-expanded={switcherOpen}
                 aria-haspopup="listbox"
                 aria-label={translations['WorkspaceSwitcher.label']}
@@ -302,7 +302,7 @@ export default function Sidebar({ onClose }: SidebarProps = {}) {
                     <li key={ws.id} role="option" aria-selected={ws.id === activeWorkspace?.id}>
                       <Button
                         variant="ghost"
-                        onClick={() => handleSwitchWorkspace(ws.id)}
+                        onClick={() => { handleSwitchWorkspace(ws.id); }}
                         className="w-full rounded-none px-3 py-1.5 text-left text-sm font-normal justify-start"
                       >
                         {ws.name}
@@ -441,7 +441,7 @@ export default function Sidebar({ onClose }: SidebarProps = {}) {
             !collapsed && (
               <Button
                 variant="ghost"
-                onClick={() => setShowCreateModal(true)}
+                onClick={() => { setShowCreateModal(true); }}
                 className="mt-2 w-full rounded-lg border border-dashed border-border px-3 py-2 text-sm font-normal text-muted hover:border-border-strong hover:text-subtle"
               >
                 {translations['Sidebar.createFirst']}
@@ -458,7 +458,7 @@ export default function Sidebar({ onClose }: SidebarProps = {}) {
               <div className="relative group">
                 <Button
                   variant="ghost"
-                  onClick={() => setUserMenuOpen((o) => !o)}
+                  onClick={() => { setUserMenuOpen((o) => !o); }}
                   aria-expanded={userMenuOpen}
                   aria-haspopup="menu"
                   aria-label={userDisplayName}
@@ -487,7 +487,7 @@ export default function Sidebar({ onClose }: SidebarProps = {}) {
               // Expanded: full user button
               <Button
                 variant="ghost"
-                onClick={() => setUserMenuOpen((o) => !o)}
+                onClick={() => { setUserMenuOpen((o) => !o); }}
                 aria-expanded={userMenuOpen}
                 aria-haspopup="menu"
                 className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm font-normal justify-start"
@@ -526,7 +526,7 @@ export default function Sidebar({ onClose }: SidebarProps = {}) {
                   <NavLink
                     to="/settings/profile"
                     role="menuitem"
-                    onClick={() => setUserMenuOpen(false)}
+                    onClick={() => { setUserMenuOpen(false); }}
                     className="block w-full px-3 py-1.5 text-left text-sm text-base hover:bg-bg-overlay transition-colors"
                   >
                     {translations['Sidebar.settings']}
@@ -536,7 +536,7 @@ export default function Sidebar({ onClose }: SidebarProps = {}) {
                   <NavLink
                     to="/settings/api-tokens"
                     role="menuitem"
-                    onClick={() => setUserMenuOpen(false)}
+                    onClick={() => { setUserMenuOpen(false); }}
                     className="block w-full px-3 py-1.5 text-left text-sm text-base hover:bg-bg-overlay transition-colors"
                   >
                     {translations['Sidebar.apiTokens']}
@@ -546,7 +546,7 @@ export default function Sidebar({ onClose }: SidebarProps = {}) {
                   <NavLink
                     to="/settings/webhooks"
                     role="menuitem"
-                    onClick={() => setUserMenuOpen(false)}
+                    onClick={() => { setUserMenuOpen(false); }}
                     className="block w-full px-3 py-1.5 text-left text-sm text-base hover:bg-bg-overlay transition-colors"
                   >
                     {translations['Sidebar.webhooks']}


### PR DESCRIPTION
## Summary

Fixes 59 `@typescript-eslint/no-confusing-void-expression` findings across 7 files. Arrow-function shorthands returning a void expression (`() => void fn()`) are converted to block-body form (`() => { void fn(); }`). Behaviour-identical: void returns are discarded either way.

## Scope

- Rule family: `@typescript-eslint/no-confusing-void-expression`
- 7 files, 66 insertions / 65 deletions (the +1 is a multiline-conversion cleanup by the same fixer)
- Files: ScheduledCommandBuilder.tsx (9), BoardCustomFieldsPanel.tsx (9), Sidebar.tsx (9), CommandPalette.tsx (8), InviteExternalUserModal.tsx (8), SignupForm.tsx (8), ActionList.tsx (8)

## Verification

- Focused lint on all 7 touched files: **0 `no-confusing-void-expression` findings** (exit 0)
- `bun run typecheck`: exit 2, **146 errors — identical to current main baseline** (no new failures)
- `bun test`: **1444 tests, identical fail identities to current main** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**

## UI/E2E coverage

All touched files are UI components with no dedicated executable UI/E2E coverage — recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched. No unrelated files in the diff.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.