### PR TITLE
lint: replace explicit any in e2e/integration test callbacks (no-explicit-any batch 3)

### DIFF
--- a/tests/e2e/board-members.spec.ts
+++ b/tests/e2e/board-members.spec.ts
@@ -52,7 +52,7 @@ test.describe('Board member API flows', () => {
     });
     const body = await res.json();
     expect(Array.isArray(body.data)).toBe(true);
-    expect(body.data.some((m: any) => m.userId === 'user-2')).toBe(true);
+    expect(body.data.some((m: { userId?: string }) => m.userId === 'user-2')).toBe(true);
   });
 
   test('POST /boards/:id/members adds/updates member idempotently', async ({ request }) => {
@@ -111,6 +111,6 @@ test.describe('Board member API flows', () => {
       headers: { Authorization: `Bearer ${token}` },
     });
     const body = await res.json();
-    expect(body.data.some((b: any) => b.id === boardId)).toBe(true);
+    expect(body.data.some((b: { id?: string }) => b.id === boardId)).toBe(true);
   });
 });

--- a/tests/integration/offlineCommentDraftRecovery.test.ts
+++ b/tests/integration/offlineCommentDraftRecovery.test.ts
@@ -40,7 +40,7 @@ test.describe('Offline Comment Draft Recovery', () => {
       });
     });
     expect(Array.isArray(draft)).toBeTruthy();
-    const found = draft.find((d: any) => d.draftType === 'comment' && d.contentMarkdown === 'My offline comment text');
+    const found = draft.find((d: { draftType?: string; contentMarkdown?: string }) => d.draftType === 'comment' && d.contentMarkdown === 'My offline comment text');
     expect(found).toBeTruthy();
     expect(found.intent).toBe('editing');
     expect(found.key).toMatch(/.+::.+::C1::comment/);


### PR DESCRIPTION
## Summary

Replaces 3 `@typescript-eslint/no-explicit-any` findings across 2 test files with concrete typed shapes, behaviour-preserving:
- **tests/e2e/board-members.spec.ts**: `body.data.some((m: any) => m.userId...)` → `(m: { userId?: string })`; `(b: any) => b.id...` → `(b: { id?: string })`
- **tests/integration/offlineCommentDraftRecovery.test.ts**: `draft.find((d: any) => ...)` → `(d: { draftType?: string; contentMarkdown?: string })`

Both `.some`/`.find` predicates test for presence/equality of specific fields — the typed shapes only narrow the callback param, producing identical results on the actual `unknown`/`any` runtime values.

## Scope / rule

- Rule: `@typescript-eslint/no-explicit-any` (explicit `any`)
- 2 test files (1 e2e Playwright, 1 integration)
- Excluded: `server/extensions/payment/`, `db/seeds/trello-import.ts`

## Verification

- **Any-rule gate vs trusted baseline (after294): -3 no-explicit-any, ZERO newly-introduced findings**
- `bunx tsc --noEmit`: **146 — identical to current main baseline** (offlineCommentDraftRecovery is an integration test outside the tsc program; the LSP `draft is unknown` diagnostic is pre-existing from Playwright's `page.evaluate`, not from this change)
- `bun test`: **300 fail identities identical to current main** (no new failures)
- `bun run build:client`: **passed**; `git diff --check`: **clean**
- Note: these are e2e/integration specs that require a live server + browser to execute; not run here (missing execution coverage recorded).

## Honest scope note

Remaining no-explicit-any deferred:
- **RuleBuilder axios-unwrap `.then((res: any))` (9)** — the apiClient interceptor (src/common/api/client.ts:43) already unwraps `response.data`, so typing `res` to any concrete body type would make `res.data` `unknown` → cascade `no-unsafe-assignment` on `setBoardLists`/`setCustomFields` etc. Genuinely requires a response-type refactor, not a safe mechanical fix.
- skip-gated redis/broadcast test seams (`(adapter as any).sub`, `} as any`)

Per "preserve behaviour first" > batch size, these are deferred rather than forced.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files. No unrelated files.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.