### PR TITLE
lint: type apiRequestContext param in mcp-http-init helper (no-explicit-any)

### DIFF
--- a/tests/e2e/mcp-http-init.spec.ts
+++ b/tests/e2e/mcp-http-init.spec.ts
@@ -1,11 +1,11 @@
 // Playwright MCP HTTP Init test for Sprint 106
 // Covers: unauthenticated POST, valid POST, DELETE, session hijack, proxying
-import { test, expect } from '@playwright/test';
+import { test, expect, type APIRequestContext } from '@playwright/test';
 
 const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:3000';
 
 // Helper: login and get JWT
-async function loginAndGetJwt(request: any, email: string, password: string) {
+async function loginAndGetJwt(request: APIRequestContext, email: string, password: string) {
   const loginRes = await request.post(`${BASE_URL}/api/v1/auth/login`, {
     data: { email, password },
   });


### PR DESCRIPTION
## Summary

Replaces 1 `@typescript-eslint/no-explicit-any` in tests/e2e/mcp-http-init.spec.ts:
- `loginAndGetJwt(request: any, email, password)` → `request: APIRequestContext` (imported as a type from `@playwright/test`). The two callers pass the Playwright fixture `request`, which is already `APIRequestContext`, so this is exact and behaviour-preserving — the helper only uses `request.post`/`.json()`.

## Scope / rule

- Rule: `@typescript-eslint/no-explicit-any`
- 1 file, 1 fix
- Excluded: payment/, trello-import.ts

## Verification

- **Any-rule gate vs trusted baseline (after295): -1 no-explicit-any, ZERO newly-introduced findings**
- `bunx tsc --noEmit`: **146 — identical** (mcp-http-init is an e2e spec outside tsconfig `include: src/**`, `server/**`, but the change type is exact so no effect)
- `bun test`: **300 fail identities identical** (no new failures)
- `bun run build:client`: **passed**; `git diff --check`: **clean**
- Note: this is an e2e spec needing a live server+browser to execute; not run here (missing execution coverage recorded; change is type-only).

## Remaining no-explicit-any (18) all deferred as high-risk

- **RuleBuilder axios-unwrap `.then((res: any))` (9)** — apiClient interceptor (src/common/api/client.ts:43) already unwraps `response.data`, so typing `res` would make `res.data` `unknown` → cascade `no-unsafe-assignment` on setState. Needs a response-type refactor.
- skip-gated redis/broadcast test seams (`(adapter as any).sub`, `} as any`)
- RuleBuilder TriggerConfig/ActionList/ActionItem partial-unwrap cases

All deferred per "preserve behaviour first" > batch size.

## Exclusions

No payments/monetisation/Stripe/billing/subscription files. No unrelated files.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.