### PR TITLE
lint: replace explicit any with typed shapes (no-explicit-any batch 2)

### DIFF
--- a/src/extensions/Attachment/components/AttachmentUrlModal.tsx
+++ b/src/extensions/Attachment/components/AttachmentUrlModal.tsx
@@ -26,8 +26,9 @@ export function AttachmentUrlModal({ onAdd, onClose }: Props): React.ReactElemen
     try {
       await onAdd(name.trim(), url.trim());
       onClose();
-    } catch (err: any) {
-      setError(err?.message ?? translations['attachment.urlModal.error.failed']);
+    } catch (err: unknown) {
+      const e = err as { message?: string };
+      setError(e.message ?? translations['attachment.urlModal.error.failed']);
     } finally {
       setSubmitting(false);
     }

--- a/src/extensions/Automation/components/BoardButtons/BoardButtonBuilder.tsx
+++ b/src/extensions/Automation/components/BoardButtons/BoardButtonBuilder.tsx
@@ -95,7 +95,7 @@ const BoardButtonBuilder: FC<Props> = ({ boardId, existing, onSave, onClose }) =
             name: name.trim(),
             automationType: 'BOARD_BUTTON',
             icon,
-            trigger: null as any, // BOARD_BUTTON has no trigger
+            trigger: null, // BOARD_BUTTON has no trigger
             actions: actionPayload,
           },
         });

--- a/src/extensions/Automation/components/CardButtons/CardButtonBuilder.tsx
+++ b/src/extensions/Automation/components/CardButtons/CardButtonBuilder.tsx
@@ -68,7 +68,7 @@ const CardButtonBuilder: FC<Props> = ({ boardId, existing, onSave, onClose }) =>
             name: name.trim(),
             automationType: 'CARD_BUTTON',
             icon,
-            trigger: null as any, // CARD_BUTTON has no trigger
+            trigger: null, // CARD_BUTTON has no trigger
             actions: actionPayload,
           },
         });

--- a/tests/unit/webhooks/WebhookCreatedModal.test.tsx
+++ b/tests/unit/webhooks/WebhookCreatedModal.test.tsx
@@ -104,7 +104,7 @@ describe('WebhookCreatedModal — signing secret display', () => {
 
     // A plain WebhookItem should NOT have signingSecret (type-level check via cast)
     const listItem: WebhookItem = { ...response.data };
-    expect((listItem as any).signingSecret).toBe('secret-value'); // exists on object but not on type
+    expect((listItem as WebhookItem & { signingSecret: string }).signingSecret).toBe('secret-value'); // exists on object but not on type
   });
 });
 
@@ -122,8 +122,9 @@ describe('WebhookCreatedModal — translation keys', () => {
       'WebhookCreatedModal.done',
     ];
     for (const key of required) {
-      expect((translations as any)[key]).toBeDefined();
-      expect(typeof (translations as any)[key]).toBe('string');
+      const v = (translations as Record<string, unknown>)[key];
+      expect(v).toBeDefined();
+      expect(typeof v).toBe('string');
     }
   });
 
@@ -142,8 +143,9 @@ describe('WebhookCreatedModal — translation keys', () => {
       'RegisterWebhookModal.cancel',
     ];
     for (const key of required) {
-      expect((translations as any)[key]).toBeDefined();
-      expect(typeof (translations as any)[key]).toBe('string');
+      const v = (translations as Record<string, unknown>)[key];
+      expect(v).toBeDefined();
+      expect(typeof v).toBe('string');
     }
   });
 });


### PR DESCRIPTION
## Summary

Replaces 8 `@typescript-eslint/no-explicit-any` findings across 4 files with concrete typed shapes, behaviour-preserving:
- **CardButtonBuilder/BoardButtonBuilder**: `trigger: null as any` → `trigger: null` (payload type `AutomationTrigger | null` already accepts `null`; the `as any` was redundant)
- **WebhookCreatedModal.test.tsx**: `(translations as any)[key]` → `(translations as Record<string, unknown>)[key]` (5 casts); `(listItem as any).signingSecret` → `(listItem as WebhookItem & { signingSecret: string })`
- **AttachmentUrlModal.tsx**: `catch (err: any)` → `catch (err: unknown)` + `err as { message?: string }` narrow

Also resolves downstream `no-unsafe-assignment`/`no-unsafe-member-access`/`no-unsafe-argument` caused by the redundant `any` (the trigger values and err.message were unsafe before).

## Scope / rule

- Rule: `@typescript-eslint/no-explicit-any` (explicit `any`)
- 4 files, 2 UI components + 1 UI modal + 1 unit test
- Excluded: `server/extensions/payment/`, `db/seeds/trello-import.ts`

## Verification

- **Any-rule gate vs trusted baseline (after293): -8 no-explicit-any, -1 no-unsafe-assignment, -1 no-unsafe-member-access, -1 no-unsafe-argument, ZERO newly-introduced findings**
- `bunx tsc --noEmit`: **146 — identical to current main baseline**
- `bun test`: **300 fail identities identical to current main** (no new failures); focused WebhookCreatedModal.test: **9 pass / 0 fail**
- `bun run build:client`: **passed**; `git diff --check`: **clean**

## UI/E2E coverage

Changed 2 UI components (CardButtonBuilder, BoardButtonBuilder) + 1 UI modal (AttachmentUrlModal). No dedicated UI/E2E coverage exists for these components — recorded as missing. Exercised via typecheck + build + full suite.

## Honest scope note

Remaining no-explicit-any deferred because correctly typing them would cascade into new `no-unsafe-*` findings or require behaviour change:
- axios-unwrap `.then((res: any))` (11 in RuleBuilder) — typing `res` makes `res.data` `unknown` → no-unsafe-assignment on `setBoardLists` etc.
- skip-gated redis/broadcast test seams (`(adapter as any).sub`, `} as any`)
- e2e body shapes (`(m: any)`, `request: any` in mcp-http-init)
- `null as any` unions where props require a non-nullable discriminant

Per "preserve behaviour first" > batch size, these are deferred rather than forced.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files. No unrelated files.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.