### PR TITLE
lint: add braces to void-returning arrow shorthands (confusing-void batch 5)

### DIFF
--- a/server/extensions/trelloCompat/tests/unit/server/extensions/trelloCompat/checklists.contract.test.ts
+++ b/server/extensions/trelloCompat/tests/unit/server/extensions/trelloCompat/checklists.contract.test.ts
@@ -21,8 +21,8 @@ describe('trelloCompat checklists adapter contract', () => {
       assigned_member_id: null,
     }));
 
-    expect(() => assertTrelloShape('checkitem', completeItem)).not.toThrow();
-    expect(() => assertTrelloShape('checkitem', incompleteItem)).not.toThrow();
+    expect(() => { assertTrelloShape('checkitem', completeItem); }).not.toThrow();
+    expect(() => { assertTrelloShape('checkitem', incompleteItem); }).not.toThrow();
 
     expect(completeItem).toMatchObject({
       id: 'item-1',
@@ -50,7 +50,7 @@ describe('trelloCompat checklists adapter contract', () => {
       checkItems: [checkItem],
     }));
 
-    expect(() => assertTrelloShape('checklist', checklist)).not.toThrow();
+    expect(() => { assertTrelloShape('checklist', checklist); }).not.toThrow();
     expect(checklist).toMatchObject({
       id: 'checklist-2',
       idBoard: 'board-1',

--- a/src/extensions/Attachments/components/AttachmentPanel.tsx
+++ b/src/extensions/Attachments/components/AttachmentPanel.tsx
@@ -426,7 +426,7 @@ export function AttachmentPanel({ cardId, canWrite = true, insertMarkdownRef, on
               key={entry.clientId}
               attachment={tempAttachment}
               uploadProgress={entry.phase === 'uploading' ? entry.progress : null}
-              onDelete={() => removeEntry(entry.clientId)}
+              onDelete={() => { removeEntry(entry.clientId); }}
             />
           );
         })}
@@ -513,7 +513,7 @@ export function AttachmentPanel({ cardId, canWrite = true, insertMarkdownRef, on
                 type="url"
                 placeholder={translations['attachments.panel.link.urlPlaceholder']}
                 value={linkUrl}
-                onChange={(e) => handleLinkUrlChange(e.target.value)}
+                onChange={(e) => { handleLinkUrlChange(e.target.value); }}
                 required
                 className="w-full text-sm bg-bg-overlay text-base placeholder:text-subtle border border-border rounded px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary"
                 data-testid="link-url-input"
@@ -557,7 +557,7 @@ export function AttachmentPanel({ cardId, canWrite = true, insertMarkdownRef, on
                   type="text"
                   placeholder={translations['attachments.panel.link.namePlaceholder']}
                   value={linkName}
-                  onChange={(e) => setLinkName(e.target.value)}
+                  onChange={(e) => { setLinkName(e.target.value); }}
                   className="w-full text-sm bg-bg-overlay text-base placeholder:text-subtle border border-border rounded px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary"
                   data-testid="link-name-input"
                 />
@@ -592,7 +592,7 @@ export function AttachmentPanel({ cardId, canWrite = true, insertMarkdownRef, on
           ) : (
             <button
               type="button"
-              onClick={() => setShowLinkForm(true)}
+              onClick={() => { setShowLinkForm(true); }}
               className="flex items-center gap-1 text-xs text-muted hover:text-subtle transition-colors"
               data-testid="attach-link-button"
             >

--- a/src/extensions/Attachments/components/InlineUploadPreview.tsx
+++ b/src/extensions/Attachments/components/InlineUploadPreview.tsx
@@ -24,14 +24,14 @@ export function InlineUploadPreview({ entry, onCancel }: Props) {
     if (!isImage) return;
     const url = URL.createObjectURL(entry.file);
     setObjectUrl(url);
-    return () => URL.revokeObjectURL(url);
+    return () => { URL.revokeObjectURL(url); };
   }, [entry.file, isImage]);
 
   // Auto-dismiss completed entries after 2 s so they don't clutter the editor
   useEffect(() => {
     if (entry.phase !== 'done') return;
-    const id = window.setTimeout(() => onCancel(entry.clientId), 2000);
-    return () => window.clearTimeout(id);
+    const id = window.setTimeout(() => { onCancel(entry.clientId); }, 2000);
+    return () => { window.clearTimeout(id); };
   }, [entry.phase, entry.clientId, onCancel]);
 
   const Icon = getMimeIcon(entry.file.type);
@@ -100,7 +100,7 @@ export function InlineUploadPreview({ entry, onCancel }: Props) {
         aria-label={translations['attachments.inline.cancel.ariaLabel'].replace('{fileName}', entry.file.name)}
         title={entry.phase === 'pending' ? translations['attachments.inline.cancel.remove'] : entry.phase === 'error' || entry.phase === 'done' ? translations['attachments.inline.cancel.dismiss'] : translations['attachments.inline.cancel.cancelUpload']}
         className="flex-shrink-0 text-muted hover:text-danger transition-colors"
-        onClick={() => onCancel(entry.clientId)}
+        onClick={() => { onCancel(entry.clientId); }}
       >
         <XMarkIcon className="h-4 w-4" />
       </button>

--- a/src/extensions/Auth/components/ChangeEmailForm.tsx
+++ b/src/extensions/Auth/components/ChangeEmailForm.tsx
@@ -35,7 +35,7 @@ export default function ChangeEmailForm({ currentEmail, onSuccess, onPending }: 
   const [pendingEmail, setPendingEmail] = useState<string | null>(null);
 
   if (pendingEmail) {
-    return <EmailChangePending pendingEmail={pendingEmail} onDismiss={() => setPendingEmail(null)} />;
+    return <EmailChangePending pendingEmail={pendingEmail} onDismiss={() => { setPendingEmail(null); }} />;
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -84,7 +84,7 @@ export default function ChangeEmailForm({ currentEmail, onSuccess, onPending }: 
         type="email"
         required
         value={newEmail}
-        onChange={(e) => setNewEmail(e.target.value)}
+        onChange={(e) => { setNewEmail(e.target.value); }}
         placeholder={currentEmail}
         className="w-full"
       />
@@ -95,7 +95,7 @@ export default function ChangeEmailForm({ currentEmail, onSuccess, onPending }: 
         type="password"
         required
         value={password}
-        onChange={(e) => setPassword(e.target.value)}
+        onChange={(e) => { setPassword(e.target.value); }}
         className="w-full"
       />
 

--- a/src/extensions/Auth/components/LoginForm.tsx
+++ b/src/extensions/Auth/components/LoginForm.tsx
@@ -63,8 +63,8 @@ export default function LoginForm({ onSubmit, isLoading, apiError }: LoginFormPr
             type="email"
             autoComplete="email"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            onBlur={() => setErrors((prev) => ({ ...prev, email: validateEmail(email) }))}
+            onChange={(e) => { setEmail(e.target.value); }}
+            onBlur={() => { setErrors((prev) => ({ ...prev, email: validateEmail(email) })); }}
             placeholder="you@example.com"
             className={`w-full bg-bg-overlay border ${errors.email ? 'border-danger' : 'border-border'} text-base placeholder:text-subtle rounded-lg px-4 py-2.5 focus:outline-none focus:ring-2 focus:ring-primary`}
           />
@@ -77,8 +77,8 @@ export default function LoginForm({ onSubmit, isLoading, apiError }: LoginFormPr
           label={translations.fields.password}
           autoComplete="current-password"
           value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          onBlur={() => setErrors((prev) => ({ ...prev, password: validatePassword(password) }))}
+          onChange={(e) => { setPassword(e.target.value); }}
+          onBlur={() => { setErrors((prev) => ({ ...prev, password: validatePassword(password) })); }}
           placeholder="••••••••"
           error={errors.password}
         />

--- a/src/extensions/Auth/containers/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/src/extensions/Auth/containers/ResetPasswordPage/ResetPasswordPage.tsx
@@ -25,10 +25,10 @@ export default function ResetPasswordPage() {
   useEffect(() => {
     if (status === 'success') {
       const timer = setTimeout(
-        () => navigate('/login', { replace: true, state: { toast: translations.resetPassword.success } }),
+        () => { navigate('/login', { replace: true, state: { toast: translations.resetPassword.success } }); },
         1500,
       );
-      return () => clearTimeout(timer);
+      return () => { clearTimeout(timer); };
     }
   }, [status, navigate]);
 
@@ -109,7 +109,7 @@ export default function ResetPasswordPage() {
                   type="password"
                   autoComplete="new-password"
                   value={password}
-                  onChange={(e) => setPassword(e.target.value)}
+                  onChange={(e) => { setPassword(e.target.value); }}
                   className="bg-bg-overlay border border-border rounded-lg px-3 py-2 text-base placeholder:text-subtle focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent text-sm"
                   aria-invalid={!!errors.password}
                   aria-describedby={errors.password ? 'reset-password-error' : undefined}
@@ -130,7 +130,7 @@ export default function ResetPasswordPage() {
                   type="password"
                   autoComplete="new-password"
                   value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  onChange={(e) => { setConfirmPassword(e.target.value); }}
                   className="bg-bg-overlay border border-border rounded-lg px-3 py-2 text-base placeholder:text-subtle focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent text-sm"
                   aria-invalid={!!errors.confirmPassword}
                   aria-describedby={errors.confirmPassword ? 'reset-confirm-error' : undefined}

--- a/src/extensions/Automation/components/BoardButtons/BoardButtonBuilder.tsx
+++ b/src/extensions/Automation/components/BoardButtons/BoardButtonBuilder.tsx
@@ -142,7 +142,7 @@ const BoardButtonBuilder: FC<Props> = ({ boardId, existing, onSave, onClose }) =
             id="board-btn-name"
             type="text"
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e) => { setName(e.target.value); }}
             placeholder={translations['automation.boardButtonBuilder.namePlaceholder']}
             maxLength={80}
             className="rounded-md bg-bg-surface border border-border px-3 py-2 text-sm text-base placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-blue-500"
@@ -163,7 +163,7 @@ const BoardButtonBuilder: FC<Props> = ({ boardId, existing, onSave, onClose }) =
               <button
                 key={s}
                 type="button"
-                onClick={() => setScope(s)}
+                onClick={() => { setScope(s); }}
                 className={[
                   'flex-1 rounded-md px-3 py-1.5 text-xs font-medium capitalize transition-colors border',
                   scope === s
@@ -185,7 +185,7 @@ const BoardButtonBuilder: FC<Props> = ({ boardId, existing, onSave, onClose }) =
                 id="scope-list-id"
                 type="text"
                 value={listId}
-                onChange={(e) => setListId(e.target.value)}
+                onChange={(e) => { setListId(e.target.value); }}
                 placeholder={translations['automation.boardButtonBuilder.listIdPlaceholder']}
                 className="rounded-md bg-bg-surface border border-border px-3 py-2 text-sm text-base placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-blue-500"
               />

--- a/src/extensions/Board/components/BoardHeader.tsx
+++ b/src/extensions/Board/components/BoardHeader.tsx
@@ -80,7 +80,7 @@ const BoardHeader = ({
       }
     };
     document.addEventListener('mousedown', handleMouseDown);
-    return () => document.removeEventListener('mousedown', handleMouseDown);
+    return () => { document.removeEventListener('mousedown', handleMouseDown); };
   }, [menuOpen]);
 
   const handleTitleClick = () => {
@@ -139,7 +139,7 @@ const BoardHeader = ({
           type="text"
           value={title}
           autoFocus
-          onChange={(e) => setTitle(e.target.value)}
+          onChange={(e) => { setTitle(e.target.value); }}
           onBlur={handleTitleSave}
           onKeyDown={handleKeyDown}
           className={`bg-bg-overlay font-semibold text-lg rounded px-2 py-0.5 focus:outline-none focus:ring-2 focus:ring-primary min-w-0 max-w-xs${hasBackground ? ' text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.5)]' : ' text-base'}`}
@@ -229,7 +229,7 @@ const BoardHeader = ({
           <div className="relative" ref={menuContainerRef}>
             <button
               className={`rounded p-1.5 transition-colors${hasBackground ? ' text-white/90 hover:bg-white/20 hover:text-white' : ' text-muted hover:bg-bg-surface hover:text-subtle'}`}
-              onClick={() => setMenuOpen((v) => !v)}
+              onClick={() => { setMenuOpen((v) => !v); }}
               aria-label="Board settings"
               aria-haspopup="true"
               aria-expanded={menuOpen}

--- a/src/extensions/Board/components/BoardMembersPanel/index.tsx
+++ b/src/extensions/Board/components/BoardMembersPanel/index.tsx
@@ -158,7 +158,7 @@ const BoardMembersPanel = ({ onClose, isGuest = false }: Props) => {
       {/* Panel — stop propagation so clicks inside don't close */}
       <div
         className="absolute right-0 top-0 h-full w-80 bg-bg-base border-l border-border flex flex-col shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
+        onClick={(e) => { e.stopPropagation(); }}
         role="dialog"
         aria-label="Board Members"
       >
@@ -178,7 +178,7 @@ const BoardMembersPanel = ({ onClose, isGuest = false }: Props) => {
         <div className="flex border-b border-border">
           <button
             type="button"
-            onClick={() => setActiveTab('members')}
+            onClick={() => { setActiveTab('members'); }}
             className={`flex-1 py-2 text-xs font-semibold uppercase tracking-wide transition-colors ${
               activeTab === 'members'
                 ? 'text-indigo-400 border-b-2 border-indigo-400 -mb-px'
@@ -192,7 +192,7 @@ const BoardMembersPanel = ({ onClose, isGuest = false }: Props) => {
           {/* Guests tab — only admins can invite guests; all can view */}
           <button
             type="button"
-            onClick={() => setActiveTab('guests')}
+            onClick={() => { setActiveTab('guests'); }}
             className={`flex-1 py-2 text-xs font-semibold uppercase tracking-wide transition-colors ${
               activeTab === 'guests'
                 ? 'text-indigo-400 border-b-2 border-indigo-400 -mb-px'

--- a/src/extensions/CalendarView/CalendarDayCell.tsx
+++ b/src/extensions/CalendarView/CalendarDayCell.tsx
@@ -46,7 +46,7 @@ const CalendarDayCell = ({
     setIsDragOver(true);
   };
 
-  const handleDragLeave = () => setIsDragOver(false);
+  const handleDragLeave = () => { setIsDragOver(false); };
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -90,7 +90,7 @@ const CalendarDayCell = ({
         {!expanded && overflow > 0 && (
           // [theme-exception]: CalendarView dark theme
           <button
-            onClick={() => setExpanded(true)}
+            onClick={() => { setExpanded(true); }}
             className="w-full rounded bg-bg-overlay px-1.5 py-0.5 text-left text-xs text-subtle hover:bg-bg-sunken hover:text-base focus:outline-none"
             data-testid={`calendar-day-overflow-${toIsoDate(date)}`}
           >
@@ -100,7 +100,7 @@ const CalendarDayCell = ({
         {expanded && overflow > 0 && (
           // [theme-exception]: CalendarView dark theme
           <button
-            onClick={() => setExpanded(false)}
+            onClick={() => { setExpanded(false); }}
             className="w-full rounded bg-bg-overlay px-1.5 py-0.5 text-left text-xs text-subtle hover:bg-bg-sunken hover:text-base focus:outline-none"
           >
             {translations['CalendarView.showLess']}

--- a/src/extensions/Card/components/CardLabels.tsx
+++ b/src/extensions/Card/components/CardLabels.tsx
@@ -85,7 +85,7 @@ const CardLabels = ({
           <button
             type="button"
             className="text-xs text-muted hover:text-base flex items-center gap-1 transition-colors"
-            onClick={() => setPickerOpen((v) => !v)}
+            onClick={() => { setPickerOpen((v) => !v); }}
             aria-haspopup="true"
             aria-expanded={pickerOpen}
           >
@@ -97,7 +97,7 @@ const CardLabels = ({
               {/* Backdrop to close picker */}
               <div
                 className="fixed inset-0 z-10"
-                onClick={() => setPickerOpen(false)}
+                onClick={() => { setPickerOpen(false); }}
                 aria-hidden="true"
               />
               <div className="absolute left-0 top-6 z-20 w-64 rounded-xl bg-bg-surface border border-border shadow-2xl p-3 space-y-3">
@@ -106,7 +106,7 @@ const CardLabels = ({
                   className="w-full bg-bg-overlay border border-border rounded-lg px-2 py-1.5 text-sm text-base placeholder:text-subtle focus:outline-none focus:ring-2 focus:ring-primary"
                   placeholder="Label name…"
                   value={newLabelName}
-                  onChange={(e) => setNewLabelName(e.target.value)}
+                  onChange={(e) => { setNewLabelName(e.target.value); }}
                   onKeyDown={(e) => { if (e.key === 'Enter') handleCreate(); }}
                   autoFocus
                 />
@@ -124,7 +124,7 @@ const CardLabels = ({
                           selectedColor === c.hex ? 'ring-2 ring-white ring-offset-2 ring-offset-slate-800' : ''
                         }`}
                         style={{ backgroundColor: c.hex }}
-                        onClick={() => setSelectedColor(c.hex)}
+                        onClick={() => { setSelectedColor(c.hex); }}
                         aria-label={c.name}
                       />
                     ))}

--- a/src/extensions/Card/components/CardModalBottomBar.tsx
+++ b/src/extensions/Card/components/CardModalBottomBar.tsx
@@ -104,7 +104,7 @@ const CardModalBottomBar = ({
             className={barButtonClass}
             aria-expanded={powerUps.open}
             aria-haspopup="true"
-            onClick={() => powerUps.setOpen((v) => !v)}
+            onClick={() => { powerUps.setOpen((v) => !v); }}
           >
             <PuzzlePieceIcon className="w-4 h-4" />
             Power-ups
@@ -134,7 +134,7 @@ const CardModalBottomBar = ({
             aria-expanded={automations.open}
             aria-haspopup="true"
             disabled={disabled}
-            onClick={() => automations.setOpen((v) => !v)}
+            onClick={() => { automations.setOpen((v) => !v); }}
           >
             <BoltIcon className="w-4 h-4" />
             Automations
@@ -154,7 +154,7 @@ const CardModalBottomBar = ({
             className={barButtonClass}
             aria-expanded={actions.open}
             aria-haspopup="true"
-            onClick={() => actions.setOpen((v) => !v)}
+            onClick={() => { actions.setOpen((v) => !v); }}
           >
             Actions
             <ChevronUpIcon className={`w-3 h-3 transition-transform ${actions.open ? '' : 'rotate-180'}`} />

--- a/src/extensions/Comment/components/CommentReactions.tsx
+++ b/src/extensions/Comment/components/CommentReactions.tsx
@@ -45,8 +45,8 @@ const CommentReactions = ({ reactions, onAdd, onRemove, className }: Props) => {
           <button
             type="button"
             onClick={() => void handlePillClick(reaction)}
-            onMouseEnter={() => setHoveredEmoji(reaction.emoji)}
-            onMouseLeave={() => setHoveredEmoji(null)}
+            onMouseEnter={() => { setHoveredEmoji(reaction.emoji); }}
+            onMouseLeave={() => { setHoveredEmoji(null); }}
             aria-label={translations['comment.reactions.aria.pill']
               .replace('{{emoji}}', reaction.emoji)
               .replace('{{count}}', String(reaction.count))
@@ -80,7 +80,7 @@ const CommentReactions = ({ reactions, onAdd, onRemove, className }: Props) => {
       <button
         ref={addButtonRef}
         type="button"
-        onClick={() => setPickerOpen((v) => !v)}
+        onClick={() => { setPickerOpen((v) => !v); }}
         aria-label={translations['comment.reactions.add']}
         className="inline-flex items-center gap-0.5 rounded-full border border-border bg-bg-overlay px-2 py-0.5 text-muted hover:text-base hover:bg-bg-sunken transition-colors cursor-pointer"
       >
@@ -92,7 +92,7 @@ const CommentReactions = ({ reactions, onAdd, onRemove, className }: Props) => {
         <EmojiPickerPopover
           anchorRef={addButtonRef as React.RefObject<HTMLElement | null>}
           onSelect={(emoji) => { void onAdd(emoji); }}
-          onClose={() => setPickerOpen(false)}
+          onClose={() => { setPickerOpen(false); }}
         />
       )}
     </div>

--- a/src/extensions/Webhooks/containers/WebhooksRegisterPage/RegisterWebhookModal.tsx
+++ b/src/extensions/Webhooks/containers/WebhooksRegisterPage/RegisterWebhookModal.tsx
@@ -153,7 +153,7 @@ export default function RegisterWebhookModal({ workspaceId, onClose, onCreated }
             <Input
               label={translations['RegisterWebhookModal.labelField']}
               value={label}
-              onChange={(e) => setLabel(e.target.value)}
+              onChange={(e) => { setLabel(e.target.value); }}
               maxLength={100}
               required
               placeholder="e.g. My production server"
@@ -200,11 +200,13 @@ export default function RegisterWebhookModal({ workspaceId, onClose, onCreated }
                         <button
                           type="button"
                           className="text-xs text-primary hover:underline"
-                          onClick={() =>
-                            allSelected
-                              ? clearAllInGroup(available)
-                              : selectAllInGroup(available)
-                          }
+                          onClick={() => {
+                            if (allSelected) {
+                              clearAllInGroup(available);
+                            } else {
+                              selectAllInGroup(available);
+                            }
+                          }}
                           data-testid={`group-toggle-${group.label.replace(/\s+/g, '-').toLowerCase()}`}
                         >
                           {allSelected
@@ -221,7 +223,7 @@ export default function RegisterWebhookModal({ workspaceId, onClose, onCreated }
                             <input
                               type="checkbox"
                               checked={selectedEvents.has(event)}
-                              onChange={() => toggleEvent(event)}
+                              onChange={() => { toggleEvent(event); }}
                               className="h-3.5 w-3.5 rounded border-border text-primary focus:ring-primary"
                               data-testid={`event-checkbox-${event}`}
                             />


### PR DESCRIPTION
## Summary

Fixes 49 `@typescript-eslint/no-confusing-void-expression` findings across 14 files. Arrow-function shorthands returning a void expression (`() => void fn()`) are converted to block-body form (`() => { void fn(); }`). Ternaries are converted to behaviour-identical if/else blocks (avoiding introducing `no-unused-expressions`). Behaviour-identical: void returns are discarded either way.

## Scope

- Rule family: `@typescript-eslint/no-confusing-void-expression`
- 14 files, 51 insertions / 49 deletions (all brace conversions / if-else; multiline conversions collapse lines)
- Files: AttachmentPanel, InlineUploadPreview, LoginForm, ResetPasswordPage, CardLabels, CommentReactions, RegisterWebhookModal (all 4 each), plus checklists.contract.test.ts, ChangeEmailForm, BoardButtonBuilder, BoardHeader, BoardMembersPanel/index, CalendarDayCell, CardModalBottomBar (3 each)

## Verification

- Focused lint on all 14 touched files: **0 `no-confusing-void-expression` findings**
- **Base-vs-head eslint rule-race on the 14 files: ONLY delta is -49 no-confusing-void-expression — zero newly-introduced findings of any rule** (this is the strengthened gate adopted after PR #280 caught a ternary→no-unused-expressions regression)
- `bun run typecheck`: **146 errors — identical to current main baseline** (no new failures)
- `bun test`: **1444 tests, identical fail identities to current main** (no new failures)
- Focused test on checklists.contract.test.ts: **2 pass / 0 fail**
- `bun run build:client`: **passed**; `git diff --check`: **clean**

## UI/E2E coverage

13/14 touched files are UI components with no dedicated executable UI/E2E coverage — recorded as **missing**, not claimed as passed. The 14th (checklists.contract.test.ts) is its own executable coverage and passes.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched. No unrelated files in the diff.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.