### PR TITLE
lint: add braces to void-returning arrow shorthands (confusing-void batch 3)

### DIFF
--- a/src/extensions/Attachments/components/AttachmentItem.tsx
+++ b/src/extensions/Attachments/components/AttachmentItem.tsx
@@ -302,12 +302,12 @@ export function AttachmentItem({ attachment, uploadProgress, onDelete, onRename,
     });
   };
 
-  const handleDeleteClick = (): void => setConfirming(true);
+  const handleDeleteClick = (): void => { setConfirming(true); };
   const handleDeleteConfirm = (): void => {
     setConfirming(false);
     onDelete(attachment.id);
   };
-  const handleDeleteCancel = (): void => setConfirming(false);
+  const handleDeleteCancel = (): void => { setConfirming(false); };
 
   // Begin inline rename: pre-fill with current display name and show input
   const handleEditClick = (): void => {
@@ -452,7 +452,7 @@ export function AttachmentItem({ attachment, uploadProgress, onDelete, onRename,
               aria-label={translations['attachment.rename.save']}
               data-testid="attachment-rename-save"
               // Prevent onBlur from firing before click registers
-              onMouseDown={(e) => e.preventDefault()}
+              onMouseDown={(e) => { e.preventDefault(); }}
             >
               {translations['attachment.rename.save']}
             </Button>
@@ -464,7 +464,7 @@ export function AttachmentItem({ attachment, uploadProgress, onDelete, onRename,
               aria-label={translations['attachment.rename.cancel']}
               data-testid="attachment-rename-cancel"
               // Prevent onBlur from firing commit before cancel registers
-              onMouseDown={(e) => e.preventDefault()}
+              onMouseDown={(e) => { e.preventDefault(); }}
             >
               {translations['attachment.rename.cancel']}
             </Button>
@@ -508,17 +508,17 @@ export function AttachmentItem({ attachment, uploadProgress, onDelete, onRename,
 
       {/* Video player overlay — use proxy view_url */}
       {videoOpen && isVideo && attachment.view_url && (
-        <VideoLightbox src={attachment.view_url} name={attachment.name} onClose={() => setVideoOpen(false)} />
+        <VideoLightbox src={attachment.view_url} name={attachment.name} onClose={() => { setVideoOpen(false); }} />
       )}
 
       {/* PDF preview overlay — use proxy view_url */}
       {pdfOpen && isPdf && attachment.view_url && (
-        <PdfLightbox src={attachment.view_url} name={attachment.name} onClose={() => setPdfOpen(false)} />
+        <PdfLightbox src={attachment.view_url} name={attachment.name} onClose={() => { setPdfOpen(false); }} />
       )}
 
       {/* Image preview overlay — use thumbnail/view proxy url */}
       {imageOpen && isImage && imagePreviewSrc && (
-        <ImageLightbox src={imagePreviewSrc} name={attachment.name} onClose={() => setImageOpen(false)} />
+        <ImageLightbox src={imagePreviewSrc} name={attachment.name} onClose={() => { setImageOpen(false); }} />
       )}
     </div>
   );

--- a/src/extensions/Automation/components/AutomationPanel/RuleBuilder/TriggerConfig.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/RuleBuilder/TriggerConfig.tsx
@@ -57,7 +57,7 @@ const TriggerConfig = ({ triggerType, config, onChange, boardId }: Props) => {
   useEffect(() => {
     apiClient
       .get(`/boards/${boardId}/lists`)
-      .then((res: any) => setBoardLists(res.data ?? []))
+      .then((res: any) => { setBoardLists(res.data ?? []); })
       .catch(() => {});
   }, [boardId]);
 
@@ -77,7 +77,7 @@ const TriggerConfig = ({ triggerType, config, onChange, boardId }: Props) => {
             }))
         );
       })
-      .catch(() => setCustomFields([]));
+      .catch(() => { setCustomFields([]); });
   }, [boardId]);
 
   if (triggerType.type === CUSTOM_FIELD_VALUE_UPDATED_TRIGGER) {
@@ -130,7 +130,7 @@ const TriggerConfig = ({ triggerType, config, onChange, boardId }: Props) => {
             id="cfg-fieldId"
             className="w-full rounded-md border border-border bg-bg-overlay px-3 py-1.5 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
             value={selectedFieldId}
-            onChange={(e) => setField(e.target.value)}
+            onChange={(e) => { setField(e.target.value); }}
           >
             <option value="">{translations['automation.triggerConfig.customField.selectFieldPlaceholder']}</option>
             {customFields.map((field) => (
@@ -157,7 +157,7 @@ const TriggerConfig = ({ triggerType, config, onChange, boardId }: Props) => {
                 className="w-full rounded-md border border-border bg-bg-overlay px-3 py-1.5 text-sm text-base placeholder:text-subtle focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder={translations['automation.triggerConfig.customField.textPlaceholder']}
                 value={typeof config.valueText === 'string' ? config.valueText : ''}
-                onChange={(e) => setValue({ valueText: e.target.value })}
+                onChange={(e) => { setValue({ valueText: e.target.value }); }}
               />
             )}
 
@@ -179,7 +179,7 @@ const TriggerConfig = ({ triggerType, config, onChange, boardId }: Props) => {
                 type="date"
                 className="w-full rounded-md border border-border bg-bg-overlay px-3 py-1.5 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
                 value={typeof config.valueDate === 'string' ? config.valueDate.slice(0, 10) : ''}
-                onChange={(e) => setValue({ valueDate: e.target.value })}
+                onChange={(e) => { setValue({ valueDate: e.target.value }); }}
               />
             )}
 
@@ -187,7 +187,7 @@ const TriggerConfig = ({ triggerType, config, onChange, boardId }: Props) => {
               <select
                 className="w-full rounded-md border border-border bg-bg-overlay px-3 py-1.5 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
                 value={typeof config.valueCheckbox === 'boolean' ? String(config.valueCheckbox) : ''}
-                onChange={(e) => setValue({ valueCheckbox: e.target.value === 'true' })}
+                onChange={(e) => { setValue({ valueCheckbox: e.target.value === 'true' }); }}
               >
                 <option value="false">{translations['automation.triggerConfig.customField.checkboxFalse']}</option>
                 <option value="true">{translations['automation.triggerConfig.customField.checkboxTrue']}</option>
@@ -198,7 +198,7 @@ const TriggerConfig = ({ triggerType, config, onChange, boardId }: Props) => {
               <select
                 className="w-full rounded-md border border-border bg-bg-overlay px-3 py-1.5 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
                 value={typeof config.valueOptionId === 'string' ? config.valueOptionId : ''}
-                onChange={(e) => setValue({ valueOptionId: e.target.value })}
+                onChange={(e) => { setValue({ valueOptionId: e.target.value }); }}
               >
                 <option value="">{translations['automation.triggerConfig.customField.selectOptionPlaceholder']}</option>
                 {(selectedField.options ?? []).map((option) => (
@@ -225,7 +225,7 @@ const TriggerConfig = ({ triggerType, config, onChange, boardId }: Props) => {
           key,
           fieldDef,
           value: config[key],
-          onChange: (val) => onChange({ ...config, [key]: val }),
+          onChange: (val) => { onChange({ ...config, [key]: val }); },
           boardLists,
         })
       )}

--- a/src/extensions/Automation/components/AutomationPanel/index.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/index.tsx
@@ -67,7 +67,7 @@ const AutomationPanel = ({ boardId, isOpen, activeTab, onClose, onTabChange }: P
       if (e.key === 'Escape') onClose();
     };
     document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
+    return () => { document.removeEventListener('keydown', handleKey); };
   }, [isOpen, onClose]);
 
   if (!isOpen) return null;
@@ -111,7 +111,7 @@ const AutomationPanel = ({ boardId, isOpen, activeTab, onClose, onTabChange }: P
           {TABS.map((tab) => (
             <button
               key={tab.id}
-              onClick={() => onTabChange(tab.id)}
+              onClick={() => { onTabChange(tab.id); }}
               className={`rounded-t px-3 py-2 text-xs font-medium transition-colors ${
                 activeTab === tab.id
                   ? 'border-b-2 border-blue-500 text-blue-400'
@@ -154,7 +154,7 @@ const AutomationPanel = ({ boardId, isOpen, activeTab, onClose, onTabChange }: P
                     setEditingRule(null);
                     void loadAutomations();
                   }}
-                  onCancel={() => setEditingRule(null)}
+                  onCancel={() => { setEditingRule(null); }}
                 />
               )}
               {!loading && !error && editingRule === undefined && (
@@ -165,18 +165,18 @@ const AutomationPanel = ({ boardId, isOpen, activeTab, onClose, onTabChange }: P
                     setEditingRule(null);
                     void loadAutomations();
                   }}
-                  onCancel={() => setEditingRule(null)}
+                  onCancel={() => { setEditingRule(null); }}
                 />
               )}
               {!loading && !error && editingRule === null && rules.length === 0 && (
-                <AutomationEmptyState onCreateRule={() => setEditingRule(undefined)} />
+                <AutomationEmptyState onCreateRule={() => { setEditingRule(undefined); }} />
               )}
               {!loading && !error && editingRule === null && rules.length > 0 && (
                 <AutomationList
                   boardId={boardId}
                   automations={automations}
-                  onCreateRule={() => setEditingRule(undefined)}
-                  onEditRule={(a) => setEditingRule(a)}
+                  onCreateRule={() => { setEditingRule(undefined); }}
+                  onEditRule={(a) => { setEditingRule(a); }}
                   onChanged={() => void loadAutomations()}
                 />
               )}

--- a/src/extensions/Card/components/CardDatesPicker.tsx
+++ b/src/extensions/Card/components/CardDatesPicker.tsx
@@ -209,7 +209,7 @@ export const CardDatesPicker = ({
             <button
               type="button"
               className="h-7 w-7 rounded text-muted hover:bg-bg-overlay hover:text-base transition-colors"
-              onClick={() => shiftYear(-1)}
+              onClick={() => { shiftYear(-1); }}
               aria-label="Previous year"
             >
               <ChevronDoubleLeftIcon className="mx-auto h-3.5 w-3.5" aria-hidden="true" />
@@ -217,7 +217,7 @@ export const CardDatesPicker = ({
             <button
               type="button"
               className="h-7 w-7 rounded text-muted hover:bg-bg-overlay hover:text-base transition-colors"
-              onClick={() => shiftMonth(-1)}
+              onClick={() => { shiftMonth(-1); }}
               aria-label="Previous month"
             >
               <ChevronLeftIcon className="mx-auto h-3.5 w-3.5" aria-hidden="true" />
@@ -230,7 +230,7 @@ export const CardDatesPicker = ({
             <button
               type="button"
               className="h-7 w-7 rounded text-muted hover:bg-bg-overlay hover:text-base transition-colors"
-              onClick={() => shiftMonth(1)}
+              onClick={() => { shiftMonth(1); }}
               aria-label="Next month"
             >
               <ChevronRightIcon className="mx-auto h-3.5 w-3.5" aria-hidden="true" />
@@ -238,7 +238,7 @@ export const CardDatesPicker = ({
             <button
               type="button"
               className="h-7 w-7 rounded text-muted hover:bg-bg-overlay hover:text-base transition-colors"
-              onClick={() => shiftYear(1)}
+              onClick={() => { shiftYear(1); }}
               aria-label="Next year"
             >
               <ChevronDoubleRightIcon className="mx-auto h-3.5 w-3.5" aria-hidden="true" />
@@ -283,7 +283,7 @@ export const CardDatesPicker = ({
               type="text"
               placeholder="M/D/YYYY"
               value={startInput}
-              onChange={(e) => setStartInput(e.target.value)}
+              onChange={(e) => { setStartInput(e.target.value); }}
               onFocus={() => { setActiveField('start'); setStartEnabled(true); }}
               onBlur={handleStartBlur}
               disabled={disabled}
@@ -311,8 +311,8 @@ export const CardDatesPicker = ({
               type="text"
               placeholder="M/D/YYYY"
               value={dueInput}
-              onChange={(e) => setDueInput(e.target.value)}
-              onFocus={() => setActiveField('due')}
+              onChange={(e) => { setDueInput(e.target.value); }}
+              onFocus={() => { setActiveField('due'); }}
               onBlur={handleDueBlur}
               disabled={disabled}
               className="flex-1 min-w-0 bg-bg-overlay border border-border rounded px-2.5 py-1.5 text-sm text-base placeholder:text-subtle focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50"
@@ -321,7 +321,7 @@ export const CardDatesPicker = ({
               type="text"
               placeholder="H:MM AM"
               value={timeInput}
-              onChange={(e) => setTimeInput(e.target.value)}
+              onChange={(e) => { setTimeInput(e.target.value); }}
               disabled={!draftDue || disabled}
               className="w-24 flex-shrink-0 bg-bg-overlay border border-border rounded px-2.5 py-1.5 text-sm text-base placeholder:text-subtle focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50"
             />

--- a/src/extensions/Card/components/CardDescriptionTiptap.tsx
+++ b/src/extensions/Card/components/CardDescriptionTiptap.tsx
@@ -1442,14 +1442,14 @@ const CardDescriptionTiptap = ({ boardId, cardId, description, onSave, disabled 
               <button
                 type="button"
                 className={`px-2 py-1 text-xs ${editMode === 'rich' ? 'bg-indigo-600 text-inverse' : 'bg-bg-surface text-muted'}`}
-                onClick={() => handleModeChange('rich')}
+                onClick={() => { handleModeChange('rich'); }}
               >
                 Rich text
               </button>
               <button
                 type="button"
                 className={`px-2 py-1 text-xs ${editMode === 'markdown' ? 'bg-indigo-600 text-inverse' : 'bg-bg-surface text-muted'}`}
-                onClick={() => handleModeChange('markdown')}
+                onClick={() => { handleModeChange('markdown'); }}
               >
                 Markdown
               </button>
@@ -1463,7 +1463,7 @@ const CardDescriptionTiptap = ({ boardId, cardId, description, onSave, disabled 
                 <OneLineToolbar
                   editor={editor}
                   overflowOpen={overflowOpen}
-                  onToggleOverflow={() => setOverflowOpen((o) => !o)}
+                  onToggleOverflow={() => { setOverflowOpen((o) => !o); }}
                   linkPopoverOpen={linkPopoverOpen}
                   onToggleLinkPopover={() => {
                     closeLinkConfigUi();
@@ -1475,7 +1475,7 @@ const CardDescriptionTiptap = ({ boardId, cardId, description, onSave, disabled 
                 {linkPopoverOpen && (
                   <LinkInsertPopover
                     editor={editor}
-                    onClose={() => setLinkPopoverOpen(false)}
+                    onClose={() => { setLinkPopoverOpen(false); }}
                   />
                 )}
                 {assetPickerOpen && cardId && (
@@ -1483,7 +1483,7 @@ const CardDescriptionTiptap = ({ boardId, cardId, description, onSave, disabled 
                     attachments={cardAttachments}
                     onUploadNew={() => fileInputRef.current?.click()}
                     onInsert={handleInsertExisting}
-                    onClose={() => setAssetPickerOpen(false)}
+                    onClose={() => { setAssetPickerOpen(false); }}
                   />
                 )}
               </div>
@@ -1798,12 +1798,12 @@ const CardDescriptionTiptap = ({ boardId, cardId, description, onSave, disabled 
                   <button
                     type="button"
                     className="text-indigo-400 hover:text-indigo-300 underline transition-colors"
-                    onClick={() => retrySync(buildDescriptionSaveMarkdown(
+                    onClick={() => { retrySync(buildDescriptionSaveMarkdown(
                       editMode,
                       editor,
                       draft,
                       cardAttachmentsRef.current,
-                    ))}
+                    )); }}
                     data-testid="draft-retry-sync"
                   >
                     {/* [why] "Retry Save" clarifies the user's pending action vs a background sync retry */}
@@ -1914,7 +1914,7 @@ const CardDescriptionTiptap = ({ boardId, cardId, description, onSave, disabled 
             <button
               type="button"
               className="mt-2 text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
-              onClick={() => setExpanded((e) => !e)}
+              onClick={() => { setExpanded((e) => !e); }}
             >
               {expanded ? 'Show less ↑' : 'Show more ↓'}
             </button>

--- a/src/extensions/Card/components/CopyCardModal.tsx
+++ b/src/extensions/Card/components/CopyCardModal.tsx
@@ -183,7 +183,7 @@ const CopyCardModal = ({
               id="copy-card-title"
               type="text"
               value={title}
-              onChange={(e) => setTitle(e.target.value)}
+              onChange={(e) => { setTitle(e.target.value); }}
               className="w-full rounded-lg border border-border bg-bg-overlay px-3 py-2 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
               autoFocus
             />
@@ -197,7 +197,7 @@ const CopyCardModal = ({
                 <input
                   type="checkbox"
                   checked={keepChecklists}
-                  onChange={(e) => setKeepChecklists(e.target.checked)}
+                  onChange={(e) => { setKeepChecklists(e.target.checked); }}
                   className="rounded border-border-strong text-blue-500 focus:ring-blue-500"
                 />
                 <span className="text-sm text-base">
@@ -213,7 +213,7 @@ const CopyCardModal = ({
                 <input
                   type="checkbox"
                   checked={keepMembers}
-                  onChange={(e) => setKeepMembers(e.target.checked)}
+                  onChange={(e) => { setKeepMembers(e.target.checked); }}
                   className="rounded border-border-strong text-blue-500 focus:ring-blue-500"
                 />
                 <span className="text-sm text-base">
@@ -240,7 +240,7 @@ const CopyCardModal = ({
                 <select
                   id="copy-card-board"
                   value={selectedBoardId}
-                  onChange={(e) => setSelectedBoardId(e.target.value)}
+                  onChange={(e) => { setSelectedBoardId(e.target.value); }}
                   className="w-full rounded-lg border border-border bg-bg-overlay px-2 py-1.5 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
                 >
                   {boards.map((b) => (
@@ -260,7 +260,7 @@ const CopyCardModal = ({
                   <select
                     id="copy-card-list"
                     value={selectedListId}
-                    onChange={(e) => handleListChange(e.target.value)}
+                    onChange={(e) => { handleListChange(e.target.value); }}
                     className="w-full rounded-lg border border-border bg-bg-overlay px-2 py-1.5 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
                   >
                     {lists.map((l) => (
@@ -278,7 +278,7 @@ const CopyCardModal = ({
                   <select
                     id="copy-card-position"
                     value={selectedPosition}
-                    onChange={(e) => setSelectedPosition(Number(e.target.value))}
+                    onChange={(e) => { setSelectedPosition(Number(e.target.value)); }}
                     className="w-full rounded-lg border border-border bg-bg-overlay px-2 py-1.5 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary"
                   >
                     {Array.from({ length: maxPosition }, (_, i) => i + 1).map((pos) => (

--- a/src/extensions/Card/components/OneLineToolbar.tsx
+++ b/src/extensions/Card/components/OneLineToolbar.tsx
@@ -196,7 +196,7 @@ const ListDropdown = ({ editor }: ListDropdownProps) => {
       if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
     };
     document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    return () => { document.removeEventListener('mousedown', handler); };
   }, [open]);
 
   const { isBullet, isOrdered } = useEditorState({
@@ -298,7 +298,7 @@ const HeadingDropdown = ({ editor }: HeadingDropdownProps) => {
       if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
     };
     document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    return () => { document.removeEventListener('mousedown', handler); };
   }, [open]);
 
   // [why] editor.isActive() reads the current selection from the editor state.
@@ -434,7 +434,7 @@ const OneLineToolbar = ({ editor, overflowOpen, onToggleOverflow, onAttach, link
       }
     };
     document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
+    return () => { document.removeEventListener('keydown', handler); };
   }, []);
 
   // Close emoji picker when clicking outside.
@@ -475,7 +475,7 @@ const OneLineToolbar = ({ editor, overflowOpen, onToggleOverflow, onAttach, link
       }
     };
     document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    return () => { document.removeEventListener('mousedown', handler); };
   }, [overflowOpen, onToggleOverflow]);
 
   const runCmd = useCallback(
@@ -694,7 +694,7 @@ const OneLineToolbar = ({ editor, overflowOpen, onToggleOverflow, onAttach, link
             <CommandMenu
               editor={editor}
               onClose={onToggleOverflow}
-              onOpenEmojiPicker={() => setEmojiPickerOpen(true)}
+              onOpenEmojiPicker={() => { setEmojiPickerOpen(true); }}
               extraCommands={hiddenResponsiveCommands}
             />
           )}
@@ -718,7 +718,7 @@ const OneLineToolbar = ({ editor, overflowOpen, onToggleOverflow, onAttach, link
     </div>
 
       {/* Editor help modal — rendered via portal outside the toolbar div */}
-      {helpOpen && <EditorHelpModal onClose={() => setHelpOpen(false)} />}
+      {helpOpen && <EditorHelpModal onClose={() => { setHelpOpen(false); }} />}
     </>
   );
 };

--- a/src/extensions/Comment/components/CommentItem.tsx
+++ b/src/extensions/Comment/components/CommentItem.tsx
@@ -442,7 +442,7 @@ const CommentItem = ({ comment, boardId, attachments = [], currentUserId, isAdmi
 
     return () => {
       cancelled = true;
-      objectUrls.forEach((value) => URL.revokeObjectURL(value));
+      objectUrls.forEach((value) => { URL.revokeObjectURL(value); });
     };
   }, [comment.content, attachments, editing]);
 
@@ -506,7 +506,7 @@ const CommentItem = ({ comment, boardId, attachments = [], currentUserId, isAdmi
             availableAttachments={attachments}
             initialValue={comment.content}
             onSubmit={handleEdit}
-            onCancel={() => setEditing(false)}
+            onCancel={() => { setEditing(false); }}
             submitLabel={translations['comment.editor.update']}
           />
         ) : (
@@ -571,7 +571,7 @@ const CommentItem = ({ comment, boardId, attachments = [], currentUserId, isAdmi
               <Button
                 variant="link"
                 className="p-0 text-xs text-muted hover:text-subtle"
-                onClick={() => setEditing(true)}
+                onClick={() => { setEditing(true); }}
               >
                 {translations['comment.action.edit']}
               </Button>
@@ -594,7 +594,7 @@ const CommentItem = ({ comment, boardId, attachments = [], currentUserId, isAdmi
                 <Button
                   variant="link"
                   className="p-0 text-xs text-muted hover:text-subtle"
-                  onClick={() => setShowReplyEditor((prev) => !prev)}
+                  onClick={() => { setShowReplyEditor((prev) => !prev); }}
                 >
                   {translations['comment.action.reply']}
                 </Button>
@@ -614,7 +614,7 @@ const CommentItem = ({ comment, boardId, attachments = [], currentUserId, isAdmi
             expanded={replyExpanded}
             showReplyEditor={showReplyEditor}
             onExpandToggle={setReplyExpanded}
-            onHideReplyEditor={() => setShowReplyEditor(false)}
+            onHideReplyEditor={() => { setShowReplyEditor(false); }}
             onAddReply={handleAddReply}
             onEditReply={onEditReply ?? (() => Promise.resolve())}
             onDeleteReply={onDeleteReply ?? (() => Promise.resolve())}
@@ -627,7 +627,7 @@ const CommentItem = ({ comment, boardId, attachments = [], currentUserId, isAdmi
         <ImageLightbox
           src={previewImage.src}
           name={previewImage.alt}
-          onClose={() => setPreviewImage(null)}
+          onClose={() => { setPreviewImage(null); }}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary

Fixes 55 `@typescript-eslint/no-confusing-void-expression` findings across 8 files. Arrow-function shorthands returning a void expression (`() => void fn()`) are converted to block-body form (`() => { void fn(); }`). Behaviour-identical: void returns are discarded either way.

## Scope

- Rule family: `@typescript-eslint/no-confusing-void-expression`
- 8 files, 56 insertions / 56 deletions (all brace conversions)
- Files: TriggerConfig.tsx (8), CardDatesPicker.tsx (8), AttachmentItem.tsx (7), AutomationPanel/index.tsx (7), CardDescriptionTiptap.tsx (7), CopyCardModal.tsx (6), OneLineToolbar.tsx (6), CommentItem.tsx (6)

## Verification

- Focused lint on all 8 touched files: **0 `no-confusing-void-expression` findings** (exit 0)
- `bun run typecheck`: exit 2, **146 errors — identical to current main baseline** (no new failures)
- `bun test`: **1444 tests, identical fail identities to current main** (pre-existing 180 fail / 30 errors baseline, no new failures)
- `bun run build:client`: **passed** (exit 0)
- `git diff --check`: **clean**
- Diff audited line-by-line: every change is a pure brace conversion (incl. non-React promise callbacks and `(): void => x` assignments), no out-of-scope edits

## UI/E2E coverage

All touched files are UI components with no dedicated executable UI/E2E coverage — recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched. No unrelated files in the diff.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.