### PR TITLE
lint: coerce non-string values in template literals (restrict-template batch 3)

### DIFF
--- a/server/extensions/attachment/workers/orphanCleanup.ts
+++ b/server/extensions/attachment/workers/orphanCleanup.ts
@@ -26,7 +26,7 @@ export async function cleanupOrphanAttachments(): Promise<void> {
       }
     }
     await db('attachments').where({ id: attachment.id }).delete();
-    console.info(`[orphan-cleanup] deleted attachment ${attachment.id}`);
+    console.info(`[orphan-cleanup] deleted attachment ${String(attachment.id)}`);
   }
 }
 

--- a/server/extensions/auth/api/logout.ts
+++ b/server/extensions/auth/api/logout.ts
@@ -28,7 +28,7 @@ export async function handleLogout(req: Request): Promise<Response> {
     // Notify any open WebSocket connections for this user to close (code 4001).
     if (tokenRow?.user_id) {
       await pubsub.publish(
-        `session:${tokenRow.user_id}`,
+        `session:${String(tokenRow.user_id)}`,
         JSON.stringify({ type: 'session_revoked' }),
       );
     }

--- a/server/extensions/auth/api/oauth/callback.ts
+++ b/server/extensions/auth/api/oauth/callback.ts
@@ -91,13 +91,13 @@ export async function handleOAuthCallback(
   const responseHeaders = new Headers();
   responseHeaders.append(
     'Set-Cookie',
-    `refresh_token=${refreshToken}; HttpOnly; Path=/api/v1/auth/refresh; SameSite=Strict; Secure; Max-Age=${jwtConfig.refreshTokenTtlDays * 86400}`,
+    `refresh_token=${refreshToken}; HttpOnly; Path=/api/v1/auth/refresh; SameSite=Strict; Secure; Max-Age=${String(jwtConfig.refreshTokenTtlDays * 86400)}`,
   );
   // [why] access_token cookie lets <img> tags and other browser resource
   // requests authenticate without an Authorization header.
   responseHeaders.append(
     'Set-Cookie',
-    `access_token=${accessToken}; HttpOnly; Path=/; SameSite=Strict; Secure; Max-Age=${jwtConfig.accessTokenTtlSeconds}`,
+    `access_token=${accessToken}; HttpOnly; Path=/; SameSite=Strict; Secure; Max-Age=${String(jwtConfig.accessTokenTtlSeconds)}`,
   );
   // Redirect to frontend with access token in fragment (never in query string).
   responseHeaders.set('Location', `${env.APP_URL}/#access_token=${accessToken}`);

--- a/server/extensions/auth/api/refresh.ts
+++ b/server/extensions/auth/api/refresh.ts
@@ -44,12 +44,12 @@ export async function handleRefresh(req: Request): Promise<Response> {
   const responseHeaders = new Headers({ 'Content-Type': 'application/json' });
   responseHeaders.append(
     'Set-Cookie',
-    `refresh_token=${result.token}; HttpOnly; Path=/api/v1/auth/refresh; SameSite=Strict; Secure; Max-Age=${jwtConfig.refreshTokenTtlDays * 86400}`,
+    `refresh_token=${result.token}; HttpOnly; Path=/api/v1/auth/refresh; SameSite=Strict; Secure; Max-Age=${String(jwtConfig.refreshTokenTtlDays * 86400)}`,
   );
   // Rotate the access_token cookie to match the new JWT.
   responseHeaders.append(
     'Set-Cookie',
-    `access_token=${accessToken}; HttpOnly; Path=/; SameSite=Strict; Secure; Max-Age=${jwtConfig.accessTokenTtlSeconds}`,
+    `access_token=${accessToken}; HttpOnly; Path=/; SameSite=Strict; Secure; Max-Age=${String(jwtConfig.accessTokenTtlSeconds)}`,
   );
 
   const avatarUrl = buildAvatarProxyUrl({ userId: user.id, avatarUrl: user.avatar_url ?? null });

--- a/server/extensions/auth/api/register.ts
+++ b/server/extensions/auth/api/register.ts
@@ -79,7 +79,7 @@ export async function handleRegister(req: Request): Promise<Response> {
 
   // When verification is enabled: send email and return 201 without a JWT
   if (verificationEnabled) {
-    const verificationUrl = `${env.APP_URL}/verify-email?token=${verificationToken}`;
+    const verificationUrl = `${env.APP_URL}/verify-email?token=${verificationToken ?? ''}`;
     const emailContent = await buildVerificationEmail({ verificationUrl });
     await send({ to: email, ...emailContent });
 
@@ -104,7 +104,7 @@ export async function handleRegister(req: Request): Promise<Response> {
   const responseHeaders = new Headers({ 'Content-Type': 'application/json' });
   responseHeaders.append(
     'Set-Cookie',
-    `refresh_token=${refreshToken}; HttpOnly; Path=/api/v1/auth/refresh; SameSite=Strict; Max-Age=${jwtConfig.refreshTokenTtlDays * 86400}`,
+    `refresh_token=${refreshToken}; HttpOnly; Path=/api/v1/auth/refresh; SameSite=Strict; Max-Age=${String(jwtConfig.refreshTokenTtlDays * 86400)}`,
   );
 
   const avatarUrl = buildAvatarProxyUrl({ userId: user.id, avatarUrl: user.avatar_url ?? null });

--- a/server/extensions/auth/api/resetPassword.ts
+++ b/server/extensions/auth/api/resetPassword.ts
@@ -62,7 +62,7 @@ export async function handleResetPassword(req: Request): Promise<Response> {
 
   // Notify any open WebSocket connections for this user to close (code 4001).
   await pubsub.publish(
-    `session:${user.id}`,
+    `session:${String(user.id)}`,
     JSON.stringify({ type: 'session_revoked' }),
   );
 

--- a/server/extensions/auth/mods/token/token.test.ts
+++ b/server/extensions/auth/mods/token/token.test.ts
@@ -73,7 +73,7 @@ describe('token issue and verify', () => {
 
     const token = await issueAccessToken({ sub: 'user-123', email: 'test@example.com' });
     const [header, payload] = token.split('.');
-    const tampered = `${header}.${payload}.invalidsignature`;
+    const tampered = `${header ?? ''}.${payload ?? ''}.invalidsignature`;
 
     const result = await verifyAccessToken({ token: tampered });
     expect(result).toBeNull();

--- a/server/extensions/healthCheck/mods/probe/runProbe.ts
+++ b/server/extensions/healthCheck/mods/probe/runProbe.ts
@@ -125,7 +125,7 @@ export async function runProbe({ url, expectedStatus }: { url: string; expectedS
     const responseTimeMs = Date.now() - startTime;
     const isTimeout = (err as Error).name === 'AbortError';
     const errorMessage = isTimeout
-      ? `Timeout after ${responseTimeMs}ms`
+      ? `Timeout after ${String(responseTimeMs)}ms`
       : (err as Error).message;
 
     return {

--- a/server/extensions/mcp/apiClient.ts
+++ b/server/extensions/mcp/apiClient.ts
@@ -37,7 +37,7 @@ export async function apiCall<T>({
     const errPayload = payload as { name?: string; data?: unknown } | null;
     return {
       error: {
-        name: errPayload?.name ?? `http-${res.status}`,
+        name: errPayload?.name ?? `http-${String(res.status)}`,
         data: errPayload?.data ?? payload,
       },
     };

--- a/server/extensions/plugins/api/board-plugins/token.ts
+++ b/server/extensions/plugins/api/board-plugins/token.ts
@@ -74,7 +74,7 @@ export async function handleGetPluginToken(
     .setProtectedHeader({ alg: 'HS256' })
     .setSubject(authedReq.currentUser!.id)
     .setIssuedAt()
-    .setExpirationTime(`${TOKEN_TTL_SECONDS}s`)
+    .setExpirationTime(`${String(TOKEN_TTL_SECONDS)}s`)
     .sign(secret);
 
   return Response.json({

--- a/server/extensions/plugins/api/registry/create.ts
+++ b/server/extensions/plugins/api/registry/create.ts
@@ -98,7 +98,7 @@ export async function handleCreatePlugin(req: Request): Promise<Response> {
         {
           name: 'too-many-whitelisted-domains',
           data: {
-            message: `whitelistedDomains may contain at most ${MAX_WHITELISTED_DOMAINS} entries`,
+            message: `whitelistedDomains may contain at most ${String(MAX_WHITELISTED_DOMAINS)} entries`,
           },
         },
         { status: 422 }
@@ -109,7 +109,7 @@ export async function handleCreatePlugin(req: Request): Promise<Response> {
         return Response.json(
           {
             name: 'invalid-whitelisted-domain',
-            data: { message: `'${domain}' is not a valid HTTPS origin` },
+            data: { message: `'${String(domain)}' is not a valid HTTPS origin` },
           },
           { status: 422 }
         );

--- a/server/extensions/plugins/api/registry/update.ts
+++ b/server/extensions/plugins/api/registry/update.ts
@@ -54,14 +54,14 @@ export async function handleUpdatePlugin(req: Request, pluginId: string): Promis
     }
     if (rawDomains.length > MAX_WHITELISTED_DOMAINS) {
       return Response.json(
-        { error: { code: 'too-many-whitelisted-domains', message: `whitelistedDomains may contain at most ${MAX_WHITELISTED_DOMAINS} entries` } },
+        { error: { code: 'too-many-whitelisted-domains', message: `whitelistedDomains may contain at most ${String(MAX_WHITELISTED_DOMAINS)} entries` } },
         { status: 422 },
       );
     }
     for (const domain of rawDomains) {
       if (typeof domain !== 'string' || !isValidHttpsOrigin(domain)) {
         return Response.json(
-          { error: { code: 'invalid-whitelisted-domain', message: `'${domain}' is not a valid HTTPS origin` } },
+          { error: { code: 'invalid-whitelisted-domain', message: `'${String(domain)}' is not a valid HTTPS origin` } },
           { status: 422 },
         );
       }

--- a/server/extensions/plugins/sdk/jh-instance.ts
+++ b/server/extensions/plugins/sdk/jh-instance.ts
@@ -69,7 +69,7 @@ function serializeResult(value: unknown): unknown {
 
 let msgCounter = 0;
 function nextId(): string {
-  return `jh-${Date.now()}-${++msgCounter}`;
+  return `jh-${String(Date.now())}-${String(++msgCounter)}`;
 }
 
 function sendToHost(type: string, payload?: unknown): Promise<unknown> {

--- a/server/index.ts
+++ b/server/index.ts
@@ -311,4 +311,4 @@ Bun.serve({
   websocket: wsHandlers,
 });
 
-console.info(`[server] Listening on http://localhost:${appConfig.port}`);
+console.info(`[server] Listening on http://localhost:${String(appConfig.port)}`);

--- a/server/mods/cache/adapters/nodeCache.test.ts
+++ b/server/mods/cache/adapters/nodeCache.test.ts
@@ -30,7 +30,7 @@ describe('NodeCacheAdapter', () => {
   });
 
   it('incr increments a counter', async () => {
-    const key = `counter-${Date.now()}`;
+    const key = `counter-${String(Date.now())}`;
     expect(await adapter.incr(key, 60)).toBe(1);
     expect(await adapter.incr(key, 60)).toBe(2);
     expect(await adapter.incr(key, 60)).toBe(3);
@@ -50,7 +50,7 @@ describe('memCache (legacy sync API)', () => {
   });
 
   it('incr increments', () => {
-    const key = `sync-counter-${Date.now()}`;
+    const key = `sync-counter-${String(Date.now())}`;
     expect(memCache.incr(key, 60)).toBe(1);
     expect(memCache.incr(key, 60)).toBe(2);
   });

--- a/src/common/components/MentionInput/MentionInput.tsx
+++ b/src/common/components/MentionInput/MentionInput.tsx
@@ -48,7 +48,7 @@ const MentionInput = ({
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = 'auto';
-    el.style.height = `${el.scrollHeight}px`;
+    el.style.height = `${String(el.scrollHeight)}px`;
   }, [value]);
 
   return (

--- a/src/extensions/Activity/components/ActivityItem.tsx
+++ b/src/extensions/Activity/components/ActivityItem.tsx
@@ -23,7 +23,7 @@ interface Props {
 
 // Replaces {placeholders} in a translation template with values from a record.
 function interpolate(template: string, vars: Record<string, string>): string {
-  return template.replaceAll(/\{(\w+)\}/g, (_, key) => vars[key] ?? `{${key}}`);
+  return template.replaceAll(/\{(\w+)\}/g, (_, key) => vars[key] ?? `{${String(key)}}`);
 }
 
 function textValue(value: unknown): string {

--- a/src/extensions/AdminInvite/InviteExternalUserModal.tsx
+++ b/src/extensions/AdminInvite/InviteExternalUserModal.tsx
@@ -307,7 +307,7 @@ export default function InviteExternalUserModal() {
                             <div
                               key={i}
                               className={`h-1.5 flex-1 rounded-full transition-colors ${
-                                i < score ? STRENGTH_COLORS[score - 1] : 'bg-bg-overlay'
+                                i < score ? (STRENGTH_COLORS[score - 1] ?? 'bg-bg-overlay') : 'bg-bg-overlay'
                               }`}
                             />
                           ))}

--- a/src/extensions/Attachment/hooks/useAttachmentUpload.ts
+++ b/src/extensions/Attachment/hooks/useAttachmentUpload.ts
@@ -57,7 +57,7 @@ export function useAttachmentUpload({ cardId, onComplete, authToken = '', apiBas
             if (xhr.status >= 200 && xhr.status < 300) {
               resolve(attachmentId);
             } else {
-              reject(new Error(`S3 upload failed with status ${xhr.status}`));
+              reject(new Error(`S3 upload failed with status ${String(xhr.status)}`));
             }
           });
 

--- a/src/extensions/Attachments/components/AttachmentItem.tsx
+++ b/src/extensions/Attachments/components/AttachmentItem.tsx
@@ -62,10 +62,10 @@ function formatAttachedMeta(createdAt: string): string {
   let relative = 'just now';
   if (diffSeconds >= 3600) {
     const hours = Math.floor(diffSeconds / 3600);
-    relative = `${hours} hour${hours === 1 ? '' : 's'} ago`;
+    relative = `${String(hours)} hour${hours === 1 ? '' : 's'} ago`;
   } else if (diffSeconds >= 60) {
     const minutes = Math.floor(diffSeconds / 60);
-    relative = `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+    relative = `${String(minutes)} minute${minutes === 1 ? '' : 's'} ago`;
   }
 
   return `Added ${relative} at ${timeLabel}`;

--- a/src/extensions/Attachments/hooks/useClipboardPaste.ts
+++ b/src/extensions/Attachments/hooks/useClipboardPaste.ts
@@ -37,7 +37,7 @@ export function useClipboardPaste({ enabled, onFiles, onLink }: UseClipboardPast
         const blob = item.getAsFile();
         if (!blob) continue;
         const timestamp = Date.now();
-        imageFiles.push(new File([blob], `pasted-image-${timestamp}.png`, { type: 'image/png' }));
+        imageFiles.push(new File([blob], `pasted-image-${String(timestamp)}.png`, { type: 'image/png' }));
       }
 
       if (imageFiles.length > 0 && !isTextInputFocused()) {

--- a/src/extensions/Automation/components/AutomationPanel/RuleBuilder/ActionList.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/RuleBuilder/ActionList.tsx
@@ -89,7 +89,7 @@ const ActionList = ({ actions, onChange, boardId }: Props) => {
   };
 
   const handlePickAction = (type: ActionType) => {
-    const localId = `action-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    const localId = `action-${String(Date.now())}-${Math.random().toString(36).slice(2, 7)}`;
     const newAction: ActionItemData = {
       id: localId,
       actionType: type.type,

--- a/src/extensions/Automation/components/AutomationPanel/RuleBuilder/configFieldRenderer.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/RuleBuilder/configFieldRenderer.tsx
@@ -263,12 +263,12 @@ function renderStringList(args: RenderArgs): JSX.Element {
       </span>
       <div className="flex flex-col gap-1.5">
         {items.map((item, idx) => (
-          <div key={`${key}-item-${idx}`} className="flex items-center gap-1.5">
+          <div key={`${key}-item-${String(idx)}`} className="flex items-center gap-1.5">
             <input
               type="text"
               className={INPUT_CLASS}
               value={item}
-              placeholder={`Item ${idx + 1}`}
+              placeholder={`Item ${String(idx + 1)}`}
               onChange={(e) => {
                 const next = [...items];
                 next[idx] = e.target.value;

--- a/src/extensions/Automation/components/BoardButtons/BoardButtonsBar.tsx
+++ b/src/extensions/Automation/components/BoardButtons/BoardButtonsBar.tsx
@@ -68,8 +68,8 @@ const BoardButtonsBar: FC<Props> = ({ boardId, hasBackground = false }) => {
       {overflowCount > 0 && (
         <div
           className="flex items-center justify-center rounded px-1.5 py-1 text-xs text-muted"
-          title={`${overflowCount} more board button${overflowCount !== 1 ? 's' : ''}`}
-          aria-label={`${overflowCount} more board buttons`}
+          title={`${String(overflowCount)} more board button${overflowCount !== 1 ? 's' : ''}`}
+          aria-label={`${String(overflowCount)} more board buttons`}
         >
           +{overflowCount}
         </div>

--- a/src/extensions/Automation/components/LogPanel/QuotaBar.tsx
+++ b/src/extensions/Automation/components/LogPanel/QuotaBar.tsx
@@ -47,12 +47,12 @@ const QuotaBar: FC<Props> = ({ quota }) => {
       <div className="h-2 w-full rounded-full bg-bg-overlay overflow-hidden">
         <div
           className={`h-full rounded-full transition-all duration-300 ${barColor(pct)}`}
-          style={{ width: `${pct}%` }}
+          style={{ width: `${String(pct)}%` }}
           role="progressbar"
           aria-valuenow={pct}
           aria-valuemin={0}
           aria-valuemax={100}
-          aria-label={`${pct}% quota used`}
+          aria-label={`${String(pct)}% quota used`}
         />
       </div>
 

--- a/src/extensions/Board/components/BoardMembersPanel/MemberRow.tsx
+++ b/src/extensions/Board/components/BoardMembersPanel/MemberRow.tsx
@@ -8,7 +8,7 @@ const ROLES: BoardMemberRole[] = ['ADMIN', 'MEMBER', 'VIEWER'];
 function initials(member: BoardMember): string {
   const name = member.display_name ?? member.email;
   const parts = name.split(' ').filter(Boolean);
-  if (parts.length >= 2) return `${parts[0]![0]}${parts[1]![0]}`.toUpperCase();
+  if (parts.length >= 2) return `${parts[0]![0] ?? ''}${parts[1]![0] ?? ''}`.toUpperCase();
   return name.slice(0, 2).toUpperCase();
 }
 

--- a/src/extensions/Board/components/VirtualCardList.tsx
+++ b/src/extensions/Board/components/VirtualCardList.tsx
@@ -63,7 +63,7 @@ const VirtualCardList = ({ cards, renderCard, estimatedCardHeight = 80 }: Props)
             style={{
               position: 'absolute',
               top: 0,
-              transform: `translateY(${row.start}px)`,
+              transform: `translateY(${String(row.start)}px)`,
               width: '100%',
               paddingBottom: '8px',
             }}

--- a/src/extensions/CalendarView/CalendarDayCell.tsx
+++ b/src/extensions/CalendarView/CalendarDayCell.tsx
@@ -17,7 +17,7 @@ function toIsoDate(date: Date): string {
   const y = date.getFullYear();
   const m = String(date.getMonth() + 1).padStart(2, '0');
   const d = String(date.getDate()).padStart(2, '0');
-  return `${y}-${m}-${d}`;
+  return `${String(y)}-${m}-${d}`;
 }
 
 const CalendarDayCell = ({

--- a/src/extensions/Card/components/CardMemberAvatars.tsx
+++ b/src/extensions/Card/components/CardMemberAvatars.tsx
@@ -67,7 +67,7 @@ function CardMemberAvatarsComponent({
       {overflow > 0 && (
         <span
           className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-bg-overlay text-[10px] font-bold text-muted ring-2 ring-bg-surface"
-          title={`${overflow} more`}
+          title={`${String(overflow)} more`}
         >
           +{overflow}
         </span>

--- a/src/extensions/Card/components/CardMetaStrip.tsx
+++ b/src/extensions/Card/components/CardMetaStrip.tsx
@@ -636,7 +636,7 @@ function formatMoney(amount: string, currency: string | null): string {
       minimumFractionDigits: numericAmount % 1 === 0 ? 0 : 2,
     }).format(numericAmount);
   } catch {
-    return `${currencyCode} ${numericAmount}`;
+    return `${currencyCode} ${String(numericAmount)}`;
   }
 }
 

--- a/src/extensions/Card/components/CommandMenu.tsx
+++ b/src/extensions/Card/components/CommandMenu.tsx
@@ -134,7 +134,7 @@ const CommandMenu = ({ editor, onClose, onOpenEmojiPicker, extraCommands = [] }:
 
   // Scroll active item into view when navigating with keyboard.
   useEffect(() => {
-    const item = listRef.current?.querySelector<HTMLButtonElement>(`[data-index="${activeIndex}"]`);
+    const item = listRef.current?.querySelector<HTMLButtonElement>(`[data-index="${String(activeIndex)}"]`);
     item?.scrollIntoView({ block: 'nearest' });
   }, [activeIndex]);
 

--- a/src/extensions/Card/components/OneLineToolbar.tsx
+++ b/src/extensions/Card/components/OneLineToolbar.tsx
@@ -321,7 +321,7 @@ const HeadingDropdown = ({ editor }: HeadingDropdownProps) => {
   const activeLabel =
     activeLevel === null
       ? 'Normal text'
-      : `Heading ${activeLevel}`;
+      : `Heading ${String(activeLevel)}`;
 
   const apply = (level: HeadingLevel | null) => {
     if (!editor) return;

--- a/src/extensions/Mention/TiptapMentionExtension.ts
+++ b/src/extensions/Mention/TiptapMentionExtension.ts
@@ -108,7 +108,7 @@ export function buildMentionExtension(boardId: string) {
       class: 'rounded bg-blue-100 dark:bg-blue-900/60 px-1 py-0.5 text-xs font-medium text-blue-700 dark:text-blue-300',
     },
     renderText({ node }) {
-      return `@${node.attrs.label ?? node.attrs.id ?? ''}`;
+      return `@${String(node.attrs.label ?? node.attrs.id ?? '')}`;
     },
     suggestion: buildSuggestion(boardId),
   });

--- a/src/extensions/Plugins/containers/PluginDashboardPage/PluginDashboardPage.tsx
+++ b/src/extensions/Plugins/containers/PluginDashboardPage/PluginDashboardPage.tsx
@@ -66,7 +66,7 @@ const PluginDashboardPage = () => {
   const [toasts, setToasts] = useState<ToastItem[]>([]);
 
   const addToast = useCallback((message: string, variant: ToastItem['variant'] = 'info') => {
-    const id = `toast-${Date.now()}`;
+    const id = `toast-${String(Date.now())}`;
     setToasts((prev) => [...prev, { id, message, variant }]);
   }, []);
 

--- a/src/extensions/Plugins/uiInjections/CardPluginButtons.tsx
+++ b/src/extensions/Plugins/uiInjections/CardPluginButtons.tsx
@@ -84,7 +84,7 @@ const CardPluginButtons = ({ cardId, listId, cardTitle, listTitle, boardTitle, c
       for (const bp of boardPlugins) {
         bridge.sendToPlugin(bp.plugin.id, {
           jhSdk: true,
-          id: `btn-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+          id: `btn-${String(Date.now())}-${Math.random().toString(36).slice(2)}`,
           type: 'BUTTON_CLICKED',
           payload: {
             callbackId: button.callback.__callbackId,

--- a/src/extensions/Realtime/PollingFallback.tsx
+++ b/src/extensions/Realtime/PollingFallback.tsx
@@ -38,7 +38,7 @@ export function usePollingFallback({
     try {
       // apiClient response interceptor auto-unwraps to response.data
       const result = (await apiClient.get(
-        `/boards/${boardId}/events?since=${lastSeqRef.current}`
+        `/boards/${boardId}/events?since=${String(lastSeqRef.current)}`
       )) as { data: RealtimeEvent[]; metadata: { hasMore: boolean; latestSequence: string } };
 
       const events = result.data;

--- a/src/extensions/TimelineView/useTimelineDrag.ts
+++ b/src/extensions/TimelineView/useTimelineDrag.ts
@@ -33,7 +33,7 @@ function parseLocalDate(s: string): Date {
 }
 
 function formatDate(d: Date): string {
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  return `${String(d.getFullYear())}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 }
 
 function addDaysToStr(dateStr: string, days: number): string {


### PR DESCRIPTION
## Summary

Fixes 50 `@typescript-eslint/restrict-template-expressions` findings across 37 files — **completes the family to zero repo-wide**. Non-string values interpolated in template literals are wrapped in `String(...)` (for numbers/`any`), and `string | undefined` values get a `?? ''` fallback.

## Scope

- Rule family: `@typescript-eslint/restrict-template-expressions`
- 37 files, 47 insertions / 47 deletions (50 finding-occurrences; 3 lines had multiple interpolations)
- Includes server API endpoints (auth register/refresh/oauth-callback/reset/logout, plugins registry create/update/token) where coercions are **output-identical** — `String(x) == ${x}` for every value, so auth cookie Set-Cookie strings, response bodies, and error/log output are byte-identical
- 2 test files touched: nodeCache.test.ts, token.test.ts

## Verification

- Focused lint on all 37 touched files: **0 `restrict-template-expressions` findings** (family fully cleared)
- **Base-vs-head eslint any-rule gate: ONLY delta is -50 restrict-template-expressions — zero newly-introduced findings of any rule across all 37 files**
- Focused tests: **token.test.ts (3 pass / 0 fail)**, **nodeCache.test.ts (all pass)** — both green
- `bun run typecheck`: **146 errors — identical to current main baseline** (no new failures)
- `bun test`: **1444 tests, identical fail identities to current main** (no new failures)
- `bun run build:client`: **passed**; `git diff --check`: **clean**

## UI/E2E coverage

Touched files are UI components, server endpoints, pure utils, and server test files. No dedicated executable UI/E2E coverage for the UI components — recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched. No unrelated files in the diff.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.