### PR TITLE
lint: add braces to void-returning arrow shorthands (confusing-void batch 7)

### DIFF
--- a/src/common/components/ThemeToggle.tsx
+++ b/src/common/components/ThemeToggle.tsx
@@ -38,13 +38,13 @@ export function ThemeToggle() {
       if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
     };
     document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    return () => { document.removeEventListener('mousedown', handler); };
   }, [open]);
 
   return (
     <div ref={ref} className="relative">
       <button
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => { setOpen((v) => !v); }}
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-label={`Theme: ${current.label}`}

--- a/src/extensions/Attachment/components/AttachmentSection.tsx
+++ b/src/extensions/Attachment/components/AttachmentSection.tsx
@@ -69,13 +69,13 @@ export function AttachmentSection({ cardId, authToken, apiBase = '' }: Props): R
       ))}
       <AttachmentUploader cardId={cardId} onUploadComplete={handleUploadComplete} />
       <button
-        onClick={() => setShowUrlModal(true)}
+        onClick={() => { setShowUrlModal(true); }}
         style={{ marginTop: 8, fontSize: 12, cursor: 'pointer' }}
       >
         {translations['attachment.section.addUrl']}
       </button>
       {showUrlModal && (
-        <AttachmentUrlModal cardId={cardId} onAdd={handleAddUrl} onClose={() => setShowUrlModal(false)} />
+        <AttachmentUrlModal cardId={cardId} onAdd={handleAddUrl} onClose={() => { setShowUrlModal(false); }} />
       )}
     </section>
   );

--- a/src/extensions/Attachment/components/AttachmentUploader.tsx
+++ b/src/extensions/Attachment/components/AttachmentUploader.tsx
@@ -23,7 +23,7 @@ export function AttachmentUploader({ cardId, onUploadComplete }: Props): React.R
   return (
     <div
       onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
-      onDragLeave={() => setDragging(false)}
+      onDragLeave={() => { setDragging(false); }}
       onDrop={(e) => { e.preventDefault(); setDragging(false); handleFiles(e.dataTransfer.files); }}
       onClick={() => inputRef.current?.click()}
       style={{
@@ -40,7 +40,7 @@ export function AttachmentUploader({ cardId, onUploadComplete }: Props): React.R
         ref={inputRef}
         type="file"
         style={{ display: 'none' }}
-        onChange={(e) => handleFiles(e.target.files)}
+        onChange={(e) => { handleFiles(e.target.files); }}
       />
       {progress !== null ? (
         <div>

--- a/src/extensions/Attachment/components/AttachmentUrlModal.tsx
+++ b/src/extensions/Attachment/components/AttachmentUrlModal.tsx
@@ -45,7 +45,7 @@ export function AttachmentUrlModal({ onAdd, onClose }: Props): React.ReactElemen
           <input
             type="text"
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e) => { setName(e.target.value); }}
             style={{ display: 'block', width: '100%', marginTop: 4, padding: '6px 8px', border: '1px solid #d1d5db', borderRadius: 4 }}
           />
         </label>
@@ -54,7 +54,7 @@ export function AttachmentUrlModal({ onAdd, onClose }: Props): React.ReactElemen
           <input
             type="url"
             value={url}
-            onChange={(e) => setUrl(e.target.value)}
+            onChange={(e) => { setUrl(e.target.value); }}
             style={{ display: 'block', width: '100%', marginTop: 4, padding: '6px 8px', border: '1px solid #d1d5db', borderRadius: 4 }}
           />
         </label>

--- a/src/extensions/Auth/containers/ConfirmEmailChangePage/ConfirmEmailChangePage.tsx
+++ b/src/extensions/Auth/containers/ConfirmEmailChangePage/ConfirmEmailChangePage.tsx
@@ -28,10 +28,10 @@ export default function ConfirmEmailChangePage() {
   useEffect(() => {
     if (status === 'success') {
       const timer = setTimeout(
-        () => navigate('/login', { replace: true, state: { toast: translations.changeEmail.confirmed } }),
+        () => { navigate('/login', { replace: true, state: { toast: translations.changeEmail.confirmed } }); },
         1500,
       );
-      return () => clearTimeout(timer);
+      return () => { clearTimeout(timer); };
     }
   }, [status, navigate]);
 

--- a/src/extensions/Auth/containers/VerifyEmailPage/VerifyEmailPage.tsx
+++ b/src/extensions/Auth/containers/VerifyEmailPage/VerifyEmailPage.tsx
@@ -31,8 +31,8 @@ export default function VerifyEmailPage() {
   useEffect(() => {
     if (status === 'success') {
       // Slight delay so user sees the success message before redirect
-      const timer = setTimeout(() => navigate('/workspaces', { replace: true }), 1500);
-      return () => clearTimeout(timer);
+      const timer = setTimeout(() => { navigate('/workspaces', { replace: true }); }, 1500);
+      return () => { clearTimeout(timer); };
     }
   }, [status, navigate]);
 

--- a/src/extensions/Automation/components/AutomationPanel/AutomationList.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/AutomationList.tsx
@@ -142,7 +142,7 @@ const AutomationRow = ({ boardId, automation, onEdit, onDeleted, onToggled }: Ro
           disabled={deleting}
           aria-label={confirmDelete ? translations['automation.list.row.confirmDeleteAriaLabel'] : translations['automation.list.row.deleteAriaLabel']}
           title={confirmDelete ? translations['automation.list.row.confirmDeleteTitle'] : translations['automation.list.row.deleteTitle']}
-          onBlur={() => setConfirmDelete(false)}
+          onBlur={() => { setConfirmDelete(false); }}
         >
           <TrashIcon className="h-4 w-4" aria-hidden="true" />
         </button>
@@ -175,7 +175,7 @@ const AutomationList = ({ boardId, automations, onCreateRule, onEditRule, onChan
             key={automation.id}
             boardId={boardId}
             automation={automation}
-            onEdit={() => onEditRule(automation)}
+            onEdit={() => { onEditRule(automation); }}
             onDeleted={onChanged}
             onToggled={onChanged}
           />

--- a/src/extensions/Automation/components/AutomationPanel/RuleBuilder/index.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/RuleBuilder/index.tsx
@@ -39,11 +39,11 @@ const RuleBuilder = ({ boardId, initialAutomation, onSaved, onCancel }: Props) =
 
   useEffect(() => {
     getTriggerTypes()
-      .then((res) => setAllTriggerTypes(res.data))
+      .then((res) => { setAllTriggerTypes(res.data); })
       .catch(() => {});
 
     getActionTypes()
-      .then((res) => setAllActionTypes(res.data))
+      .then((res) => { setAllActionTypes(res.data); })
       .catch(() => {});
   }, []);
   const [actions, setActions] = useState<ActionItemData[]>(

--- a/src/extensions/Automation/components/CardButtons/CardButtonsSection.tsx
+++ b/src/extensions/Automation/components/CardButtons/CardButtonsSection.tsx
@@ -82,7 +82,7 @@ const CardButtonsSection: FC<Props> = ({ boardId, cardId, disabled = false }) =>
           <BoltIcon className="h-4 w-4 text-muted" aria-hidden="true" />
           <h3 className="text-sm font-medium text-subtle">{translations['automation.panel.title']}</h3>
         </div>
-        <AddCardButtonButton onClick={() => setShowBuilder(true)} disabled={disabled} />
+        <AddCardButtonButton onClick={() => { setShowBuilder(true); }} disabled={disabled} />
 
         {showBuilder && (
           <CardButtonBuilder
@@ -116,7 +116,7 @@ const CardButtonsSection: FC<Props> = ({ boardId, cardId, disabled = false }) =>
       </ul>
 
       <div className="mt-1.5">
-        <AddCardButtonButton onClick={() => setShowBuilder(true)} disabled={disabled} />
+        <AddCardButtonButton onClick={() => { setShowBuilder(true); }} disabled={disabled} />
       </div>
 
       {(showBuilder || editingButton) && (

--- a/src/extensions/Automation/components/LogPanel/RunLogTable.tsx
+++ b/src/extensions/Automation/components/LogPanel/RunLogTable.tsx
@@ -92,7 +92,7 @@ const RunLogTable: FC<Props> = ({
           <button
             className="px-2 py-1 text-xs text-muted hover:text-subtle disabled:opacity-40"
             disabled={page <= 1}
-            onClick={() => onPageChange(page - 1)}
+            onClick={() => { onPageChange(page - 1); }}
             aria-label={translations['automation.runLogTable.prevAriaLabel']}
           >
             {translations['automation.runLogTable.prev']}
@@ -103,7 +103,7 @@ const RunLogTable: FC<Props> = ({
           <button
             className="px-2 py-1 text-xs text-muted hover:text-subtle disabled:opacity-40"
             disabled={page >= totalPage}
-            onClick={() => onPageChange(page + 1)}
+            onClick={() => { onPageChange(page + 1); }}
             aria-label={translations['automation.runLogTable.nextAriaLabel']}
           >
             {translations['automation.runLogTable.next']}

--- a/src/extensions/Board/components/BoardMembersPanel/AddMemberInput.tsx
+++ b/src/extensions/Board/components/BoardMembersPanel/AddMemberInput.tsx
@@ -42,7 +42,7 @@ const AddMemberInput = ({ candidates, onAdd, onFocusInput }: Props) => {
       }
     };
     document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    return () => { document.removeEventListener('mousedown', handler); };
   }, []);
 
   const handleSelect = async (member: WorkspaceMember) => {
@@ -108,7 +108,7 @@ const AddMemberInput = ({ candidates, onAdd, onFocusInput }: Props) => {
 
         <select
           value={selectedRole}
-          onChange={(e) => setSelectedRole(e.target.value as BoardMemberRole)}
+          onChange={(e) => { setSelectedRole(e.target.value as BoardMemberRole); }}
           className="rounded border border-border bg-bg-surface px-2 py-1.5 text-xs text-subtle focus:outline-none focus:ring-2 focus:ring-primary"
           aria-label="Role for new board member"
         >

--- a/src/extensions/Board/components/BoardMembersPanel/GuestsTab.tsx
+++ b/src/extensions/Board/components/BoardMembersPanel/GuestsTab.tsx
@@ -109,7 +109,7 @@ const GuestsTab = ({ boardId, isAdmin }: Props) => {
             <span className="mr-1 text-xs text-muted">Role:</span>
             <button
               type="button"
-              onClick={() => setGuestType('VIEWER')}
+              onClick={() => { setGuestType('VIEWER'); }}
               aria-pressed={guestType === 'VIEWER'}
               className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
                 guestType === 'VIEWER'
@@ -121,7 +121,7 @@ const GuestsTab = ({ boardId, isAdmin }: Props) => {
             </button>
             <button
               type="button"
-              onClick={() => setGuestType('MEMBER')}
+              onClick={() => { setGuestType('MEMBER'); }}
               aria-pressed={guestType === 'MEMBER'}
               className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
                 guestType === 'MEMBER'

--- a/src/extensions/Board/components/BoardMembersPanel/MemberRow.tsx
+++ b/src/extensions/Board/components/BoardMembersPanel/MemberRow.tsx
@@ -61,7 +61,7 @@ const MemberRow = ({ member, isLastAdmin, canEdit, onRoleChange, onRemove }: Pro
       {canEdit ? (
         <select
           value={member.role}
-          onChange={(e) => onRoleChange(member.user_id, e.target.value as BoardMemberRole)}
+          onChange={(e) => { onRoleChange(member.user_id, e.target.value as BoardMemberRole); }}
           className="rounded border border-border bg-bg-overlay px-2 py-1 text-xs text-base focus:outline-none focus:ring-2 focus:ring-primary"
           aria-label={`Change role for ${label}`}
         >
@@ -81,7 +81,7 @@ const MemberRow = ({ member, isLastAdmin, canEdit, onRoleChange, onRemove }: Pro
           type="button"
           disabled={isLastAdmin}
           title={removeTitle}
-          onClick={() => !isLastAdmin && onRemove(member.user_id)}
+          onClick={() => { if (!isLastAdmin) { onRemove(member.user_id); } }}
           className={`ml-1 rounded p-1 text-muted transition-colors ${
             isLastAdmin
               ? 'cursor-not-allowed opacity-40'

--- a/src/extensions/Card/components/CardMemberAvatars.tsx
+++ b/src/extensions/Card/components/CardMemberAvatars.tsx
@@ -85,7 +85,7 @@ function CardMemberAvatarsComponent({
                 },
               }
             : {})}
-          onClose={() => setActiveMember(null)}
+          onClose={() => { setActiveMember(null); }}
           anchorRef={anchorRef as React.RefObject<HTMLElement>}
         />
       )}

--- a/src/extensions/Card/components/CreateCardForm.tsx
+++ b/src/extensions/Card/components/CreateCardForm.tsx
@@ -43,7 +43,7 @@ const CreateCardForm = ({ listId, onSubmit, onCancel }: Props) => {
         placeholder="Enter a title for this card…"
         rows={2}
         value={title}
-        onChange={(e) => setTitle(e.target.value)}
+        onChange={(e) => { setTitle(e.target.value); }}
         autoFocus
         aria-label="New card title"
         disabled={submitting}

--- a/src/extensions/Card/components/LabelPicker.tsx
+++ b/src/extensions/Card/components/LabelPicker.tsx
@@ -31,7 +31,7 @@ export const LabelPicker = ({ allLabels, selectedIds, onAttach, onDetach, disabl
         type="button"
         variant="secondary"
         className="px-2 py-1 text-sm"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => { setOpen((v) => !v); }}
         disabled={disabled}
         aria-haspopup="listbox"
         aria-expanded={open}

--- a/src/extensions/Card/components/MemberAssignModal.tsx
+++ b/src/extensions/Card/components/MemberAssignModal.tsx
@@ -35,7 +35,7 @@ export const MemberAssignModal = ({
       aria-label="Assign members"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
-      <div className="w-80 rounded-lg bg-bg-surface shadow-xl" onClick={(e) => e.stopPropagation()}>
+      <div className="w-80 rounded-lg bg-bg-surface shadow-xl" onClick={(e) => { e.stopPropagation(); }}>
         <div className="flex items-center justify-between border-b px-4 py-3">
           <h2 className="font-semibold">Assign Members</h2>
           <IconButton

--- a/src/extensions/Comment/components/CommentReplyThread.tsx
+++ b/src/extensions/Comment/components/CommentReplyThread.tsx
@@ -122,7 +122,7 @@ const CommentReplyThread = ({
         <Button
           variant="link"
           size="sm"
-          onClick={() => onExpandToggle(!expanded)}
+          onClick={() => { onExpandToggle(!expanded); }}
           className="mt-1"
         >
           {expanded

--- a/src/extensions/CustomFields/api.ts
+++ b/src/extensions/CustomFields/api.ts
@@ -362,7 +362,7 @@ export function useCardCustomFieldValues(cardId: string | undefined): UseCardCus
   const [loading, setLoading] = useState(false);
   const [tick, setTick] = useState(0);
 
-  const refetch = useCallback(() => setTick((t) => t + 1), []);
+  const refetch = useCallback(() => { setTick((t) => t + 1); }, []);
 
   useEffect(() => {
     if (!cardId) return;

--- a/src/extensions/HealthCheck/components/HealthCheckRow.tsx
+++ b/src/extensions/HealthCheck/components/HealthCheckRow.tsx
@@ -100,7 +100,7 @@ export function HealthCheckRow({ entry, isProbing, onRemove }: Props) {
       <IconButton
         type="button"
         variant="ghost"
-        onClick={() => onRemove(entry.id)}
+        onClick={() => { onRemove(entry.id); }}
         disabled={isProbing}
         aria-label={`Remove ${entry.name}`}
         title={`Remove ${entry.name}`}

--- a/src/extensions/HealthCheck/components/HealthCheckStatusDot.tsx
+++ b/src/extensions/HealthCheck/components/HealthCheckStatusDot.tsx
@@ -69,7 +69,7 @@ export function HealthCheckStatusDot({ status, httpStatus, responseTimeMs, error
       setTooltipPos({ x: rect.left + rect.width / 2, y: rect.top - 8 });
     }
   };
-  const hideTooltip = () => setTooltipPos(null);
+  const hideTooltip = () => { setTooltipPos(null); };
 
   return (
     <span

--- a/src/extensions/Notifications/NotificationPreferences/NotificationPreferencesPanel.tsx
+++ b/src/extensions/Notifications/NotificationPreferences/NotificationPreferencesPanel.tsx
@@ -45,7 +45,7 @@ const ToggleSwitch = ({
         aria-checked={enabled}
         aria-label={ariaLabel}
         disabled={disabled}
-        onClick={() => !disabled && onChange(!enabled)}
+        onClick={() => { if (!disabled) { onChange(!enabled); } }}
         className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900 ${track}`}
       >
         <span

--- a/src/extensions/Plugins/components/DiscoverPluginRow.tsx
+++ b/src/extensions/Plugins/components/DiscoverPluginRow.tsx
@@ -69,7 +69,7 @@ const DiscoverPluginRow = ({ plugin, onEnable, loading = false }: Props) => {
         <Button
           variant="primary"
           size="sm"
-          onClick={() => onEnable(plugin)}
+          onClick={() => { onEnable(plugin); }}
           disabled={loading}
         >
           {loading ? translations['plugins.card.enabling'] : translations['plugins.card.enable']}

--- a/src/extensions/Plugins/components/PluginCard.tsx
+++ b/src/extensions/Plugins/components/PluginCard.tsx
@@ -81,7 +81,7 @@ const PluginCard = (props: Props) => {
         {/* Edit pencil — platform admins only, always visible when onEdit provided */}
         {props.onEdit && (
           <button
-            onClick={() => props.onEdit!(plugin)}
+            onClick={() => { props.onEdit!(plugin); }}
             title={translations['plugins.card.editTitle']}
             className="text-muted hover:text-subtle p-1 rounded transition-colors"
             aria-label={translations['plugins.card.editAriaLabel']}

--- a/src/extensions/Plugins/containers/PluginRegistryPage/PluginRegistryPage.tsx
+++ b/src/extensions/Plugins/containers/PluginRegistryPage/PluginRegistryPage.tsx
@@ -284,7 +284,7 @@ const PluginRegistryPage = () => {
         open={registerOpen}
         isSubmitting={isSubmittingRegister}
         serverError={registerServerError}
-        onClose={() => setRegisterOpen(false)}
+        onClose={() => { setRegisterOpen(false); }}
         onSubmit={(body) => void handleRegisterSubmit(body)}
       />
 

--- a/src/extensions/Plugins/iframeHost/usePluginBridge.ts
+++ b/src/extensions/Plugins/iframeHost/usePluginBridge.ts
@@ -502,7 +502,7 @@ export function usePluginBridge({
     };
 
     window.addEventListener('message', handler);
-    return () => window.removeEventListener('message', handler);
+    return () => { window.removeEventListener('message', handler); };
   }, [findPluginByOrigin, handleDataGet, handleDataSet, handleCapabilityResponse, handleCtxQuery, isDomainAllowed, sendDomainError, onOpenModal, onCloseModal, onUpdateModal, onOpenPopup, onClosePopup, onSizeTo]);
 
   // Resolve a capability across all active plugins that have registered it

--- a/src/extensions/Plugins/modals/ApiKeyRevealModal.tsx
+++ b/src/extensions/Plugins/modals/ApiKeyRevealModal.tsx
@@ -17,7 +17,7 @@ const ApiKeyRevealModal = ({ apiKey, onClose }: Props) => {
     try {
       await navigator.clipboard.writeText(apiKey);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      setTimeout(() => { setCopied(false); }, 2000);
     } catch {
       // fallback: select the text
     }

--- a/src/extensions/Search/components/SearchInput.tsx
+++ b/src/extensions/Search/components/SearchInput.tsx
@@ -19,7 +19,7 @@ const SearchInput: React.FC<SearchInputProps> = ({
     <input
       type="text"
       value={value}
-      onChange={(e) => onChange(e.target.value)}
+      onChange={(e) => { onChange(e.target.value); }}
       placeholder={placeholder}
       autoFocus={autoFocus}
       className="w-full rounded-md border border-border bg-bg-overlay px-4 py-2 text-sm text-base outline-none focus:outline-none focus:ring-2 focus:ring-primary"

--- a/src/extensions/Search/hooks/useSearch.ts
+++ b/src/extensions/Search/hooks/useSearch.ts
@@ -59,7 +59,7 @@ export function useSearch({ workspaceId, token, type }: UseSearchOptions): UseSe
     const timer = setTimeout(() => {
       doSearch(query).catch(() => {});
     }, DEBOUNCE_MS);
-    return () => clearTimeout(timer);
+    return () => { clearTimeout(timer); };
   }, [query, type, doSearch]);
 
   return { query, setQuery, results, loading, error };

--- a/src/extensions/TableView/TableRow.tsx
+++ b/src/extensions/TableView/TableRow.tsx
@@ -49,7 +49,7 @@ const TableRow = ({ row, onCardClick }: Props) => {
         <Button
           variant="ghost"
           className="text-sm font-semibold text-base hover:text-primary justify-start underline-offset-2 hover:underline px-0 py-0"
-          onClick={() => onCardClick(row.id)}
+          onClick={() => { onCardClick(row.id); }}
           aria-label={`${translations['TableView.ariaOpenCard']} ${row.title}`}
           data-testid={`table-card-title-${row.id}`}
         >

--- a/src/extensions/TimelineView/TimelineRow.tsx
+++ b/src/extensions/TimelineView/TimelineRow.tsx
@@ -161,7 +161,7 @@ const TimelineRow = ({
                 key={card.id}
                 variant="ghost"
                 className="rounded bg-bg-overlay px-2 py-0.5 text-xs text-subtle hover:bg-bg-sunken"
-                onClick={() => onCardClick(card.id)}
+                onClick={() => { onCardClick(card.id); }}
                 data-testid={`timeline-unscheduled-chip-${card.id}`}
               >
                 {card.title}

--- a/src/extensions/User/components/AvatarUploader.tsx
+++ b/src/extensions/User/components/AvatarUploader.tsx
@@ -71,7 +71,7 @@ export default function AvatarUploader({ avatarUrl, name }: AvatarUploaderProps)
         style={{ width: 128, height: 128 }}
         onClick={() => inputRef.current?.click()}
         onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
-        onDragLeave={() => setDragOver(false)}
+        onDragLeave={() => { setDragOver(false); }}
         onDrop={handleDrop}
         role="button"
         tabIndex={0}

--- a/src/extensions/Webhooks/containers/WebhooksRegisterPage/WebhookCreatedModal.tsx
+++ b/src/extensions/Webhooks/containers/WebhooksRegisterPage/WebhookCreatedModal.tsx
@@ -19,7 +19,7 @@ export default function WebhookCreatedModal({ signingSecret, onClose }: Props) {
       await navigator.clipboard.writeText(signingSecret);
       setCopied(true);
       // [why] Reset label after 2s so the user knows the button is ready for another copy.
-      setTimeout(() => setCopied(false), 2000);
+      setTimeout(() => { setCopied(false); }, 2000);
     } catch {
       // Silently fail — clipboard may be unavailable in some environments
     }

--- a/src/extensions/Workspace/components/CreateWorkspaceModal.tsx
+++ b/src/extensions/Workspace/components/CreateWorkspaceModal.tsx
@@ -65,7 +65,7 @@ export default function CreateWorkspaceModal({ open, onOpenChange }: CreateWorks
                 id="workspace-name"
                 type="text"
                 value={name}
-                onChange={(e) => setName(e.target.value)}
+                onChange={(e) => { setName(e.target.value); }}
                 placeholder={translations['CreateWorkspaceModal.namePlaceholder']}
                 required
                 autoFocus

--- a/src/extensions/Workspace/containers/AcceptInvitePage/AcceptInvitePage.tsx
+++ b/src/extensions/Workspace/containers/AcceptInvitePage/AcceptInvitePage.tsx
@@ -30,7 +30,7 @@ const AcceptInvitePage = () => {
       return;
     }
     inspectInvite({ api, token })
-      .then((res) => setState({ status: 'ready', invite: res.data }))
+      .then((res) => { setState({ status: 'ready', invite: res.data }); })
       .catch((err) => {
         const errorName =
           err?.response?.data?.error?.code ?? 'unknown-error';


### PR DESCRIPTION
## Summary

Fixes 48 `@typescript-eslint/no-confusing-void-expression` findings across 35 files. Arrow-function shorthands returning a void expression (`() => void fn()`) are converted to block-body form (`() => { void fn(); }`). Behaviour-identical: void returns are discarded either way.

## Scope

- Rule family: `@typescript-eslint/no-confusing-void-expression`
- 35 files, 48 insertions / 48 deletions (all brace conversions)
- Files are UI components / hooks / utils across BoardMembersPanel, Automation, Auth, Attachment, ThemeToggle, Workspace, Search, Plugins, Notifications, HealthCheck, CustomFields, Comment, Card

## Verification

- Focused lint on all 35 touched files: **0 `no-confusing-void-expression` findings**
- **Base-vs-head eslint any-rule gate: ONLY delta is -48 no-confusing-void-expression — zero newly-introduced findings of any rule** (the strengthened gate from PR #280)
- `bun run typecheck`: **146 errors — identical to current main baseline** (no new failures)
- `bun test`: **1444 tests, identical fail identities to current main** (no new failures)
- `bun run build:client`: **passed**; `git diff --check`: **clean**

## UI/E2E coverage

All touched files are UI components / hooks / utils with no dedicated executable UI/E2E coverage — recorded as **missing**, not claimed as passed.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files touched. No unrelated files in the diff.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.