### PR TITLE
lint: prefix fire-and-forget promises with void (floating-promises batch 2)

### DIFF
--- a/server/extensions/plugins/sdk/jh-instance.ts
+++ b/server/extensions/plugins/sdk/jh-instance.ts
@@ -152,23 +152,23 @@ class FrameContext {
   // ── UI actions ────────────────────────────────────────────────────
 
   popup(options: { title: string; url: string; args?: Record<string, unknown>; mouseEvent?: MouseEvent }): void {
-    sendToHost('UI_POPUP', options);
+    void sendToHost('UI_POPUP', options);
   }
 
   modal(options: { title?: string; url: string; fullscreen?: boolean; accentColor?: string }): void {
-    sendToHost('UI_MODAL', options);
+    void sendToHost('UI_MODAL', options);
   }
 
   updateModal(options: Partial<{ title: string; fullscreen: boolean; accentColor: string }>): void {
-    sendToHost('UI_UPDATE_MODAL', options);
+    void sendToHost('UI_UPDATE_MODAL', options);
   }
 
   closePopup(): void {
-    sendToHost('UI_CLOSE_POPUP', {});
+    void sendToHost('UI_CLOSE_POPUP', {});
   }
 
   closeModal(): void {
-    sendToHost('UI_CLOSE_MODAL', {});
+    void sendToHost('UI_CLOSE_MODAL', {});
   }
 
   sizeTo(element: HTMLElement | string): void {
@@ -176,7 +176,7 @@ class FrameContext {
     const height = typeof element === 'string'
       ? document.querySelector(element)?.scrollHeight ?? document.body.scrollHeight
       : element.scrollHeight;
-    sendToHost('UI_SIZE_TO', { height, selector });
+    void sendToHost('UI_SIZE_TO', { height, selector });
   }
 
   render(fn: () => void): void {

--- a/src/extensions/Attachment/components/AttachmentSection.tsx
+++ b/src/extensions/Attachment/components/AttachmentSection.tsx
@@ -31,7 +31,7 @@ export function AttachmentSection({ cardId, authToken, apiBase = '' }: Props): R
     // TODO: add a dedicated list endpoint in a future sprint.
   };
 
-  useEffect(() => { refresh(); }, [cardId]);
+  useEffect(() => { void refresh(); }, [cardId]);
 
   const handleDelete = async (id: string): Promise<void> => {
     await fetch(`${apiBase}/api/v1/attachments/${id}`, { method: 'DELETE', headers: authHeaders });
@@ -58,7 +58,7 @@ export function AttachmentSection({ cardId, authToken, apiBase = '' }: Props): R
   };
 
   const handleUploadComplete = (): void => {
-    refresh();
+    void refresh();
   };
 
   return (

--- a/src/extensions/Auth/containers/VerifyEmailPage/VerifyEmailPage.tsx
+++ b/src/extensions/Auth/containers/VerifyEmailPage/VerifyEmailPage.tsx
@@ -24,7 +24,7 @@ export default function VerifyEmailPage() {
 
   useEffect(() => {
     if (token) {
-      dispatch(verifyEmailThunk({ token }));
+      void dispatch(verifyEmailThunk({ token }));
     }
   }, []);
 
@@ -37,7 +37,7 @@ export default function VerifyEmailPage() {
   }, [status, navigate]);
 
   const handleResend = () => {
-    dispatch(resendVerificationThunk());
+    void dispatch(resendVerificationThunk());
   };
 
   return (

--- a/src/extensions/Board/components/BoardMembersPanel/index.tsx
+++ b/src/extensions/Board/components/BoardMembersPanel/index.tsx
@@ -55,7 +55,7 @@ const BoardMembersPanel = ({ onClose, isGuest = false }: Props) => {
       && !isMembersLoading
       && (workspaceMembers.length === 0 || membersWorkspaceId !== boardWorkspaceId)
     ) {
-      dispatch(fetchWorkspaceMembersThunk({ workspaceId: boardWorkspaceId }));
+      void dispatch(fetchWorkspaceMembersThunk({ workspaceId: boardWorkspaceId }));
     }
   }, [dispatch, boardWorkspaceId, isMembersLoading, workspaceMembers.length, membersWorkspaceId]);
 
@@ -65,7 +65,7 @@ const BoardMembersPanel = ({ onClose, isGuest = false }: Props) => {
       && !isMembersLoading
       && (workspaceMembers.length === 0 || membersWorkspaceId !== boardWorkspaceId)
     ) {
-      dispatch(fetchWorkspaceMembersThunk({ workspaceId: boardWorkspaceId }));
+      void dispatch(fetchWorkspaceMembersThunk({ workspaceId: boardWorkspaceId }));
     }
   };
 

--- a/src/extensions/Card/components/CardModalBottomBar.tsx
+++ b/src/extensions/Card/components/CardModalBottomBar.tsx
@@ -164,7 +164,7 @@ const CardModalBottomBar = ({
               <button
                 type="button"
                 className="w-full flex items-center gap-2 px-3 py-2 text-sm text-base hover:bg-bg-overlay rounded-lg transition-colors"
-                onClick={() => { actions.setOpen(false); onArchive(); }}
+                onClick={() => { actions.setOpen(false); void onArchive(); }}
               >
                 {archived
                   ? <><ArchiveBoxXMarkIcon className="w-4 h-4 shrink-0" /> Unarchive card</>
@@ -203,7 +203,7 @@ const CardModalBottomBar = ({
                 className="w-full flex items-center gap-2 px-3 py-2 text-sm text-danger hover:bg-red-50 dark:hover:bg-red-900/30 rounded-lg transition-colors disabled:opacity-40"
                 onClick={() => {
                   actions.setOpen(false);
-                  if (confirm('Delete this card? This cannot be undone.')) onDelete();
+                  if (confirm('Delete this card? This cannot be undone.')) void onDelete();
                 }}
                 disabled={disabled}
               >

--- a/src/extensions/CustomFields/CustomFieldValueEditor.tsx
+++ b/src/extensions/CustomFields/CustomFieldValueEditor.tsx
@@ -105,7 +105,7 @@ const CustomFieldValueEditor = ({
           onChange={(e) => setDraft(e.target.value)}
           onBlur={() => {
             if (draft !== resolvedDisplayValue(field, value)) {
-              save({ value_text: draft || null });
+              void save({ value_text: draft || null });
             }
           }}
           onKeyDown={(e) => {
@@ -143,9 +143,9 @@ const CustomFieldValueEditor = ({
             const num = parseFloat(draft);
             const current = value?.value_number ? parseFloat(value.value_number) : null;
             if (draft === '' && current !== null) {
-              handleClear();
+              void handleClear();
             } else if (!isNaN(num) && num !== current) {
-              save({ value_number: num });
+              void save({ value_number: num });
             }
           }}
           onKeyDown={(e) => {
@@ -178,9 +178,9 @@ const CustomFieldValueEditor = ({
           onChange={(e) => {
             setDraft(e.target.value);
             if (e.target.value) {
-              save({ value_date: new Date(e.target.value).toISOString() });
+              void save({ value_date: new Date(e.target.value).toISOString() });
             } else {
-              handleClear();
+              void handleClear();
             }
           }}
         />
@@ -208,7 +208,7 @@ const CustomFieldValueEditor = ({
           disabled={disabled || saving}
           aria-label={field.name}
           onChange={(e) => {
-            save({ value_checkbox: e.target.checked });
+            void save({ value_checkbox: e.target.checked });
           }}
         />
       </label>
@@ -239,9 +239,9 @@ const CustomFieldValueEditor = ({
             onChange={(e) => {
               const val = e.target.value;
               if (val === '') {
-                handleClear();
+                void handleClear();
               } else {
-                save({ value_option_id: val });
+                void save({ value_option_id: val });
               }
             }}
           >

--- a/src/extensions/HealthCheck/containers/HealthCheckTab/HealthCheckTab.tsx
+++ b/src/extensions/HealthCheck/containers/HealthCheckTab/HealthCheckTab.tsx
@@ -59,7 +59,7 @@ export function HealthCheckTab({ boardId }: Props) {
 
   // Fetch the list on mount (and when boardId changes).
   useEffect(() => {
-    dispatch(fetchHealthChecksThunk({ boardId }));
+    void dispatch(fetchHealthChecksThunk({ boardId }));
   }, [dispatch, boardId]);
 
   // Probe-all on refresh (manual or auto).
@@ -83,7 +83,7 @@ export function HealthCheckTab({ boardId }: Props) {
 
   const handleRemove = useCallback(
     (healthCheckId: string) => {
-      dispatch(removeHealthCheckThunk({ boardId, healthCheckId }));
+      void dispatch(removeHealthCheckThunk({ boardId, healthCheckId }));
     },
     [dispatch, boardId],
   );

--- a/src/extensions/Plugins/containers/PluginDashboardPage/PluginDashboardPage.tsx
+++ b/src/extensions/Plugins/containers/PluginDashboardPage/PluginDashboardPage.tsx
@@ -104,7 +104,7 @@ const PluginDashboardPage = () => {
 
   // Fetch categories once on mount
   useEffect(() => {
-    dispatch(fetchCategoriesThunk());
+    void dispatch(fetchCategoriesThunk());
   }, [dispatch]);
 
   // If the API returns a 403-style error for a non-member, redirect back to board.
@@ -158,7 +158,7 @@ const PluginDashboardPage = () => {
   }, []);
 
   const handleRegisterSubmit = useCallback((body: RegisterPluginBody) => {
-    dispatch(registerPluginThunk(body));
+    void dispatch(registerPluginThunk(body));
   }, [dispatch]);
 
   const handleRegisterClose = useCallback(() => {
@@ -172,7 +172,7 @@ const PluginDashboardPage = () => {
       const params: { boardId: string; q?: string; category?: string | null } = { boardId };
       if (searchQuery) params.q = searchQuery;
       if (selectedCategory) params.category = selectedCategory;
-      dispatch(fetchDiscoverablePluginsThunk(params));
+      void dispatch(fetchDiscoverablePluginsThunk(params));
     }
   }, [dispatch, boardId, searchQuery, selectedCategory]);
 
@@ -187,7 +187,7 @@ const PluginDashboardPage = () => {
   }, [dispatch]);
 
   const handleEditSubmit = useCallback((pluginId: string, body: UpdatePluginBody) => {
-    dispatch(updatePluginThunk({ pluginId, body }));
+    void dispatch(updatePluginThunk({ pluginId, body }));
   }, [dispatch]);
 
   const handleSearchChange = useCallback((q: string) => {
@@ -196,7 +196,7 @@ const PluginDashboardPage = () => {
       const params: { boardId: string; q?: string; category?: string | null } = { boardId };
       if (q) params.q = q;
       if (selectedCategory) params.category = selectedCategory;
-      dispatch(fetchDiscoverablePluginsThunk(params));
+      void dispatch(fetchDiscoverablePluginsThunk(params));
     }
   }, [dispatch, boardId, selectedCategory]);
 
@@ -206,13 +206,13 @@ const PluginDashboardPage = () => {
       const params: { boardId: string; q?: string; category?: string | null } = { boardId };
       if (searchQuery) params.q = searchQuery;
       if (category) params.category = category;
-      dispatch(fetchDiscoverablePluginsThunk(params));
+      void dispatch(fetchDiscoverablePluginsThunk(params));
     }
   }, [dispatch, boardId, searchQuery]);
 
   const handleClearSearch = useCallback(() => {
     dispatch(clearSearch());
-    if (boardId) dispatch(fetchDiscoverablePluginsThunk({ boardId }));
+    if (boardId) void dispatch(fetchDiscoverablePluginsThunk({ boardId }));
   }, [dispatch, boardId]);
 
   return (

--- a/src/extensions/Plugins/containers/PluginRegistryPage/PluginRegistryPage.tsx
+++ b/src/extensions/Plugins/containers/PluginRegistryPage/PluginRegistryPage.tsx
@@ -80,7 +80,7 @@ const PluginRegistryPage = () => {
       const params: Parameters<typeof fetchPluginsThunk>[0] = { status: statusFilter };
       if (searchQuery) params.q = searchQuery;
       if (selectedCategory) params.category = selectedCategory;
-      dispatch(fetchPluginsThunk(params));
+      void dispatch(fetchPluginsThunk(params));
     }
   }, [isAdmin, dispatch]);
 
@@ -98,7 +98,7 @@ const PluginRegistryPage = () => {
       const params: Parameters<typeof fetchPluginsThunk>[0] = { status: s ?? statusFilter };
       if (q) params.q = q;
       if (category) params.category = category;
-      dispatch(fetchPluginsThunk(params));
+      void dispatch(fetchPluginsThunk(params));
     },
     [dispatch, statusFilter]
   );
@@ -118,7 +118,7 @@ const PluginRegistryPage = () => {
     const params: Parameters<typeof fetchPluginsThunk>[0] = { status: s };
     if (searchQuery) params.q = searchQuery;
     if (selectedCategory) params.category = selectedCategory;
-    dispatch(fetchPluginsThunk(params));
+    void dispatch(fetchPluginsThunk(params));
   };
 
   const handleRegisterSubmit = async (body: RegisterPluginBody) => {
@@ -148,7 +148,7 @@ const PluginRegistryPage = () => {
       const params: Parameters<typeof fetchPluginsThunk>[0] = { status: statusFilter };
       if (searchQuery) params.q = searchQuery;
       if (selectedCategory) params.category = selectedCategory;
-      dispatch(fetchPluginsThunk(params));
+      void dispatch(fetchPluginsThunk(params));
     }
     setRevealApiKey(null);
   };
@@ -169,7 +169,7 @@ const PluginRegistryPage = () => {
       const params: Parameters<typeof fetchPluginsThunk>[0] = { status: statusFilter };
       if (searchQuery) params.q = searchQuery;
       if (selectedCategory) params.category = selectedCategory;
-      dispatch(fetchPluginsThunk(params));
+      void dispatch(fetchPluginsThunk(params));
     }
     setReactivatingId(null);
   };

--- a/src/extensions/Plugins/hooks/useBoardPlugins.ts
+++ b/src/extensions/Plugins/hooks/useBoardPlugins.ts
@@ -25,9 +25,9 @@ export function useBoardPlugins({ boardId }: { boardId: string }) {
   const error = useAppSelector(selectPluginsError);
 
   const loadPlugins = useCallback(() => {
-    dispatch(fetchBoardPluginsThunk({ boardId })).then(() => {
+    void dispatch(fetchBoardPluginsThunk({ boardId })).then(() => {
       // [why] Use board-specific /available endpoint so the Discover list is pre-filtered
-      dispatch(fetchDiscoverablePluginsThunk({ boardId }));
+      void dispatch(fetchDiscoverablePluginsThunk({ boardId }));
     });
   }, [dispatch, boardId]);
 

--- a/src/extensions/User/components/AvatarUploader.tsx
+++ b/src/extensions/User/components/AvatarUploader.tsx
@@ -41,7 +41,7 @@ export default function AvatarUploader({ avatarUrl, name }: AvatarUploaderProps)
       setLocalError(translations['ProfilePage.invalidFile']);
       return;
     }
-    dispatch(uploadAvatarThunk({ file }));
+    void dispatch(uploadAvatarThunk({ file }));
   }
 
   function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
@@ -58,7 +58,7 @@ export default function AvatarUploader({ avatarUrl, name }: AvatarUploaderProps)
   }
 
   function handleRemove() {
-    dispatch(removeAvatarThunk());
+    void dispatch(removeAvatarThunk());
   }
 
   return (

--- a/src/extensions/Workspace/components/MemberList.tsx
+++ b/src/extensions/Workspace/components/MemberList.tsx
@@ -37,7 +37,7 @@ const MemberList = ({
   const ownerCount = members.filter((m) => m.role === 'OWNER').length;
 
   const handleRoleChange = (userId: string, newRole: Role) => {
-    dispatch(updateMemberRoleThunk({ workspaceId, userId, role: newRole }));
+    void dispatch(updateMemberRoleThunk({ workspaceId, userId, role: newRole }));
   };
 
   const handleRemoveConfirm = (userId: string) => {
@@ -46,7 +46,7 @@ const MemberList = ({
 
   const handleRemove = () => {
     if (confirmRemoveUserId) {
-      dispatch(removeMemberThunk({ workspaceId, userId: confirmRemoveUserId }));
+      void dispatch(removeMemberThunk({ workspaceId, userId: confirmRemoveUserId }));
       setConfirmRemoveUserId(null);
     }
   };

--- a/src/extensions/Workspace/containers/WorkspaceDashboard/index.tsx
+++ b/src/extensions/Workspace/containers/WorkspaceDashboard/index.tsx
@@ -43,7 +43,7 @@ const WorkspaceDashboard = () => {
   const [showCreateModal, setShowCreateModal] = useState(false);
 
   useEffect(() => {
-    if (workspaceId) dispatch(fetchBoardsThunk({ workspaceId }));
+    if (workspaceId) void dispatch(fetchBoardsThunk({ workspaceId }));
   }, [dispatch, workspaceId]);
 
   const handleCreate = (title: string) => {
@@ -60,7 +60,7 @@ const WorkspaceDashboard = () => {
   const handleArchive = (boardId: string) => dispatch(archiveBoardThunk({ boardId }));
   const handleDelete = (boardId: string) => {
     if (window.confirm('Are you sure you want to delete this board? This cannot be undone.')) {
-      dispatch(deleteBoardThunk({ boardId }));
+      void dispatch(deleteBoardThunk({ boardId }));
     }
   };
   const handleDuplicate = (boardId: string) => dispatch(duplicateBoardThunk({ boardId }));

--- a/src/layout/AppShell.tsx
+++ b/src/layout/AppShell.tsx
@@ -33,9 +33,9 @@ export default function AppShell() {
 
   // Load workspace list, user profile, and client feature flags once when the shell mounts
   useEffect(() => {
-    dispatch(fetchWorkspacesThunk());
-    dispatch(fetchProfileThunk());
-    dispatch(fetchFeatureFlagsThunk());
+    void dispatch(fetchWorkspacesThunk());
+    void dispatch(fetchProfileThunk());
+    void dispatch(fetchFeatureFlagsThunk());
   }, [dispatch]);
 
   // Close mobile drawer on route change (e.g. nav link clicked or browser back)


### PR DESCRIPTION
## Summary

Fixes 47 `@typescript-eslint/no-floating-promises` findings across 14 files. Fire-and-forget promise-returning calls (Redux thunk dispatches, async side-effects) are prefixed with `void` (or subexpression `void` inside useEffect/arrow-block/if bodies). Behaviour-identical: fire-and-forget semantics preserved, the return value explicitly discarded.

## Scope

- Rule family: `@typescript-eslint/no-floating-promises`
- 14 files, 47 insertions / 47 deletions
- Files: CustomFieldValueEditor (8), PluginDashboardPage (7), jh-instance (6), PluginRegistryPage (5), AppShell (3), plus 9 files at 2 each

## Verification

- Focused lint on all 14 touched files: **0 `no-floating-promises` findings**
- **Base-vs-head eslint any-rule gate: ONLY delta is -47 no-floating-promises — zero newly-introduced findings of any rule** (no-confusing-void-expression held at 20 in both, so the void additions are clean)
- `bun run typecheck`: **146 errors — identical to current main baseline** (no new failures)
- `bun test`: **1444 tests, identical fail identities to current main** (no new failures)
- `bun run build:client`: **passed**; `git diff --check`: **clean**

## UI/E2E coverage

All touched files are UI components / hooks / a plugin SDK file with no dedicated executable UI/E2E coverage — recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched. No unrelated files in the diff.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.