### PR TITLE
lint: void-wrap promise-returning event handlers (no-misused-promises batch 1)

### DIFF
--- a/server/extensions/attachment/mods/orphanCleanup.ts
+++ b/server/extensions/attachment/mods/orphanCleanup.ts
@@ -30,4 +30,4 @@ export async function cleanupOrphanAttachments(): Promise<void> {
 
 // Schedule cleanup to run every 15 minutes when this module is imported.
 // The interval reference is kept in module scope so it can be cleared in tests.
-export const orphanCleanupInterval = setInterval(cleanupOrphanAttachments, 15 * 60 * 1000);
+export const orphanCleanupInterval = setInterval(() => { void cleanupOrphanAttachments(); }, 15 * 60 * 1000);

--- a/server/extensions/attachment/workers/orphanCleanup.ts
+++ b/server/extensions/attachment/workers/orphanCleanup.ts
@@ -34,5 +34,5 @@ export async function cleanupOrphanAttachments(): Promise<void> {
 export let orphanCleanupInterval: ReturnType<typeof setInterval> | null = null;
 
 export function startOrphanCleanupWorker(): void {
-  orphanCleanupInterval = setInterval(cleanupOrphanAttachments, CLEANUP_INTERVAL_MS);
+  orphanCleanupInterval = setInterval(() => { void cleanupOrphanAttachments(); }, CLEANUP_INTERVAL_MS);
 }

--- a/src/common/components/MentionInput/useMentionInput.ts
+++ b/src/common/components/MentionInput/useMentionInput.ts
@@ -52,22 +52,24 @@ export function useMentionInput({
   const fetchSuggestions = useCallback(
     (query: string) => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(async () => {
-        try {
-          // apiClient auto-attaches the Bearer token and unwraps response.data
-          const result = (await apiClient.get(
-            `/boards/${boardId}/members/suggestions?q=${encodeURIComponent(query)}`,
-          )) as { data: MentionSuggestion[] };
-          if (result.data.length === 0) {
+      debounceRef.current = setTimeout(() => {
+        void (async () => {
+          try {
+            // apiClient auto-attaches the Bearer token and unwraps response.data
+            const result = (await apiClient.get(
+              `/boards/${boardId}/members/suggestions?q=${encodeURIComponent(query)}`,
+            )) as { data: MentionSuggestion[] };
+            if (result.data.length === 0) {
+              dismissSuggestions();
+            } else {
+              setSuggestions(result.data);
+              setShowSuggestions(true);
+              setHighlightedIndex(0);
+            }
+          } catch {
             dismissSuggestions();
-          } else {
-            setSuggestions(result.data);
-            setShowSuggestions(true);
-            setHighlightedIndex(0);
           }
-        } catch {
-          dismissSuggestions();
-        }
+        })();
       }, DEBOUNCE_MS);
     },
     [boardId, dismissSuggestions],

--- a/src/extensions/AdminInvite/CredentialSheet.tsx
+++ b/src/extensions/AdminInvite/CredentialSheet.tsx
@@ -84,7 +84,7 @@ export default function CredentialSheet({
       <div className="flex gap-3">
         <button
           type="button"
-          onClick={handleCopy}
+          onClick={() => { void handleCopy(); }}
           className="flex items-center gap-1.5 rounded-lg border border-border px-4 py-2 text-sm text-base hover:bg-bg-overlay transition-colors"
           aria-label={translations['AdminInvite.copyAriaLabel']}
         >

--- a/src/extensions/AdminInvite/InviteExternalUserModal.tsx
+++ b/src/extensions/AdminInvite/InviteExternalUserModal.tsx
@@ -196,7 +196,7 @@ export default function InviteExternalUserModal() {
                 {translations['AdminInvite.modalDescription']}
               </p>
 
-              <form onSubmit={handleSubmit} noValidate>
+              <form onSubmit={(e) => { void handleSubmit(e); }} noValidate>
                 {/* Email */}
                 <div className="mb-4">
                   <label

--- a/src/extensions/ApiToken/containers/ApiTokenPage/TokenCreatedModal.tsx
+++ b/src/extensions/ApiToken/containers/ApiTokenPage/TokenCreatedModal.tsx
@@ -39,7 +39,7 @@ export default function TokenCreatedModal({ rawToken, onDone }: Props) {
           <Button
             variant="primary"
             size="md"
-            onClick={handleCopy}
+            onClick={() => { void handleCopy(); }}
             className="min-w-[80px]"
           >
             {copied

--- a/src/extensions/Attachment/components/AttachmentUrlModal.tsx
+++ b/src/extensions/Attachment/components/AttachmentUrlModal.tsx
@@ -37,7 +37,7 @@ export function AttachmentUrlModal({ onAdd, onClose }: Props): React.ReactElemen
   return (
     <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}>
       <form
-        onSubmit={handleSubmit}
+        onSubmit={(e) => { void handleSubmit(e); }}
         style={{ background: '#fff', borderRadius: 8, padding: 24, minWidth: 320, display: 'flex', flexDirection: 'column', gap: 12 }}
       >
         <h3 style={{ margin: 0, fontSize: 16 }}>{translations['attachment.urlModal.title']}</h3>

--- a/src/extensions/Auth/components/ChangeEmailForm.tsx
+++ b/src/extensions/Auth/components/ChangeEmailForm.tsx
@@ -75,7 +75,7 @@ export default function ChangeEmailForm({ currentEmail, onSuccess, onPending }: 
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={(e) => { void handleSubmit(e); }} className="space-y-4">
       <h2 className="text-lg font-semibold text-base">{translations.changeEmail.title}</h2>
 
       <Input

--- a/src/extensions/Auth/components/LoginForm.tsx
+++ b/src/extensions/Auth/components/LoginForm.tsx
@@ -51,7 +51,7 @@ export default function LoginForm({ onSubmit, isLoading, apiError }: LoginFormPr
   const mappedApiError = apiError ? (API_ERROR_MAP[apiError] ?? translations.errors.loginFailed) : null;
 
   return (
-    <form onSubmit={handleSubmit} noValidate aria-label="Sign in form">
+    <form onSubmit={(e) => { void handleSubmit(e); }} noValidate aria-label="Sign in form">
       <div className="flex flex-col gap-4">
         {/* Email */}
         <div className="flex flex-col gap-1">

--- a/src/extensions/Auth/components/SignupForm.tsx
+++ b/src/extensions/Auth/components/SignupForm.tsx
@@ -71,7 +71,7 @@ export default function SignupForm({ onSubmit, isLoading, apiError }: SignupForm
     : null;
 
   return (
-    <form onSubmit={handleSubmit} noValidate aria-label="Sign up form">
+    <form onSubmit={(e) => { void handleSubmit(e); }} noValidate aria-label="Sign up form">
       <div className="flex flex-col gap-4">
         {/* Name */}
         <div className="flex flex-col gap-1">

--- a/src/extensions/Auth/containers/ForgotPasswordPage/ForgotPasswordPage.tsx
+++ b/src/extensions/Auth/containers/ForgotPasswordPage/ForgotPasswordPage.tsx
@@ -59,7 +59,7 @@ export default function ForgotPasswordPage() {
             </Link>
           </div>
         ) : (
-          <form onSubmit={handleSubmit} noValidate>
+          <form onSubmit={(e) => { void handleSubmit(e); }} noValidate>
             <div className="flex flex-col gap-4">
               <div className="flex flex-col gap-1">
                 <label htmlFor="forgot-email" className="text-sm font-medium text-subtle">

--- a/src/extensions/Auth/containers/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/src/extensions/Auth/containers/ResetPasswordPage/ResetPasswordPage.tsx
@@ -98,7 +98,7 @@ export default function ResetPasswordPage() {
         )}
 
         {status !== 'success' && (
-          <form onSubmit={handleSubmit} noValidate>
+          <form onSubmit={(e) => { void handleSubmit(e); }} noValidate>
             <div className="flex flex-col gap-4">
               <div className="flex flex-col gap-1">
                 <label htmlFor="reset-password" className="text-sm font-medium text-subtle">

--- a/src/extensions/Automation/components/AutomationPanel/RuleBuilder/index.tsx
+++ b/src/extensions/Automation/components/AutomationPanel/RuleBuilder/index.tsx
@@ -193,7 +193,7 @@ const RuleBuilder = ({ boardId, initialAutomation, onSaved, onCancel }: Props) =
         onRuleNameChange={setRuleName}
         canSave={canSave}
         saving={saving}
-        onSave={handleSave}
+        onSave={() => { void handleSave(); }}
         onCancel={onCancel}
       />
     </div>

--- a/src/extensions/Automation/components/BoardButtons/BoardButtonBuilder.tsx
+++ b/src/extensions/Automation/components/BoardButtons/BoardButtonBuilder.tsx
@@ -223,7 +223,7 @@ const BoardButtonBuilder: FC<Props> = ({ boardId, existing, onSave, onClose }) =
             variant="primary"
             type="button"
             disabled={!isValid || saving}
-            onClick={handleSave}
+            onClick={() => { void handleSave(); }}
           >
             {saving ? translations['automation.boardButtonBuilder.saving'] : existing ? translations['automation.boardButtonBuilder.saveChanges'] : translations['automation.boardButtonBuilder.create']}
           </Button>

--- a/src/extensions/Automation/components/BoardButtons/BoardButtonsBar.tsx
+++ b/src/extensions/Automation/components/BoardButtons/BoardButtonsBar.tsx
@@ -61,7 +61,7 @@ const BoardButtonsBar: FC<Props> = ({ boardId, hasBackground = false }) => {
           key={btn.id}
           automation={btn}
           runState={runStates[btn.id] ?? 'idle'}
-          onRun={() => handleRun(btn)}
+          onRun={() => { void handleRun(btn); }}
           hasBackground={hasBackground}
         />
       ))}

--- a/src/extensions/Automation/components/CardButtons/CardButtonBuilder.tsx
+++ b/src/extensions/Automation/components/CardButtons/CardButtonBuilder.tsx
@@ -153,7 +153,7 @@ const CardButtonBuilder: FC<Props> = ({ boardId, existing, onSave, onClose }) =>
             variant="primary"
             type="button"
             disabled={!isValid || saving}
-            onClick={handleSave}
+            onClick={() => { void handleSave(); }}
           >
             {saving ? translations['automation.cardButtonBuilder.saving'] : existing ? translations['automation.cardButtonBuilder.saveChanges'] : translations['automation.cardButtonBuilder.create']}
           </Button>

--- a/src/extensions/Automation/components/CardButtons/CardButtonsSection.tsx
+++ b/src/extensions/Automation/components/CardButtons/CardButtonsSection.tsx
@@ -108,7 +108,7 @@ const CardButtonsSection: FC<Props> = ({ boardId, cardId, disabled = false }) =>
             <CardButtonItem
               automation={btn}
               runState={runStates[btn.id] ?? 'idle'}
-              onRun={() => handleRun(btn)}
+              onRun={() => { void handleRun(btn); }}
               disabled={disabled}
             />
           </li>

--- a/src/extensions/Automation/components/SchedulePanel/builders/DueDateCommandBuilder.tsx
+++ b/src/extensions/Automation/components/SchedulePanel/builders/DueDateCommandBuilder.tsx
@@ -353,7 +353,7 @@ const DueDateCommandBuilder: FC<Props> = ({
               variant="primary"
               type="button"
               disabled={!canSave || saving}
-              onClick={handleSave}
+              onClick={() => { void handleSave(); }}
             >
               {saving ? translations['automation.dueDateBuilder.saving'] : existing ? translations['automation.dueDateBuilder.saveChanges'] : translations['automation.dueDateBuilder.create']}
             </Button>

--- a/src/extensions/Automation/components/SchedulePanel/builders/ScheduledCommandBuilder.tsx
+++ b/src/extensions/Automation/components/SchedulePanel/builders/ScheduledCommandBuilder.tsx
@@ -432,7 +432,7 @@ const ScheduledCommandBuilder: FC<Props> = ({
             <button
               type="button"
               disabled={!canSave || saving}
-              onClick={handleSave}
+              onClick={() => { void handleSave(); }}
               className="rounded-md px-4 py-2 text-sm font-medium text-white bg-primary hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors" // [theme-exception] text-white on primary button
             >
               {saving ? translations['automation.scheduledBuilder.saving'] : existing ? translations['automation.scheduledBuilder.saveChanges'] : translations['automation.scheduledBuilder.create']}

--- a/src/extensions/Board/components/BoardCanvas.tsx
+++ b/src/extensions/Board/components/BoardCanvas.tsx
@@ -1577,7 +1577,7 @@ const BoardCanvas = ({
       collisionDetection={collisionDetection}
       onDragStart={handleDragStart}
       onDragOver={handleDragOver}
-      onDragEnd={handleDragEnd}
+      onDragEnd={(event) => { void handleDragEnd(event); }}
     >
       <ProgressiveHydrationDispatcher
         listOrder={listOrder}

--- a/src/extensions/Board/components/BoardHeader.tsx
+++ b/src/extensions/Board/components/BoardHeader.tsx
@@ -140,7 +140,7 @@ const BoardHeader = ({
           value={title}
           autoFocus
           onChange={(e) => { setTitle(e.target.value); }}
-          onBlur={handleTitleSave}
+          onBlur={() => { void handleTitleSave(); }}
           onKeyDown={handleKeyDown}
           className={`bg-bg-overlay font-semibold text-lg rounded px-2 py-0.5 focus:outline-none focus:ring-2 focus:ring-primary min-w-0 max-w-xs${hasBackground ? ' text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.5)]' : ' text-base'}`}
           aria-label="Edit board title"

--- a/src/extensions/Board/components/BoardMembersPanel/AddMemberInput.tsx
+++ b/src/extensions/Board/components/BoardMembersPanel/AddMemberInput.tsx
@@ -87,7 +87,7 @@ const AddMemberInput = ({ candidates, onAdd, onFocusInput }: Props) => {
                     type="button"
                     role="option"
                     aria-selected={false}
-                    onClick={() => handleSelect(m)}
+                    onClick={() => { void handleSelect(m); }}
                     className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-subtle hover:bg-bg-overlay"
                   >
                     <span className="font-medium">{m.name ?? m.email}</span>

--- a/src/extensions/Board/components/BoardSettings/index.tsx
+++ b/src/extensions/Board/components/BoardSettings/index.tsx
@@ -107,7 +107,7 @@ const BoardSettings = ({ onClose, currentUserId, isGuest = false }: Props) => {
           {isAdmin && (
             <VisibilitySelector
               value={visibility}
-              onChange={handleVisibilityChange}
+              onChange={(v) => { void handleVisibilityChange(v); }}
               disabled={saving}
             />
           )}

--- a/src/extensions/BoardViews/BoardActivityPanel.tsx
+++ b/src/extensions/BoardViews/BoardActivityPanel.tsx
@@ -68,7 +68,7 @@ const BoardActivityPanel = ({ boardId }: Props) => {
         actorNames={actorNames}
         hasMore={hasMore}
         loading={loading}
-        onLoadMore={() => loadPage(cursor)}
+        onLoadMore={() => { void loadPage(cursor); }}
         boardId={boardId}
       />
     </div>

--- a/src/extensions/BoardViews/BoardCommentsPanel.tsx
+++ b/src/extensions/BoardViews/BoardCommentsPanel.tsx
@@ -87,7 +87,7 @@ const BoardCommentsPanel = ({ boardId, onCardClick }: Props) => {
       {loading && <p className="text-xs text-subtle">{translations['BoardViews.loadingComments']}</p>}
 
       {hasMore && !loading && (
-        <Button variant="link" size="sm" onClick={() => loadPage(cursor)}>
+        <Button variant="link" size="sm" onClick={() => { void loadPage(cursor); }}>
           {translations['BoardViews.loadMoreComments']}
         </Button>
       )}

--- a/src/extensions/Card/components/AddCardForm.tsx
+++ b/src/extensions/Card/components/AddCardForm.tsx
@@ -45,7 +45,7 @@ const AddCardForm = ({ listId, onSubmit, onCancel }: Props) => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-2 px-2 pt-2 pb-2">
+    <form onSubmit={(e) => { void handleSubmit(e); }} className="flex flex-col gap-2 px-2 pt-2 pb-2">
       <textarea
         ref={textareaRef}
         value={title}

--- a/src/extensions/Card/components/CardActionMenu.tsx
+++ b/src/extensions/Card/components/CardActionMenu.tsx
@@ -16,7 +16,7 @@ const CardActionMenu = ({ archived, onArchive, onDelete, onCopyLink, onCopyCard,
       <button
         type="button"
         className="w-full flex items-center gap-2 px-3 py-2 text-sm text-base hover:bg-bg-overlay rounded-lg transition-colors disabled:opacity-40"
-        onClick={onArchive}
+        onClick={() => { void onArchive(); }}
         disabled={disabled}
       >
         {archived

--- a/src/extensions/Card/components/CardValue.tsx
+++ b/src/extensions/Card/components/CardValue.tsx
@@ -84,7 +84,7 @@ const CardValue = ({ amount, currency, onSave, disabled }: Props) => {
           type="button"
           variant="primary"
           className="w-full text-xs"
-          onClick={handleSave}
+          onClick={() => { void handleSave(); }}
           disabled={saving}
         >
           {saving ? 'Saving…' : 'Save'}

--- a/src/extensions/Card/components/CopyCardModal.tsx
+++ b/src/extensions/Card/components/CopyCardModal.tsx
@@ -173,7 +173,7 @@ const CopyCardModal = ({
               </Dialog.Close>
             </div>
 
-            <form onSubmit={handleSubmit} className="p-4 space-y-4">
+            <form onSubmit={(e) => { void handleSubmit(e); }} className="p-4 space-y-4">
           {/* Name */}
           <div>
             <label htmlFor="copy-card-title" className="block text-xs font-medium text-muted mb-1">

--- a/src/extensions/Card/components/CreateCardForm.tsx
+++ b/src/extensions/Card/components/CreateCardForm.tsx
@@ -37,7 +37,7 @@ const CreateCardForm = ({ listId, onSubmit, onCancel }: Props) => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+    <form onSubmit={(e) => { void handleSubmit(e); }} className="flex flex-col gap-2">
       <textarea
         className="w-full rounded border border-border bg-bg-overlay p-2 text-sm text-base focus:outline-none focus:ring-2 focus:ring-primary resize-none"
         placeholder="Enter a title for this card…"

--- a/src/extensions/Card/components/LabelPicker.tsx
+++ b/src/extensions/Card/components/LabelPicker.tsx
@@ -55,7 +55,7 @@ export const LabelPicker = ({ allLabels, selectedIds, onAttach, onDetach, disabl
                 role="option"
                 aria-selected={selected}
                 className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-bg-overlay"
-                onClick={() => toggle(label)}
+                onClick={() => { void toggle(label); }}
               >
                 <span
                   className="h-3 w-3 rounded-full flex-shrink-0"

--- a/src/extensions/Card/components/MemberAssignModal.tsx
+++ b/src/extensions/Card/components/MemberAssignModal.tsx
@@ -55,7 +55,7 @@ export const MemberAssignModal = ({
                   type="button"
                   variant={assigned ? 'danger' : 'primary'}
                   size="sm"
-                  onClick={() => assigned ? onRemove(member.id) : onAssign(member.id)}
+                  onClick={() => { if (assigned) { void onRemove(member.id); } else { void onAssign(member.id); } }}
                 >
                   {assigned ? 'Remove' : 'Assign'}
                 </Button>

--- a/src/extensions/Card/components/MemberAvatarPopover.tsx
+++ b/src/extensions/Card/components/MemberAvatarPopover.tsx
@@ -159,7 +159,7 @@ export const MemberAvatarPopover = ({ member, isSelf, onRemove, onClose, anchorR
       ) : (
         <button
           className="w-full text-left px-3 py-2 text-sm rounded-lg hover:bg-red-900/40 text-danger flex items-center gap-2"
-          onClick={handleRemove}
+          onClick={() => { void handleRemove(); }}
           disabled={removing}
         >
           {removing ? (

--- a/src/extensions/Comment/components/CommentEditor.tsx
+++ b/src/extensions/Comment/components/CommentEditor.tsx
@@ -1562,7 +1562,7 @@ const CommentEditor = ({
         <Button
           variant="primary"
           size="sm"
-          onClick={handleSubmit}
+          onClick={() => { void handleSubmit(); }}
           disabled={submitting}
         >
           {submitting ? translations['comment.editor.submitting'] : submitLabel}

--- a/src/extensions/Comment/components/CommentItem.tsx
+++ b/src/extensions/Comment/components/CommentItem.tsx
@@ -581,7 +581,7 @@ const CommentItem = ({ comment, boardId, attachments = [], currentUserId, isAdmi
               <Button
                 variant="link"
                 className="p-0 text-xs text-muted hover:text-danger"
-                onClick={handleDelete}
+                onClick={() => { void handleDelete(); }}
                 disabled={deleting}
               >
                 {deleting ? translations['comment.action.deleting'] : translations['comment.action.delete']}

--- a/src/extensions/HealthCheck/containers/HealthCheckTab/HealthCheckTab.tsx
+++ b/src/extensions/HealthCheck/containers/HealthCheckTab/HealthCheckTab.tsx
@@ -74,7 +74,7 @@ export function HealthCheckTab({ boardId }: Props) {
   }, [dispatch, boardId]);
 
   const { secondsUntilRefresh, triggerRefresh } = useHealthCheckAutoRefresh({
-    onRefresh: handleRefresh,
+    onRefresh: () => { void handleRefresh(); },
   });
 
   const handleManualRefresh = useCallback(() => {

--- a/src/extensions/HealthCheck/modals/AddServiceModal.tsx
+++ b/src/extensions/HealthCheck/modals/AddServiceModal.tsx
@@ -204,7 +204,7 @@ export function AddServiceModal({ boardId, isOpen, onClose }: Props) {
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} noValidate>
+        <form onSubmit={(e) => { void handleSubmit(e); }} noValidate>
           {mode === 'preset' ? (
             <div className="mb-4">
               <label

--- a/src/extensions/List/components/AddListForm.tsx
+++ b/src/extensions/List/components/AddListForm.tsx
@@ -56,7 +56,7 @@ const AddListForm = ({ onSubmit }: Props) => {
 
   return (
     <form
-      onSubmit={handleSubmit}
+      onSubmit={(e) => { void handleSubmit(e); }}
       className="w-72 shrink-0 bg-bg-surface border border-border rounded-xl p-3 flex flex-col gap-2"
     >
       <input

--- a/src/extensions/Mention/TiptapMentionExtension.ts
+++ b/src/extensions/Mention/TiptapMentionExtension.ts
@@ -26,15 +26,17 @@ function buildSuggestion(boardId: string): Partial<SuggestionOptions<MentionSugg
     items: ({ query }): Promise<MentionSuggestion[]> =>
       new Promise((resolve) => {
         if (debounceTimer) clearTimeout(debounceTimer);
-        debounceTimer = setTimeout(async () => {
-          try {
-            const result = (await apiClient.get(
-              `/boards/${boardId}/members/suggestions?q=${encodeURIComponent(query)}`,
-            )) as { data: MentionSuggestion[] };
-            resolve(result.data);
-          } catch {
-            resolve([]);
-          }
+        debounceTimer = setTimeout(() => {
+          void (async () => {
+            try {
+              const result = (await apiClient.get(
+                `/boards/${boardId}/members/suggestions?q=${encodeURIComponent(query)}`,
+              )) as { data: MentionSuggestion[] };
+              resolve(result.data);
+            } catch {
+              resolve([]);
+            }
+          })();
         }, DEBOUNCE_MS);
       }),
 

--- a/src/extensions/Plugins/modals/ApiKeyRevealModal.tsx
+++ b/src/extensions/Plugins/modals/ApiKeyRevealModal.tsx
@@ -50,7 +50,7 @@ const ApiKeyRevealModal = ({ apiKey, onClose }: Props) => {
               {apiKey}
             </code>
             <button
-              onClick={handleCopy}
+              onClick={() => { void handleCopy(); }}
               className="flex-shrink-0 bg-bg-overlay hover:bg-bg-sunken text-subtle text-sm rounded px-3 py-2"
               aria-label={translations['plugins.apiKeyModal.copyAriaLabel']}
             >

--- a/src/extensions/Realtime/PollingFallback.tsx
+++ b/src/extensions/Realtime/PollingFallback.tsx
@@ -74,7 +74,7 @@ export function usePollingFallback({
 
     // Fire an immediate poll then set up the recurring interval
     void poll();
-    intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
+    intervalRef.current = setInterval(() => { void poll(); }, POLL_INTERVAL_MS);
 
     return () => {
       if (intervalRef.current !== null) {

--- a/src/extensions/Realtime/hooks/useWebSocket.ts
+++ b/src/extensions/Realtime/hooks/useWebSocket.ts
@@ -136,7 +136,7 @@ export function useWebSocket({
         pingPropagationDelay(event);
         onEvent(event);
       },
-      onOpen: handleOpen,
+      onOpen: () => { void handleOpen(); },
       onClose: handleClose,
       onPollingActive: () => { setPollingActive(true); },
       onPollingInactive: () => { setPollingActive(false); },

--- a/src/extensions/Search/components/SearchResults.tsx
+++ b/src/extensions/Search/components/SearchResults.tsx
@@ -151,7 +151,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
             <div key={r.id} className="relative">
               <SearchResultItem
                 result={r}
-                onSelect={handleSelect}
+                onSelect={(res) => { void handleSelect(res); }}
               />
               {/* Subtle spinner while access check is in flight */}
               {checkingId === r.id && (
@@ -170,7 +170,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
             Cards
           </p>
           {cards.map((r) => (
-            <SearchResultItem key={r.id} result={r} onSelect={handleSelect} />
+            <SearchResultItem key={r.id} result={r} onSelect={(res) => { void handleSelect(res); }} />
           ))}
         </section>
       )}

--- a/src/extensions/User/components/ProfileForm.tsx
+++ b/src/extensions/User/components/ProfileForm.tsx
@@ -54,7 +54,7 @@ export default function ProfileForm({ user }: ProfileFormProps) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+    <form onSubmit={(e) => { void handleSubmit(e); }} className="flex flex-col gap-5">
       {/* Display name */}
       <div className="flex flex-col gap-1">
         <label htmlFor="display-name" className="text-sm font-medium text-subtle">

--- a/src/extensions/UserProfile/containers/EditProfilePage/GlobalNotificationToggle.tsx
+++ b/src/extensions/UserProfile/containers/EditProfilePage/GlobalNotificationToggle.tsx
@@ -92,7 +92,7 @@ const GlobalNotificationToggle = () => {
         </div>
         <ToggleSwitch
           enabled={enabled}
-          onChange={handleToggle}
+          onChange={(next) => { void handleToggle(next); }}
           disabled={loading}
           ariaLabel={translations['UserProfile.notificationsAriaLabel']}
         />

--- a/src/extensions/Webhooks/containers/WebhooksRegisterPage/EditWebhookModal.tsx
+++ b/src/extensions/Webhooks/containers/WebhooksRegisterPage/EditWebhookModal.tsx
@@ -146,7 +146,7 @@ export default function EditWebhookModal({ webhook, onClose, onUpdated }: Props)
         </div>
 
         {/* Body */}
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={(e) => { void handleSubmit(e); }}>
           <div className="space-y-5 px-6 py-5">
             <Input
               label={translations['RegisterWebhookModal.labelField']}

--- a/src/extensions/Webhooks/containers/WebhooksRegisterPage/RegisterWebhookModal.tsx
+++ b/src/extensions/Webhooks/containers/WebhooksRegisterPage/RegisterWebhookModal.tsx
@@ -145,7 +145,7 @@ export default function RegisterWebhookModal({ workspaceId, onClose, onCreated }
         </div>
 
         {/* Body */}
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={(e) => { void handleSubmit(e); }}>
           <div className="space-y-5 px-6 py-5">
             <Input
               label={translations['RegisterWebhookModal.labelField']}

--- a/src/extensions/Webhooks/containers/WebhooksRegisterPage/WebhookCreatedModal.tsx
+++ b/src/extensions/Webhooks/containers/WebhooksRegisterPage/WebhookCreatedModal.tsx
@@ -72,7 +72,7 @@ export default function WebhookCreatedModal({ signingSecret, onClose }: Props) {
                 type="button"
                 variant="secondary"
                 size="sm"
-                onClick={handleCopy}
+                onClick={() => { void handleCopy(); }}
                 data-testid="copy-button"
               >
                 {copied

--- a/src/extensions/Workspace/components/CreateWorkspaceModal.tsx
+++ b/src/extensions/Workspace/components/CreateWorkspaceModal.tsx
@@ -56,7 +56,7 @@ export default function CreateWorkspaceModal({ open, onOpenChange }: CreateWorks
             {translations['CreateWorkspaceModal.description']}
           </p>
 
-          <form onSubmit={handleSubmit} noValidate>
+          <form onSubmit={(e) => { void handleSubmit(e); }} noValidate>
             <div className="mb-4">
               <label htmlFor="workspace-name" className="mb-1.5 block text-sm font-medium text-subtle">
                 {translations['CreateWorkspaceModal.nameLabel']}

--- a/src/extensions/Workspace/components/InviteMemberModal.tsx
+++ b/src/extensions/Workspace/components/InviteMemberModal.tsx
@@ -85,7 +85,7 @@ const InviteMemberModal = ({ workspaceId, callerRole, onClose }: InviteMemberMod
             </Button>
           </div>
         ) : (
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={(e) => { void handleSubmit(e); }} className="space-y-4">
             <div>
               <label
                 htmlFor="invite-email"

--- a/src/extensions/Workspace/components/Sidebar.tsx
+++ b/src/extensions/Workspace/components/Sidebar.tsx
@@ -354,7 +354,7 @@ export default function Sidebar() {
                   <Button
                     variant="ghost"
                     role="menuitem"
-                    onClick={handleLogout}
+                    onClick={() => { void handleLogout(); }}
                     className="w-full rounded-none px-3 py-1.5 text-left text-sm font-normal justify-start"
                   >
                     {translations['Sidebar.logout']}

--- a/src/extensions/Workspace/containers/AcceptInvitePage/AcceptInvitePage.tsx
+++ b/src/extensions/Workspace/containers/AcceptInvitePage/AcceptInvitePage.tsx
@@ -72,7 +72,7 @@ const AcceptInvitePage = () => {
             <Button
               variant="primary"
               size="md"
-              onClick={handleAccept}
+              onClick={() => { void handleAccept(); }}
             >
               Accept Invitation
             </Button>

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -557,7 +557,7 @@ export default function Sidebar({ onClose }: SidebarProps = {}) {
                   <Button
                     variant="ghost"
                     role="menuitem"
-                    onClick={handleLogout}
+                    onClick={() => { void handleLogout(); }}
                     className="w-full rounded-none px-3 py-1.5 text-left text-sm font-normal justify-start"
                   >
                     {translations['Sidebar.logout']}


### PR DESCRIPTION
## Summary

Wraps 54 `@typescript-eslint/no-misused-promises` findings across 53 files in `void`, behaviour-preserving. This family flags Promise-returning async functions/callbacks passed where a `void` return is expected (JSX event attributes like `onClick`, `onChange`, `setTimeout`/`setInterval` callbacks, and void-return event args).

**Pattern (proven across the earlier no-floating-promises/await-thenable batches):**
- `onClick={handleSubmit}` (async) → `onClick={() => { void handleSubmit(); }}`
- `setTimeout(asyncFn, ms)` → `setTimeout(() => { void asyncFn(); }, ms)`
- `onSubmit={handleSubmit}` etc. same void-wrap

The async handler already was NOT awaited by the browser DOM / timer semantics — the `void` operator just makes the deliberate fire-and-forget explicit and silences the rule. **No `await` was added inside handlers (that WOULD change behaviour by blocking the handler body), no async signatures/call-order/JSX reordered, response shapes untouched.**

## Scope / rule

- Rule: `@typescript-eslint/no-misused-promises` (Promise in void-return position)
- 53 files: 54 React components + 2 server orphanCleanup + MentionInput/Tiptap/PollingFallback utilities
- Excluded: `server/extensions/payment/`, `db/seeds/trello-import.ts`, `public/sdk/jh-instance.js`

## Verification

- **Any-rule gate vs trusted baseline (after296): -54 no-misused-promises, ZERO newly-introduced findings of any rule** across all 53 touched files
- `bunx tsc --noEmit`: **146 — identical to baseline**
- `bun test`: **300 fail identities identical to baseline** (no new failures)
- `bun run build:client`: **passed**; `git diff --check`: **clean**

## Skipped (2, deferred — not clean mechanical void-wraps)

**src/extensions/TimelineView/useTimelineDrag.ts (lines 169, 171):** the promise-returning `up`/`move` callbacks are stored in a `listenersRef` whose stored function IS the identical reference passed to `addEventListener`/`removeEventListener`. Wrapping in a distinct arrow would create two separate closures and break the `mouseup` listener cleanup on teardown — a genuine behavioural regression, not a mechanical fix. Deferred rather than risk the drag handler's lifecycle.

## UI/E2E coverage

Changed 50+ UI components (event handlers). No dedicated executable UI/E2E coverage exists for these interaction handlers — recorded as missing. Exercised via typecheck + build + full unit suite. The void-wrap does not alter any event's observable effect (same handler invoked, same async fire-and-forget semantics).

## Exclusions

No payments/monetisation/Stripe/billing/subscription files. No unrelated files.

## Review

Authored by `matthewvryanjh`. Independent review + approval + merge by `hermesrobinson-dev`.