### PR TITLE
lint: coerce non-string values in template literals (restrict-template batch 2)

### DIFF
--- a/src/common/utils/attachmentMarkdown.ts
+++ b/src/common/utils/attachmentMarkdown.ts
@@ -23,7 +23,7 @@ function replaceMarkdownTargets(
     });
     if (!nextHref || nextHref === href) return full;
     const titlePart = typeof title === 'string' && title.length > 0 ? ` "${title}"` : '';
-    return `${bang}[${label}](${nextHref}${titlePart})`;
+    return `${String(bang)}[${String(label)}](${nextHref}${titlePart})`;
   });
 }
 
@@ -101,7 +101,7 @@ export function stripCommentAttachmentPlaceholders(markdown: string): string {
     const attachmentName = readAttachmentPlaceholderName(href);
     if (!attachmentName) return full;
     const fallbackLabel = label || attachmentName;
-    return bang === '!' ? fallbackLabel : `[${fallbackLabel}]`;
+    return bang === '!' ? fallbackLabel : `[${String(fallbackLabel)}]`;
   });
 }
 

--- a/src/extensions/Attachments/hooks/useAttachmentUpload.ts
+++ b/src/extensions/Attachments/hooks/useAttachmentUpload.ts
@@ -63,7 +63,7 @@ function singleFileUpload(
       if (xhr.status >= 200 && xhr.status < 300) {
         resolve();
       } else {
-        reject(new Error(`S3 PUT failed: ${xhr.status}`));
+        reject(new Error(`S3 PUT failed: ${String(xhr.status)}`));
       }
     };
     xhr.onerror = () => reject(new Error('Network error during upload'));
@@ -78,7 +78,7 @@ async function uploadPart(url: string, slice: Blob): Promise<string> {
     body: slice,
     headers: { 'Content-Type': 'application/octet-stream' },
   });
-  if (!res.ok) throw new Error(`Part upload failed: ${res.status}`);
+  if (!res.ok) throw new Error(`Part upload failed: ${String(res.status)}`);
   return res.headers.get('ETag') ?? '';
 }
 
@@ -134,7 +134,7 @@ export function useAttachmentUpload({
       const validFiles = files.filter((file) => {
         if (file.size > config.maxAttachmentSizeBytes) {
           const maxSizeMb = Math.round(config.maxAttachmentSizeBytes / (1024 * 1024));
-          onErrorRef.current?.('', `File "${file.name}" is too large. It must be under ${maxSizeMb}MB.`);
+          onErrorRef.current?.('', `File "${file.name}" is too large. It must be under ${String(maxSizeMb)}MB.`);
           return false;
         }
         return true;

--- a/src/extensions/Automation/components/LogPanel/RunLogRow.tsx
+++ b/src/extensions/Automation/components/LogPanel/RunLogRow.tsx
@@ -25,13 +25,13 @@ interface Props {
 function relativeTime(dateStr: string): string {
   const diff = Date.now() - new Date(dateStr).getTime();
   const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 60) return `${String(seconds)}s ago`;
   const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
+  if (minutes < 60) return `${String(minutes)}m ago`;
   const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
+  if (hours < 24) return `${String(hours)}h ago`;
   const days = Math.floor(hours / 24);
-  return `${days}d ago`;
+  return `${String(days)}d ago`;
 }
 
 const STATUS_ICON: Record<string, { icon: typeof CheckCircleIcon; cls: string; label: string }> = {

--- a/src/extensions/Board/components/BoardMemberAvatars.tsx
+++ b/src/extensions/Board/components/BoardMemberAvatars.tsx
@@ -23,7 +23,7 @@ const COLORS = [
 function initials(member: Member): string {
   const name = member.display_name ?? member.email;
   const parts = name.split(' ').filter(Boolean);
-  if (parts.length >= 2) return `${parts[0]![0]}${parts[1]![0]}`.toUpperCase();
+  if (parts.length >= 2) return `${parts[0]![0] ?? ''}${parts[1]![0] ?? ''}`.toUpperCase();
   return name.slice(0, 2).toUpperCase();
 }
 
@@ -37,7 +37,7 @@ const BoardMemberAvatars = ({ members, max = 5 }: Props) => {
         <li
           key={member.id}
           title={member.display_name ?? member.email}
-          className={`relative -ml-2 first:ml-0 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border-2 border-bg-base text-xs font-semibold text-inverse overflow-hidden ${member.avatar_url ? '' : COLORS[i % COLORS.length]}`}
+          className={`relative -ml-2 first:ml-0 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border-2 border-bg-base text-xs font-semibold text-inverse overflow-hidden ${member.avatar_url ? '' : (COLORS[i % COLORS.length] ?? '')}`}
           style={{ zIndex: visible.length - i }}
         >
           {member.avatar_url ? (
@@ -58,7 +58,7 @@ const BoardMemberAvatars = ({ members, max = 5 }: Props) => {
       {overflow > 0 && (
         <li
           className="-ml-2 flex h-7 w-7 items-center justify-center rounded-full border-2 border-bg-base bg-bg-sunken text-xs font-semibold text-base"
-          title={`${overflow} more member${overflow > 1 ? 's' : ''}`}
+          title={`${String(overflow)} more member${overflow > 1 ? 's' : ''}`}
         >
           +{overflow}
         </li>

--- a/src/extensions/BoardViewSwitcher/__tests__/integration.playwright.ts
+++ b/src/extensions/BoardViewSwitcher/__tests__/integration.playwright.ts
@@ -18,18 +18,18 @@ async function loginAndGetBoardUrl(request: import('@playwright/test').APIReques
   const { data: { token } } = await loginRes.json();
 
   const workspacesRes = await request.get(`${BASE_URL}/api/v1/workspaces`, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { Authorization: `Bearer ${String(token)}` },
   });
   const { data: workspaces } = await workspacesRes.json();
   const workspaceId = workspaces[0].id;
 
-  const boardsRes = await request.get(`${BASE_URL}/api/v1/workspaces/${workspaceId}/boards`, {
-    headers: { Authorization: `Bearer ${token}` },
+  const boardsRes = await request.get(`${BASE_URL}/api/v1/workspaces/${String(workspaceId)}/boards`, {
+    headers: { Authorization: `Bearer ${String(token)}` },
   });
   const { data: boards } = await boardsRes.json();
   const boardId = boards[0].id;
 
-  return { token, boardUrl: `/boards/${boardId}` };
+  return { token, boardUrl: `/boards/${String(boardId)}` };
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/src/extensions/Card/components/CardDatesPicker.tsx
+++ b/src/extensions/Card/components/CardDatesPicker.tsx
@@ -14,7 +14,7 @@ function parseDate(s: string): Date | undefined {
 }
 
 function formatDateInput(d: Date): string {
-  return `${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}`;
+  return `${String(d.getMonth() + 1)}/${String(d.getDate())}/${String(d.getFullYear())}`;
 }
 
 function parseTime12(s: string): [number, number] | undefined {
@@ -31,7 +31,7 @@ function parseTime12(s: string): [number, number] | undefined {
 
 export function formatTime12(h: number, min: number): string {
   const ampm = h >= 12 ? 'PM' : 'AM';
-  return `${h % 12 || 12}:${min.toString().padStart(2, '0')} ${ampm}`;
+  return `${String(h % 12 || 12)}:${min.toString().padStart(2, '0')} ${ampm}`;
 }
 
 function isSameDay(a: Date, b: Date) {

--- a/src/extensions/Card/components/CardDescriptionTiptap.tsx
+++ b/src/extensions/Card/components/CardDescriptionTiptap.tsx
@@ -562,7 +562,7 @@ function hydrateEditorLinkMarkClasses(editor: Editor): void {
     const range = getMarkRange(editor.state.doc.resolve(resolvePos), linkType);
     if (!range) return;
 
-    const rangeKey = `${range.from}:${range.to}`;
+    const rangeKey = `${String(range.from)}:${String(range.to)}`;
     if (seenRanges.has(rangeKey)) return;
     seenRanges.add(rangeKey);
 
@@ -919,7 +919,7 @@ const CardDescriptionTiptap = ({ boardId, cardId, description, onSave, disabled 
         event.preventDefault();
         const pos = view.state.selection.from;
 
-        const loadingToken = `link-loading-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const loadingToken = `link-loading-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}`;
         const loadingClass = buildLinkClassName('url', [LINK_CLASS_LOADING, loadingToken]);
 
         editorRef.current

--- a/src/extensions/Card/components/ChecklistItem.tsx
+++ b/src/extensions/Card/components/ChecklistItem.tsx
@@ -179,7 +179,7 @@ function toDateInputValue(date: Date): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
+  return `${String(year)}-${month}-${day}`;
 }
 
 function toTimeInputValue(date: Date): string {
@@ -395,7 +395,7 @@ export const ChecklistItem = ({
             setTitle(e.target.value);
             // [why] Auto-resize the textarea to fit all content so long items are fully visible while editing.
             e.target.style.height = 'auto';
-            e.target.style.height = `${e.target.scrollHeight}px`;
+            e.target.style.height = `${String(e.target.scrollHeight)}px`;
           }}
           onBlur={() => void submitRename()}
           onPaste={handleEditPaste}
@@ -416,7 +416,7 @@ export const ChecklistItem = ({
           ref={(el) => {
             if (el) {
               el.style.height = 'auto';
-              el.style.height = `${el.scrollHeight}px`;
+              el.style.height = `${String(el.scrollHeight)}px`;
             }
           }}
           autoFocus

--- a/src/extensions/Card/utils/printCard.ts
+++ b/src/extensions/Card/utils/printCard.ts
@@ -73,7 +73,7 @@ function renderChecklists(checklists: Checklist[]): string {
         <div class="checklist">
           <div class="checklist-header">
             <strong>${escHtml(cl.title)}</strong>
-            <span class="checklist-progress">${done}/${total} &mdash; ${pct}%</span>
+            <span class="checklist-progress">${String(done)}/${String(total)} &mdash; ${String(pct)}%</span>
           </div>
           <ul>${items}</ul>
         </div>`;

--- a/src/extensions/Comment/components/CommentItem.tsx
+++ b/src/extensions/Comment/components/CommentItem.tsx
@@ -296,7 +296,7 @@ interface Props {
 function getInitials(name: string | null | undefined, email: string | null | undefined): string {
   const source = name || email || '?';
   const parts = source.split(/[\s@.]/).filter(Boolean);
-  if (parts.length >= 2) return `${parts[0]![0]}${parts[1]![0]}`.toUpperCase();
+  if (parts.length >= 2) return `${parts[0]![0] ?? ''}${parts[1]![0] ?? ''}`.toUpperCase();
   return source.slice(0, 2).toUpperCase();
 }
 
@@ -324,8 +324,8 @@ function relativeTime(iso: string): string {
   const diff = (Date.now() - date.getTime()) / 1000;
   const time = date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
   if (diff < 60) return translations['comment.relativeTime.justNow'];
-  if (diff < 3600) return `${Math.floor(diff / 60)} ${translations['comment.relativeTime.minAgo']} · ${time}`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)} ${translations['comment.relativeTime.hrAgo']} · ${time}`;
+  if (diff < 3600) return `${String(Math.floor(diff / 60))} ${translations['comment.relativeTime.minAgo']} · ${time}`;
+  if (diff < 86400) return `${String(Math.floor(diff / 3600))} ${translations['comment.relativeTime.hrAgo']} · ${time}`;
   const day = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
   return `${day}, ${time}`;
 }
@@ -478,7 +478,7 @@ const CommentItem = ({ comment, boardId, attachments = [], currentUserId, isAdmi
     <div ref={rootRef} className="flex gap-3">
       {/* Avatar */}
       <div
-        className={`flex-shrink-0 h-8 w-8 rounded-full flex items-center justify-center text-xs font-semibold text-white ${avatarUrl ? '' : color} overflow-hidden`} // [theme-exception] text-white on colored avatar
+        className={`flex-shrink-0 h-8 w-8 rounded-full flex items-center justify-center text-xs font-semibold text-white ${avatarUrl ? '' : (color ?? '')} overflow-hidden`} // [theme-exception] text-white on colored avatar
         title={displayName}
       >
         {avatarUrl

--- a/src/extensions/Comment/components/CommentReactions.tsx
+++ b/src/extensions/Comment/components/CommentReactions.tsx
@@ -28,11 +28,11 @@ const CommentReactions = ({ reactions, onAdd, onRemove, className }: Props) => {
   /** Build the tooltip label showing who reacted. */
   const buildTooltip = (reaction: ReactionSummary): string => {
     const reactors = reaction.reactors ?? [];
-    if (reactors.length === 0) return `${reaction.count} reaction${reaction.count === 1 ? '' : 's'}`;
+    if (reactors.length === 0) return `${String(reaction.count)} reaction${reaction.count === 1 ? '' : 's'}`;
     const names = reactors.map((r) => r.name ?? 'Someone');
     if (names.length <= 3) return names.join(', ');
     const shown = names.slice(0, 3).join(', ');
-    return `${shown} and ${names.length - 3} more`;
+    return `${shown} and ${String(names.length - 3)} more`;
   };
 
   return (

--- a/src/extensions/HealthCheck/components/HealthCheckRow.tsx
+++ b/src/extensions/HealthCheck/components/HealthCheckRow.tsx
@@ -24,7 +24,7 @@ function formatResponseTime(
     if (errorMessage) return 'Error';
     return 'Error';
   }
-  if (responseTimeMs != null) return `${responseTimeMs} ms`;
+  if (responseTimeMs != null) return `${String(responseTimeMs)} ms`;
   return '—';
 }
 
@@ -33,11 +33,11 @@ function relativeTime(isoString: string): string {
   const diffMs = Date.now() - new Date(isoString).getTime();
   const diffSec = Math.floor(diffMs / 1000);
   if (diffSec < 10) return 'just now';
-  if (diffSec < 60) return `${diffSec}s ago`;
+  if (diffSec < 60) return `${String(diffSec)}s ago`;
   const diffMin = Math.floor(diffSec / 60);
-  if (diffMin < 60) return `${diffMin} min ago`;
+  if (diffMin < 60) return `${String(diffMin)} min ago`;
   const diffHr = Math.floor(diffMin / 60);
-  return `${diffHr}h ago`;
+  return `${String(diffHr)}h ago`;
 }
 
 export function HealthCheckRow({ entry, isProbing, onRemove }: Props) {

--- a/src/extensions/HealthCheck/components/HealthCheckStatusDot.tsx
+++ b/src/extensions/HealthCheck/components/HealthCheckStatusDot.tsx
@@ -44,11 +44,11 @@ function buildTooltip({
   if (status === 'red') {
     if (errorMessage?.toLowerCase().includes('timeout')) return 'Request timed out';
     if (errorMessage) return `Network error: ${errorMessage}`;
-    if (httpStatus) return `${httpStatus} Error`;
+    if (httpStatus) return `${String(httpStatus)} Error`;
     return 'Probe failed';
   }
-  const time = responseTimeMs != null ? `${responseTimeMs} ms` : null;
-  const code = httpStatus ? `${httpStatus} OK` : null;
+  const time = responseTimeMs != null ? `${String(responseTimeMs)} ms` : null;
+  const code = httpStatus ? `${String(httpStatus)} OK` : null;
   const slow = status === 'amber' && responseTimeMs != null ? ' (slow)' : '';
   const parts = [code, time ? `${time}${slow}` : null].filter(Boolean);
   return parts.length ? parts.join(' · ') : status === 'amber' ? 'Slow response' : 'OK';

--- a/src/extensions/HealthCheck/containers/HealthCheckTab/HealthCheckTab.tsx
+++ b/src/extensions/HealthCheck/containers/HealthCheckTab/HealthCheckTab.tsx
@@ -37,11 +37,11 @@ function formatLastChecked(isoString: string | null): string {
   const diffMs = Date.now() - new Date(isoString).getTime();
   const diffSec = Math.floor(diffMs / 1000);
   if (diffSec < 10) return 'just now';
-  if (diffSec < 60) return `${diffSec}s ago`;
+  if (diffSec < 60) return `${String(diffSec)}s ago`;
   const diffMin = Math.floor(diffSec / 60);
-  if (diffMin < 60) return `${diffMin} min ago`;
+  if (diffMin < 60) return `${String(diffMin)} min ago`;
   const diffHr = Math.floor(diffMin / 60);
-  return `${diffHr}h ago`;
+  return `${String(diffHr)}h ago`;
 }
 
 /** Full Health Check tab panel: loads entries, renders rows, empty state, and countdown. */

--- a/src/extensions/Plugins/iframeHost/usePluginBridge.ts
+++ b/src/extensions/Plugins/iframeHost/usePluginBridge.ts
@@ -519,7 +519,7 @@ export function usePluginBridge({
 
       const invokeEligible = (eligible: BoardPlugin[]): Promise<unknown[]> => {
         return new Promise<unknown[]>((resolvePromise) => {
-          const requestId = `cap-${Date.now()}-${Math.random()}`;
+          const requestId = `cap-${String(Date.now())}-${String(Math.random())}`;
           pendingCapabilityRef.current.set(requestId, {
             resolve: resolvePromise,
             results: [],


### PR DESCRIPTION
## Summary

Fixes 50 `@typescript-eslint/restrict-template-expressions` findings across 15 files. Non-string values interpolated in template literals are wrapped in `String(...)` (for numbers/`any`), and `string | undefined` values get a `?? ''` fallback. Behaviour-identical: `String(x)` coerces to the same string as template interpolation for primitives.

## Scope

- Rule family: `@typescript-eslint/restrict-template-expressions`
- 15 files, 41 insertions / 41 deletions (50 finding-occurrences; some lines had multiple interpolations)
- Files: CommentItem (5), HealthCheckRow (4), CardDatesPicker (4), integration.playwright.ts (4), BoardMemberAvatars (4), RunLogRow (4), HealthCheckTab (3), HealthCheckStatusDot (3), printCard (3), ChecklistItem (3), CardDescriptionTiptap (3), useAttachmentUpload (3), attachmentMarkdown (3), usePluginBridge (2), CommentReactions (2)

## Verification

- Focused lint on all 15 touched files: **0 `restrict-template-expressions` findings**
- **Base-vs-head eslint any-rule gate: ONLY delta is -50 restrict-template-expressions — zero newly-introduced findings of any rule across all 15 files** (all pre-existing findings on changed lines confirmed pre-existing against the pre-edit lint output)
- `bun run typecheck`: **146 errors — identical to current main baseline** (no new failures)
- `bun test`: **1444 tests, identical fail identities to current main** (no new failures)
- `bun run build:client`: **passed**; `git diff --check`: **clean**

## UI/E2E coverage

Touched files are UI components / pure utilities / a Playwright integration test (`integration.playwright.ts`, not run under `bun test`). No dedicated executable UI/E2E coverage beyond that — recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched. No unrelated files in the diff.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.