### PR TITLE
lint: replace explicit any with typed shapes (no-explicit-any batch 1)

### DIFF
--- a/server/extensions/activity/mods/__tests__/createActivityEvent.test.ts
+++ b/server/extensions/activity/mods/__tests__/createActivityEvent.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, mock, beforeEach } from 'bun:test';
+import type { WriteActivityInput } from '../write';
 
-const writeActivityMock = mock(async (input: any) => ({
+const writeActivityMock = mock(async (input: WriteActivityInput) => ({
   id: 'activity-1',
   action: input.action,
   actor_id: input.actorId,

--- a/server/extensions/attachment/common/config/s3.ts
+++ b/server/extensions/attachment/common/config/s3.ts
@@ -1,7 +1,7 @@
 // S3-compatible storage client configuration.
 // All values sourced from env via the central config module.
 import { env } from '../../../../config/env';
-import { S3Client, CreateBucketCommand, HeadBucketCommand } from '@aws-sdk/client-s3';
+import { S3Client, CreateBucketCommand, HeadBucketCommand, type BucketLocationConstraint } from '@aws-sdk/client-s3';
 
 export const s3Config = {
   bucket: env.S3_BUCKET,
@@ -78,7 +78,7 @@ export async function ensureBucketExists(): Promise<void> {
           Bucket: s3Config.bucket,
           // CreateBucketConfiguration is required for regions other than us-east-1
           ...(s3Config.region !== 'us-east-1' && {
-            CreateBucketConfiguration: { LocationConstraint: s3Config.region as any },
+            CreateBucketConfiguration: { LocationConstraint: s3Config.region as BucketLocationConstraint },
           }),
         })
       );

--- a/server/extensions/attachment/mods/s3/headObject.ts
+++ b/server/extensions/attachment/mods/s3/headObject.ts
@@ -7,8 +7,9 @@ export async function headObject({ s3Key }: { s3Key: string }): Promise<boolean>
   try {
     await s3ServerClient.send(new HeadObjectCommand({ Bucket: s3Config.bucket, Key: s3Key }));
     return true;
-  } catch (err: any) {
-    if (err?.name === 'NotFound' || err?.$metadata?.httpStatusCode === 404) {
+  } catch (err: unknown) {
+    const e = err as { name?: string; $metadata?: { httpStatusCode?: number } };
+    if (e.name === 'NotFound' || e.$metadata?.httpStatusCode === 404) {
       return false;
     }
     throw err;

--- a/server/extensions/plugins/api/board-plugins/available.ts
+++ b/server/extensions/plugins/api/board-plugins/available.ts
@@ -47,7 +47,7 @@ export async function handleListAvailableBoardPlugins(
   }
 
   const countResult = await query.clone().count('plugins.id as count').first();
-  const total = parseInt(String((countResult as any)?.count ?? '0'), 10);
+  const total = parseInt(String((countResult as { count?: number | string } | undefined)?.count ?? '0'), 10);
 
   const rows = await query
     .orderBy('plugins.created_at', 'asc')
@@ -73,7 +73,7 @@ export async function handleListAvailableBoardPlugins(
     );
 
   return Response.json({
-    data: rows.map((p: any) => normalizePlugin(p)),
+    data: rows.map((p: Record<string, unknown>) => normalizePlugin(p)),
     metadata: { total },
   });
 }

--- a/server/extensions/plugins/api/registry/list.ts
+++ b/server/extensions/plugins/api/registry/list.ts
@@ -60,7 +60,7 @@ export async function handleListPlugins(req: Request): Promise<Response> {
   }
 
   const countResult = await query.clone().count('id as count').first();
-  const total = parseInt(String((countResult as any)?.count ?? '0'), 10);
+  const total = parseInt(String((countResult as { count?: number | string } | undefined)?.count ?? '0'), 10);
   const totalPage = Math.ceil(total / perPage);
 
   const plugins = await query
@@ -88,7 +88,7 @@ export async function handleListPlugins(req: Request): Promise<Response> {
       // api_key is never returned in list responses
     );
 
-  const normalised = plugins.map((p: any) => normalizePlugin(p));
+  const normalised = plugins.map((p: Record<string, unknown>) => normalizePlugin(p));
 
   return Response.json({
     data: normalised,


### PR DESCRIPTION
## Summary

Replaces 7 `@typescript-eslint/no-explicit-any` findings across 5 server files with concrete typed shapes, behaviour-preserving:
- **headObject.ts**: `catch (err: any)` → `catch (err: unknown)` + typed narrow (`err as { name?: string; $metadata?: {...} }`), preserving the NotFound/404 behaviour
- **registry/list.ts + board-plugins/available.ts**: knex `countResult as any` → `as { count?: number | string }`; `.map((p: any) => normalizePlugin(p))` → `(p: Record<string, unknown>)`
- **s3.ts / createActivityEvent.test.ts**: typed the mock input and region cast

This also removed several downstream `no-unsafe-assignment`/`no-unsafe-member-access`/`no-unsafe-argument` findings (the `any` was propagating unsafety).

## Scope / rule

- Rule: `@typescript-eslint/no-explicit-any` (explicit `any`)
- 5 files, 11 insertions / 9 deletions (server attachments, plugins registry/available, activity test)
- Excluded: `server/extensions/payment/` (out-of-scope), `db/seeds/trello-import.ts` (risk-prone seed)

## Verification

- **Base-vs-main any-rule gate: deltas include -7 no-explicit-any and several no-unsafe-*, ZERO newly-introduced findings of any rule** (4 transient findings introduced by the impl subagent — headObject no-unnecessary-condition, list/available no-base-to-string — were fixed by me to `{ count?: number|string }` and non-optional narrow)
- `bunx tsc --noEmit`: **146 — identical to current main baseline**
- `bun test`: **300 fail identities identical to current main** (no new failures)
- `bun run build:client`: **passed**; `git diff --check`: **clean**

## Honest scope note

The remaining 23 `no-explicit-any` findings (test-file casts like `(translations as any)[key]`, axios-unwrap `.then((res: any))`, deliberate `null as any` unions) are high-cascade-risk: replacing them correctly requires concrete response types that would, in most cases, expose new `no-unsafe-*` findings. Per "preserve behaviour first" over batch size, they are **deferred** rather than forced — this batch is 7 fixes, smaller than the 40-60 steer, because inflating it would risk behaviour or introduce worse lint.

## UI/E2E coverage

Server-only changes (attachments s3, plugins registry) — no UI/E2E. Exercised via typecheck + build + full suite.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files. No unrelated files. trello-import seed excluded.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.