### PR TITLE
lint: remove unused vars and imports (no-unused-vars batch 1)

### DIFF
--- a/server/extensions/attachment/__tests__/uploadFlow.test.ts
+++ b/server/extensions/attachment/__tests__/uploadFlow.test.ts
@@ -1,6 +1,6 @@
 // Integration tests for the full upload flow, external URL creation, and delete.
 // These tests mock S3 and DB to verify the API handler logic end-to-end.
-import { describe, expect, test, mock, beforeEach } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 
 // We test SSRF validator inline since it has no external dependencies
 import { isForbiddenUrl } from '../api/addUrl';

--- a/server/extensions/automation/engine/actions/card/addComment.ts
+++ b/server/extensions/automation/engine/actions/card/addComment.ts
@@ -14,7 +14,7 @@ export const cardAddCommentAction: ActionHandler = {
   label: 'Add comment to card',
   category: 'card',
   configSchema,
-  async execute({ action, automation, event, evalContext, trx }: ActionContext): Promise<void> {
+  async execute({ action, automation, evalContext, trx }: ActionContext): Promise<void> {
     const config = configSchema.parse(action.config);
     const cardId = evalContext.cardId;
     if (!cardId) throw new Error('card-id-missing');

--- a/server/extensions/plugins/sdk/jh-instance.ts
+++ b/server/extensions/plugins/sdk/jh-instance.ts
@@ -239,7 +239,7 @@ window.addEventListener('message', (event: MessageEvent) => {
       { jhSdk: true, id: nextId(), type: 'RESOLVE_CAPABILITY_RESPONSE', payload: { requestId: id, result } },
       '*',
     );
-  } catch (err) {
+  } catch {
     window.parent.postMessage(
       { jhSdk: true, id: nextId(), type: 'RESOLVE_CAPABILITY_RESPONSE', payload: { requestId: id, result: null } },
       '*',

--- a/server/extensions/realtime/api/index.ts
+++ b/server/extensions/realtime/api/index.ts
@@ -3,7 +3,7 @@
 import type { ServerWebSocket } from 'bun';
 import type { Server } from 'bun';
 import { verifyWsToken } from '../mods/auth';
-import { rooms, type WsData } from '../mods/rooms/index';
+import { type WsData } from '../mods/rooms/index';
 import { subscribeToBoard } from '../mods/rooms/subscribe';
 import { unsubscribeFromBoard } from '../mods/rooms/unsubscribe';
 import { recordPong, initHeartbeat, startHeartbeatLoop } from '../mods/heartbeat';

--- a/server/mods/cache/adapters/nodeCache.test.ts
+++ b/server/mods/cache/adapters/nodeCache.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 import { NodeCacheAdapter, memCache } from './nodeCache';
 
 describe('NodeCacheAdapter', () => {

--- a/server/mods/cache/index.ts
+++ b/server/mods/cache/index.ts
@@ -1,8 +1,7 @@
 // server/mods/cache/index.ts
 // Resolves the active CacheProvider adapter based on feature flags.
 // Also re-exports legacy memCache for backward compatibility with earlier sprints.
-import { flags } from '../flags';
-import { NodeCacheAdapter, memCache } from './adapters/nodeCache';
+import { NodeCacheAdapter } from './adapters/nodeCache';
 import { RedisCacheAdapter } from './adapters/redis';
 import { env } from '../../config/env';
 import type { CacheProvider } from './types';

--- a/server/mods/flags/providers/featbit.ts
+++ b/server/mods/flags/providers/featbit.ts
@@ -23,13 +23,13 @@ export class FeatBitProvider implements FlagProvider {
     }
   }
 
-  async isEnabled(flagKey: string, _context?: FlagContext): Promise<boolean> {
+  async isEnabled(_flagKey: string, _context?: FlagContext): Promise<boolean> {
     if (!this.initialized) return false;
     // TODO: return this.client.boolVariation(flagKey, context?.userId ?? 'anon', false)
     return false;
   }
 
-  async getValue<T>(flagKey: string, defaultValue: T, _context?: FlagContext): Promise<T> {
+  async getValue<T>(_flagKey: string, defaultValue: T, _context?: FlagContext): Promise<T> {
     if (!this.initialized) return defaultValue;
     // TODO: return this.client.jsonVariation(flagKey, context?.userId ?? 'anon', defaultValue)
     return defaultValue;

--- a/server/mods/flags/providers/flagsmith.ts
+++ b/server/mods/flags/providers/flagsmith.ts
@@ -19,13 +19,13 @@ export class FlagsmithProvider implements FlagProvider {
     }
   }
 
-  async isEnabled(flagKey: string, _context?: FlagContext): Promise<boolean> {
+  async isEnabled(_flagKey: string, _context?: FlagContext): Promise<boolean> {
     if (!this.initialized) return false;
     // TODO: return flagsmith.hasFeature(flagKey)
     return false;
   }
 
-  async getValue<T>(flagKey: string, defaultValue: T, _context?: FlagContext): Promise<T> {
+  async getValue<T>(_flagKey: string, defaultValue: T, _context?: FlagContext): Promise<T> {
     if (!this.initialized) return defaultValue;
     // TODO: return flagsmith.getValue(flagKey) ?? defaultValue
     return defaultValue;

--- a/server/mods/pubsub/index.ts
+++ b/server/mods/pubsub/index.ts
@@ -1,6 +1,5 @@
 // server/mods/pubsub/index.ts
 // Resolves the active PubSubProvider adapter from feature flags.
-import { flags } from '../flags';
 import { InMemoryPubSubAdapter } from './adapters/inMemory';
 import { RedisPubSubAdapter } from './adapters/redis';
 import { env } from '../../config/env';

--- a/src/common/components/MentionInput/MentionInput.tsx
+++ b/src/common/components/MentionInput/MentionInput.tsx
@@ -24,7 +24,6 @@ const MentionInput = ({
   onChange,
   placeholder,
   className,
-  rows = 3,
   disabled = false,
   'aria-label': ariaLabel,
   onKeyDown: externalKeyDown,
@@ -41,7 +40,7 @@ const MentionInput = ({
     dismissSuggestions,
   } = useMentionInput({ boardId, value, onChange });
 
-  const [localHighlight, setLocalHighlight] = useState(0);
+  const [, setLocalHighlight] = useState(0);
 
   // Auto-resize: expand the textarea to show all content without internal scrolling
   useEffect(() => {

--- a/src/extensions/Attachments/components/InlineUploadPreview.tsx
+++ b/src/extensions/Attachments/components/InlineUploadPreview.tsx
@@ -6,7 +6,6 @@ import { useEffect, useState } from 'react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import type { UploadEntry } from '../types';
 import { getMimeIcon } from '../utils/mimeIcon';
-import { formatBytes } from '../utils/formatBytes';
 import { UploadProgressBar } from './UploadProgressBar';
 import translations from '../translations/en.json';
 

--- a/src/extensions/Automation/components/AutomationPanel/RuleBuilder/RuleBuilderFooter.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/RuleBuilder/RuleBuilderFooter.tsx
@@ -1,5 +1,4 @@
 // RuleBuilderFooter — Save / Cancel bar at the bottom of the RuleBuilder.
-import { useState } from 'react';
 import Button from '../../../../../common/components/Button';
 import translations from '../../../translations/en.json';
 

--- a/src/extensions/Automation/components/AutomationPanel/index.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/index.tsx
@@ -28,13 +28,6 @@ const TABS: { id: AutomationTab; label: string }[] = [
   { id: 'log', label: translations['automation.panel.tab.log'] },
 ];
 
-const ComingSoon = ({ tab }: { tab: string }) => (
-  <div className="flex flex-col items-center justify-center gap-3 py-16 px-6 text-center">
-    <p className="text-subtle font-medium capitalize">{tab}</p>
-    <p className="text-sm text-muted">Coming soon</p>
-  </div>
-);
-
 const AutomationPanel = ({ boardId, isOpen, activeTab, onClose, onTabChange }: Props) => {
   const [automations, setAutomations] = useState<Automation[]>([]);
   const [loading, setLoading] = useState(false);

--- a/src/extensions/Automation/components/BoardButtons/BoardButtonBuilder.tsx
+++ b/src/extensions/Automation/components/BoardButtons/BoardButtonBuilder.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { XMarkIcon, BoltIcon } from '@heroicons/react/24/outline';
 import type { FC } from 'react';
 import Button from '../../../../common/components/Button';
-import IconPicker, { BUTTON_ICONS, type ButtonIconName } from '../shared/IconPicker';
+import IconPicker, { type ButtonIconName } from '../shared/IconPicker';
 import ActionList from '../AutomationPanel/RuleBuilder/ActionList';
 import type { ActionItemData } from '../AutomationPanel/RuleBuilder/ActionItem';
 import { createAutomation, updateAutomation } from '../../api';

--- a/src/extensions/Automation/components/CardButtons/CardButtonBuilder.tsx
+++ b/src/extensions/Automation/components/CardButtons/CardButtonBuilder.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { XMarkIcon, BoltIcon } from '@heroicons/react/24/outline';
 import type { FC } from 'react';
 import Button from '../../../../common/components/Button';
-import IconPicker, { BUTTON_ICONS, type ButtonIconName } from '../shared/IconPicker';
+import IconPicker, { type ButtonIconName } from '../shared/IconPicker';
 import ActionList from '../AutomationPanel/RuleBuilder/ActionList';
 import type { ActionItemData } from '../AutomationPanel/RuleBuilder/ActionItem';
 import { createAutomation, updateAutomation } from '../../api';

--- a/src/extensions/Automation/components/LogPanel/RunLogTable.tsx
+++ b/src/extensions/Automation/components/LogPanel/RunLogTable.tsx
@@ -1,6 +1,5 @@
 // RunLogTable — paginated table of automation run logs.
 // Columns: Status | Automation (name + type chip) | Card | Triggered by | When | Details
-import { useState } from 'react';
 import type { FC } from 'react';
 import type { AutomationRunLog, PaginatedRunLogs } from '../../types';
 import RunLogRow from './RunLogRow';

--- a/src/extensions/Board/components/BoardSearchBar.tsx
+++ b/src/extensions/Board/components/BoardSearchBar.tsx
@@ -45,7 +45,7 @@ const HighlightedTitle = ({ title, query }: { title: string; query: string }) =>
   );
 };
 
-const BoardSearchBar = ({ boardId, token, initialQuery = '', onQueryChange, onSelectResult, hasBackground = false }: Props) => {
+const BoardSearchBar = ({ boardId, token, initialQuery = '', onQueryChange, onSelectResult }: Props) => {
   const [inputValue, setInputValue] = useState(initialQuery);
   const [results, setResults] = useState<BoardSearchResult[]>([]);
   const [loading, setLoading] = useState(false);

--- a/src/extensions/Card/components/CardDescription.tsx
+++ b/src/extensions/Card/components/CardDescription.tsx
@@ -2,7 +2,7 @@
 // View mode: renders markdown; click anywhere to enter edit mode.
 // Edit mode: plain textarea (with @mention support). Save with Ctrl/Cmd+Enter or
 // the Save button. Cancel with Escape or the Cancel button.
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { marked } from 'marked';
 import MentionInput from '~/common/components/MentionInput/MentionInput';
 import Button from '../../../common/components/Button';

--- a/src/extensions/Card/components/CardReferenceChip.tsx
+++ b/src/extensions/Card/components/CardReferenceChip.tsx
@@ -6,16 +6,10 @@ import type { ReactNodeViewProps } from '@tiptap/react';
 import { useEffect, useState } from 'react';
 import apiClient from '~/common/api/client';
 import { parseCardIdFromUrl } from '../extensions/CardReferenceExtension';
-import type { Card } from '../api';
 
 interface CardPreview {
   title: string;
   listName: string;
-}
-
-interface CardApiResponse {
-  data: Card;
-  includes: { list: { id: string; title: string } };
 }
 
 const CardReferenceChip = ({ node, selected, updateAttributes }: ReactNodeViewProps) => {

--- a/src/extensions/Card/components/LabelPicker.tsx
+++ b/src/extensions/Card/components/LabelPicker.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
 import Button from '../../../common/components/Button';
 import type { Label } from '../api';
-import { LabelChip } from './LabelChip';
 
 interface Props {
   allLabels: Label[];

--- a/src/extensions/Comment/components/CommentItem.tsx
+++ b/src/extensions/Comment/components/CommentItem.tsx
@@ -357,7 +357,7 @@ function renderContent(text: string, attachments: Attachment[]): string {
   return addLinkTargetBlank(normalizeRenderedLinkHtml(withMentions));
 }
 
-const CommentItem = ({ comment, boardId, attachments = [], currentUserId, isAdmin = false, isNotificationTarget = false, autoExpandReplies = false, onEdit, onDelete, onAddReaction, onRemoveReaction, onReply, onAddReply, onEditReply, onDeleteReply, cardId }: Props) => {
+const CommentItem = ({ comment, boardId, attachments = [], currentUserId, isAdmin = false, isNotificationTarget = false, autoExpandReplies = false, onEdit, onDelete, onAddReaction, onRemoveReaction, onAddReply, onEditReply, onDeleteReply, cardId }: Props) => {
   const [editing, setEditing] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [replyExpanded, setReplyExpanded] = useState(autoExpandReplies);

--- a/src/extensions/HealthCheck/containers/HealthCheckTab/HealthCheckTab.tsx
+++ b/src/extensions/HealthCheck/containers/HealthCheckTab/HealthCheckTab.tsx
@@ -55,7 +55,7 @@ export function HealthCheckTab({ boardId }: Props) {
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   // Per-row probe state (on-demand single probe).
-  const { isProbing, probe } = useHealthCheckProbe({ boardId });
+  const { isProbing } = useHealthCheckProbe({ boardId });
 
   // Fetch the list on mount (and when boardId changes).
   useEffect(() => {

--- a/src/extensions/Plugins/containers/PluginRegistryPage/PluginRegistryPage.tsx
+++ b/src/extensions/Plugins/containers/PluginRegistryPage/PluginRegistryPage.tsx
@@ -34,7 +34,6 @@ import ApiKeyRevealModal from '../../modals/ApiKeyRevealModal';
 import { updatePlugin } from '../../api';
 import type { Plugin, UpdatePluginBody, RegisterPluginBody } from '../../api';
 import translations from '../../translations/en.json';
-import { PuzzlePieceIcon } from '@heroicons/react/24/solid';
 
 const PluginRegistryPage = () => {
   const dispatch = useAppDispatch();

--- a/src/extensions/Plugins/hooks/useBoardPlugins.ts
+++ b/src/extensions/Plugins/hooks/useBoardPlugins.ts
@@ -4,7 +4,6 @@ import { useAppSelector } from '~/hooks/useAppSelector';
 import { useAppDispatch } from '~/hooks/useAppDispatch';
 import {
   fetchBoardPluginsThunk,
-  fetchAvailablePluginsThunk,
   fetchDiscoverablePluginsThunk,
   enablePluginThunk,
   disablePluginThunk,

--- a/src/extensions/Realtime/__tests__/wsMiddleware.test.ts
+++ b/src/extensions/Realtime/__tests__/wsMiddleware.test.ts
@@ -6,15 +6,6 @@ import { socket } from '../client/socket';
 
 // ---------- Helpers ----------
 
-function makeStore(state: unknown = {}) {
-  const dispatched: unknown[] = [];
-  return {
-    getState: () => state,
-    dispatch: (a: unknown) => dispatched.push(a),
-    dispatched,
-  };
-}
-
 function makeNext() {
   const calls: unknown[] = [];
   const fn = (a: unknown) => { calls.push(a); return a; };

--- a/src/extensions/Search/components/SearchInput.tsx
+++ b/src/extensions/Search/components/SearchInput.tsx
@@ -1,6 +1,6 @@
 // src/extensions/Search/components/SearchInput.tsx
 // Debounced search input — fires onChange 300 ms after the user stops typing.
-import React, { useRef } from 'react';
+import React from 'react';
 
 interface SearchInputProps {
   value: string;

--- a/src/extensions/StateTransitions/components/GraphEditor/TransitionEdge.tsx
+++ b/src/extensions/StateTransitions/components/GraphEditor/TransitionEdge.tsx
@@ -54,12 +54,6 @@ const quadraticBezierPoint = ({
   };
 };
 
-const toPoints = (waypoints: StateTransitionWaypoint[]): Point[] =>
-  waypoints.map((waypoint) => ({ x: waypoint.x, y: waypoint.y }));
-
-const toWaypoints = (points: Point[]): StateTransitionWaypoint[] =>
-  points.map((point) => ({ x: point.x, y: point.y }));
-
 const buildOrthogonalPoints = ({
   p0,
   p2,

--- a/src/extensions/Webhooks/containers/WebhooksRegisterPage/RegisterWebhookModal.tsx
+++ b/src/extensions/Webhooks/containers/WebhooksRegisterPage/RegisterWebhookModal.tsx
@@ -54,9 +54,6 @@ export default function RegisterWebhookModal({ workspaceId, onClose, onCreated }
   const { data: serverEventTypes } = useListEventTypesQuery();
   const [createWebhook, { isLoading }] = useCreateWebhookMutation();
 
-  // [why] Only show UI-canonical groups; filter out any server aliases not in our group list.
-  const allGroupedEvents = EVENT_GROUPS.flatMap((g) => g.events);
-
   function toggleEvent(event: string) {
     setSelectedEvents((prev) => {
       const next = new Set(prev);

--- a/tests/e2e/mcp-http-init.spec.ts
+++ b/tests/e2e/mcp-http-init.spec.ts
@@ -1,6 +1,6 @@
 // Playwright MCP HTTP Init test for Sprint 106
 // Covers: unauthenticated POST, valid POST, DELETE, session hijack, proxying
-import { test, expect, request } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:3000';
 

--- a/tests/integration/attachments/orphanCleanup.test.ts
+++ b/tests/integration/attachments/orphanCleanup.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect, afterAll } from 'bun:test';
 import {
   cleanupOrphanAttachments,
   startOrphanCleanupWorker,
-  orphanCleanupInterval,
   CLEANUP_INTERVAL_MS,
 } from '../../../server/extensions/attachment/workers/orphanCleanup';
 

--- a/tests/integration/boardLifecycle.test.ts
+++ b/tests/integration/boardLifecycle.test.ts
@@ -1,7 +1,7 @@
 // Integration tests for board lifecycle — Sprint 05.
 // Tests use the requireBoardWritable middleware and duplicateBoard mod directly (unit-level),
 // plus a lightweight integration harness calling handler functions with mock DB state.
-import { describe, expect, test, beforeEach, mock } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 
 // ---------- Unit: requireBoardWritable ----------
 

--- a/tests/unit/webhooks/WebhookCreatedModal.test.tsx
+++ b/tests/unit/webhooks/WebhookCreatedModal.test.tsx
@@ -1,6 +1,6 @@
 // Unit tests for WebhookCreatedModal — secret reveal, copy/reset behaviour.
 // Pure logic tests; clipboard API interaction is tested via mock.
-import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, mock } from 'bun:test';
 
 // Simulates the copy-to-clipboard state machine used by WebhookCreatedModal.
 function createCopyState() {


### PR DESCRIPTION
## Summary

Fixes 38 `@typescript-eslint/no-unused-vars` findings across 32 files (server + UI + tests) by:
- **Removing unused imports** (safe deletion)
- **Renaming unused callback args to `_`-prefixed** (positional-safe, `argsIgnorePattern: '^_'`)
- **Removing side-effect-free unused assigned vars** (React hook calls kept intact to preserve hook-ordering)

## Scope / rule

- Rule: `@typescript-eslint/no-unused-vars`
- 32 files (server mods/plugins/automation + UI components + test files)
- `public/sdk/jh-instance.js` untouched (out-of-scope artifact)

## Verification

- **Base-vs-main any-rule gate: -38 no-unused-vars, ZERO newly-introduced findings of any rule** (verified against trusted current-main capture)
- `bunx tsc --noEmit`: **146 errors — identical to current main baseline**
- `bun test`: **300 fail identities identical to current main** (no new failures)
- Focused tests on 6 changed test files: **46 pass / 0 fail**
- `bun run build:client`: **passed**; `git diff --check`: **clean**

## UI/E2E coverage

Touched UI components (MentionInput, InlineUploadPreview, RuleBuilder/Footer, BoardButtonBuilder, CardButtonBuilder, RunLogTable, CardDescription, CardReferenceChip, LabelPicker, PluginRegistryPage, PluginDashboardPage, HealthCheckTab, SearchInput, TransitionEdge, RegisterWebhookModal) have no dedicated executable UI/E2E coverage — recorded as **missing**, not claimed as passed. Import/arg changes exercised via typecheck + build + focused test files.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files. No unrelated files. `public/sdk/jh-instance.js` out-of-scope.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.