### PR TITLE
lint: use this as return type in query-builder test fixtures (prefer-return-this-type batch 1)

### DIFF
--- a/server/extensions/stateTransitions/__tests__/getRules.test.ts
+++ b/server/extensions/stateTransitions/__tests__/getRules.test.ts
@@ -15,18 +15,18 @@ class QueryBuilder {
 
   constructor(private readonly store: DataStore, private readonly tableName: keyof DataStore) {}
 
-  where(criteria: Row): QueryBuilder {
+  where(criteria: Row): this {
     this.filters.push((row) => Object.entries(criteria).every(([key, value]) => row[key] === value));
     return this;
   }
 
-  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): QueryBuilder {
+  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): this {
     this.orderedBy = column;
     this.orderDirection = direction;
     return this;
   }
 
-  select(...columns: string[]): QueryBuilder {
+  select(...columns: string[]): this {
     this.selectedColumns = columns.length > 0 ? columns : null;
     return this;
   }

--- a/server/extensions/stateTransitions/__tests__/put.test.ts
+++ b/server/extensions/stateTransitions/__tests__/put.test.ts
@@ -16,18 +16,18 @@ class QueryBuilder {
 
   constructor(private readonly store: DataStore, private readonly tableName: keyof DataStore) {}
 
-  where(criteria: Row): QueryBuilder {
+  where(criteria: Row): this {
     this.filters.push((row) => Object.entries(criteria).every(([key, value]) => row[key] === value));
     return this;
   }
 
-  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): QueryBuilder {
+  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): this {
     this.orderedBy = column;
     this.orderDirection = direction;
     return this;
   }
 
-  select(...columns: string[]): QueryBuilder {
+  select(...columns: string[]): this {
     this.selectedColumns = columns.length > 0 ? columns : null;
     return this;
   }

--- a/server/extensions/stateTransitions/api/__tests__/copy.test.ts
+++ b/server/extensions/stateTransitions/api/__tests__/copy.test.ts
@@ -16,18 +16,18 @@ class QueryBuilder {
 
   constructor(private readonly store: DataStore, private readonly tableName: keyof DataStore) {}
 
-  where(criteria: Row): QueryBuilder {
+  where(criteria: Row): this {
     this.filters.push((row) => Object.entries(criteria).every(([key, value]) => row[key] === value));
     return this;
   }
 
-  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): QueryBuilder {
+  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): this {
     this.orderedBy = column;
     this.orderDirection = direction;
     return this;
   }
 
-  select(...columns: string[]): QueryBuilder {
+  select(...columns: string[]): this {
     this.selectedColumns = columns.length > 0 ? columns : null;
     return this;
   }

--- a/server/extensions/stateTransitions/api/__tests__/get.test.ts
+++ b/server/extensions/stateTransitions/api/__tests__/get.test.ts
@@ -15,18 +15,18 @@ class QueryBuilder {
 
   constructor(private readonly store: DataStore, private readonly tableName: keyof DataStore) {}
 
-  where(criteria: Row): QueryBuilder {
+  where(criteria: Row): this {
     this.filters.push((row) => Object.entries(criteria).every(([key, value]) => row[key] === value));
     return this;
   }
 
-  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): QueryBuilder {
+  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): this {
     this.orderedBy = column;
     this.orderDirection = direction;
     return this;
   }
 
-  select(...columns: string[]): QueryBuilder {
+  select(...columns: string[]): this {
     this.selectedColumns = columns.length > 0 ? columns : null;
     return this;
   }

--- a/server/extensions/stateTransitions/api/__tests__/getRules.test.ts
+++ b/server/extensions/stateTransitions/api/__tests__/getRules.test.ts
@@ -15,18 +15,18 @@ class QueryBuilder {
 
   constructor(private readonly store: DataStore, private readonly tableName: keyof DataStore) {}
 
-  where(criteria: Row): QueryBuilder {
+  where(criteria: Row): this {
     this.filters.push((row) => Object.entries(criteria).every(([key, value]) => row[key] === value));
     return this;
   }
 
-  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): QueryBuilder {
+  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): this {
     this.orderedBy = column;
     this.orderDirection = direction;
     return this;
   }
 
-  select(...columns: string[]): QueryBuilder {
+  select(...columns: string[]): this {
     this.selectedColumns = columns.length > 0 ? columns : null;
     return this;
   }

--- a/server/extensions/stateTransitions/api/__tests__/put_list_sync.test.ts
+++ b/server/extensions/stateTransitions/api/__tests__/put_list_sync.test.ts
@@ -15,18 +15,18 @@ class QueryBuilder {
 
   constructor(private readonly store: DataStore, private readonly tableName: keyof DataStore) {}
 
-  where(criteria: Row): QueryBuilder {
+  where(criteria: Row): this {
     this.filters.push((row) => Object.entries(criteria).every(([key, value]) => row[key] === value));
     return this;
   }
 
-  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): QueryBuilder {
+  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): this {
     this.orderedBy = column;
     this.orderDirection = direction;
     return this;
   }
 
-  select(...columns: string[]): QueryBuilder {
+  select(...columns: string[]): this {
     this.selectedColumns = columns.length > 0 ? columns : null;
     return this;
   }

--- a/server/extensions/stateTransitions/api/__tests__/put_sync_hooks.test.ts
+++ b/server/extensions/stateTransitions/api/__tests__/put_sync_hooks.test.ts
@@ -15,18 +15,18 @@ class QueryBuilder {
 
   constructor(private readonly store: DataStore, private readonly tableName: keyof DataStore) {}
 
-  where(criteria: Row): QueryBuilder {
+  where(criteria: Row): this {
     this.filters.push((row) => Object.entries(criteria).every(([key, value]) => row[key] === value));
     return this;
   }
 
-  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): QueryBuilder {
+  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): this {
     this.orderedBy = column;
     this.orderDirection = direction;
     return this;
   }
 
-  select(...columns: string[]): QueryBuilder {
+  select(...columns: string[]): this {
     this.selectedColumns = columns.length > 0 ? columns : null;
     return this;
   }

--- a/server/extensions/stateTransitions/common/__tests__/integration_list_sync.test.ts
+++ b/server/extensions/stateTransitions/common/__tests__/integration_list_sync.test.ts
@@ -21,23 +21,23 @@ class QueryBuilder {
 
   constructor(private readonly store: DataStore, private readonly tableName: keyof DataStore) {}
 
-  where(criteria: Row): QueryBuilder {
+  where(criteria: Row): this {
     this.filters.push((row) => Object.entries(criteria).every(([key, value]) => row[key] === value));
     return this;
   }
 
-  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): QueryBuilder {
+  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): this {
     this.orderedBy = column;
     this.orderDirection = direction;
     return this;
   }
 
-  select(...columns: string[]): QueryBuilder {
+  select(...columns: string[]): this {
     this.selectedColumns = columns.length > 0 ? columns : null;
     return this;
   }
 
-  count(aliasExpression: string): QueryBuilder {
+  count(aliasExpression: string): this {
     this.countAlias = aliasExpression.split(' as ')[1] ?? 'count';
     return this;
   }

--- a/server/extensions/stateTransitions/enforcement/__tests__/rules.test.ts
+++ b/server/extensions/stateTransitions/enforcement/__tests__/rules.test.ts
@@ -14,18 +14,18 @@ class QueryBuilder {
 
   constructor(private readonly store: DataStore, private readonly tableName: keyof DataStore) {}
 
-  where(criteria: Row): QueryBuilder {
+  where(criteria: Row): this {
     this.filters.push((row) => Object.entries(criteria).every(([key, value]) => row[key] === value));
     return this;
   }
 
-  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): QueryBuilder {
+  orderBy(column: string, direction: 'asc' | 'desc' = 'asc'): this {
     this.orderedBy = column;
     this.orderDirection = direction;
     return this;
   }
 
-  select(...columns: string[]): QueryBuilder {
+  select(...columns: string[]): this {
     this.selectedColumns = columns.length > 0 ? columns : null;
     return this;
   }


### PR DESCRIPTION
## Summary

Fixes 28 `@typescript-eslint/prefer-return-this-type` findings across 9 stateTransitions test-fixture files by changing annotated `QueryBuilder` return types to the more-specific `this` on class methods. Type-only annotation change — `this` is a subtype of the class name, so it is compatible with all existing chained/assigned usages. Behaviour-preserving.

## Scope / rule

- Rule: `@typescript-eslint/prefer-return-this-type` (return-type annotation should be `this` not the class name)
- 9 files, all stateTransitions test-fixture query-builder classes
- Files: integration_list_sync (4), + 8 files at 3 each (rules, put_sync_hooks, put_list_sync, getRules x2, get, copy, put)

## Verification

- **Base-vs-main any-rule gate: -28 prefer-return-this-type, ZERO newly-introduced findings of any rule** (verified against trusted current-main capture)
- `bunx tsc --noEmit`: **146 errors — identical to current main baseline** (all 28 applied, none needed revert)
- `bun test`: **300 fail identities identical to current main** (no new failures; the 2 getRules.test.ts fails are pre-existing snake_case/camelCase response-shape mismatches in untouched serializer.ts, confirmed identical on main)
- `bun run build:client`: **passed**; `git diff --check`: **clean**

## UI/E2E coverage

Type-only test-fixture annotation change — no UI/server runtime path. Covered via typecheck + focused stateTransitions tests + full suite.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files. No unrelated files (9 of 9 are stateTransitions test fixtures).

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.