### PR TITLE
fix(e2e): repair auth and resource-creation route drift in test helpers

### DIFF
--- a/tests/e2e/_helpers.ts
+++ b/tests/e2e/_helpers.ts
@@ -13,15 +13,13 @@ export async function registerAndLogin(
   const email = `e2e-${suffix}-${Date.now()}@example.com`;
   const password = 'TestPassword1!';
 
-  await request.post(`${BASE_URL}/api/v1/auth/register`, {
+  const regRes = await request.post(`${BASE_URL}/api/v1/auth/register`, {
     data: { email, password, name: `Test ${suffix}` },
   });
-
-  const loginRes = await request.post(`${BASE_URL}/api/v1/auth/login`, {
-    data: { email, password },
-  });
-  const body = await loginRes.json() as { data: { access_token: string } };
-  return body.data.access_token;
+  // Register returns an accessToken directly (201); avoid a separate login call
+  // which is rate-limited (10/IP/min) and would 429 under the full suite.
+  const body = await regRes.json() as { data: { accessToken: string } };
+  return body.data.accessToken;
 }
 
 export async function createWorkspace(

--- a/tests/e2e/board-members.spec.ts
+++ b/tests/e2e/board-members.spec.ts
@@ -8,14 +8,11 @@ const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:3000';
 async function registerAndLogin(request: APIRequestContext, suffix: string) {
   const email = `bm-test-${suffix}-${Date.now()}@example.com`;
   const password = 'TestPassword1!';
-  await request.post(`${BASE_URL}/api/v1/auth/register`, {
+  const regRes = await request.post(`${BASE_URL}/api/v1/auth/register`, {
     data: { email, password, name: `BM ${suffix}` },
   });
-  const loginRes = await request.post(`${BASE_URL}/api/v1/auth/login`, {
-    data: { email, password },
-  });
-  const body = await loginRes.json();
-  return { token: body.data.access_token, email };
+  const body = await regRes.json();
+  return { token: body.data.accessToken, email };
 }
 
 async function createWorkspace(request: APIRequestContext, token: string) {

--- a/tests/e2e/board-view-preference.spec.ts
+++ b/tests/e2e/board-view-preference.spec.ts
@@ -14,14 +14,11 @@ const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:3000';
 async function registerAndLogin(request: APIRequestContext, suffix: string): Promise<string> {
   const email = `bv-test-${suffix}-${Date.now()}@example.com`;
   const password = 'TestPassword1!';
-  await request.post(`${BASE_URL}/api/v1/auth/register`, {
+  const regRes = await request.post(`${BASE_URL}/api/v1/auth/register`, {
     data: { email, password, name: `BV ${suffix}` },
   });
-  const loginRes = await request.post(`${BASE_URL}/api/v1/auth/login`, {
-    data: { email, password },
-  });
-  const body = await loginRes.json() as { data: { access_token: string } };
-  return body.data.access_token;
+  const body = await regRes.json() as { data: { accessToken: string } };
+  return body.data.accessToken;
 }
 
 async function createWorkspace(request: APIRequestContext, token: string): Promise<string> {
@@ -34,9 +31,9 @@ async function createWorkspace(request: APIRequestContext, token: string): Promi
 }
 
 async function createBoard(request: APIRequestContext, token: string, workspaceId: string): Promise<string> {
-  const res = await request.post(`${BASE_URL}/api/v1/boards`, {
+  const res = await request.post(`${BASE_URL}/api/v1/workspaces/${workspaceId}/boards`, {
     headers: { Authorization: `Bearer ${token}` },
-    data: { name: `Board-${Date.now()}`, workspaceId },
+    data: { title: `Board-${Date.now()}` },
   });
   const body = await res.json() as { data: { id: string } };
   return body.data.id;

--- a/tests/e2e/board-visibility.spec.ts
+++ b/tests/e2e/board-visibility.spec.ts
@@ -20,15 +20,11 @@ async function registerAndLogin(request: APIRequestContext, suffix: string): Pro
   const email = `vis-test-${suffix}-${Date.now()}@example.com`;
   const password = 'TestPassword1!';
 
-  await request.post(`${BASE_URL}/api/v1/auth/register`, {
+  const regRes = await request.post(`${BASE_URL}/api/v1/auth/register`, {
     data: { email, password, name: `Test ${suffix}` },
   });
-
-  const loginRes = await request.post(`${BASE_URL}/api/v1/auth/login`, {
-    data: { email, password },
-  });
-  const body = await loginRes.json() as { data: { access_token: string } };
-  return body.data.access_token;
+  const body = await regRes.json() as { data: { accessToken: string } };
+  return body.data.accessToken;
 }
 
 async function createWorkspace(request: APIRequestContext, token: string): Promise<string> {

--- a/tests/e2e/csrf-guard.spec.ts
+++ b/tests/e2e/csrf-guard.spec.ts
@@ -120,7 +120,7 @@ test.describe('CSRF Origin Header Guard', () => {
       data: { email, password, name: 'CSRF Cookie User' },
     });
 
-    const loginRes = await request.post(`${BASE_URL}/api/v1/auth/login`, {
+    const loginRes = await request.post(`${BASE_URL}/api/v1/auth/token`, {
       data: { email, password },
     });
 

--- a/tests/e2e/mcp-http-init.spec.ts
+++ b/tests/e2e/mcp-http-init.spec.ts
@@ -6,11 +6,11 @@ const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:3000';
 
 // Helper: login and get JWT
 async function loginAndGetJwt(request: APIRequestContext, email: string, password: string) {
-  const loginRes = await request.post(`${BASE_URL}/api/v1/auth/login`, {
+  const loginRes = await request.post(`${BASE_URL}/api/v1/auth/token`, {
     data: { email, password },
   });
   const body = await loginRes.json();
-  return body.data.access_token;
+  return body.data.accessToken;
 }
 
 test.describe('MCP HTTP Init', () => {

--- a/tests/e2e/member-joined-event.spec.ts
+++ b/tests/e2e/member-joined-event.spec.ts
@@ -19,15 +19,11 @@ async function registerAndLogin(request: APIRequestContext, suffix: string): Pro
   const email = `mj-test-${suffix}-${Date.now()}@example.com`;
   const password = 'TestPassword1!';
 
-  await request.post(`${BASE_URL}/api/v1/auth/register`, {
+  const regRes = await request.post(`${BASE_URL}/api/v1/auth/register`, {
     data: { email, password, name: `MJ ${suffix}` },
   });
-
-  const loginRes = await request.post(`${BASE_URL}/api/v1/auth/login`, {
-    data: { email, password },
-  });
-  const body = await loginRes.json() as { data: { access_token: string } };
-  return { token: body.data.access_token, email };
+  const body = await regRes.json() as { data: { accessToken: string } };
+  return { token: body.data.accessToken, email };
 }
 
 async function createWorkspace(request: APIRequestContext, token: string): Promise<string> {

--- a/tests/e2e/offline-queue-persistence.spec.ts
+++ b/tests/e2e/offline-queue-persistence.spec.ts
@@ -24,15 +24,11 @@ async function registerAndLogin(
   const email = `oq-test-${suffix}-${Date.now()}@example.com`;
   const password = 'TestPassword1!';
 
-  await request.post(`${BASE_URL}/api/v1/auth/register`, {
+  const regRes = await request.post(`${BASE_URL}/api/v1/auth/register`, {
     data: { email, password, name: `OQ ${suffix}` },
   });
-
-  const loginRes = await request.post(`${BASE_URL}/api/v1/auth/login`, {
-    data: { email, password },
-  });
-  const body = await loginRes.json() as { data: { access_token: string } };
-  return { token: body.data.access_token, email, password };
+  const body = await regRes.json() as { data: { accessToken: string } };
+  return { token: body.data.accessToken, email, password };
 }
 
 async function createWorkspace(request: APIRequestContext, token: string): Promise<string> {

--- a/tests/e2e/otel-metrics.spec.ts
+++ b/tests/e2e/otel-metrics.spec.ts
@@ -27,15 +27,16 @@ async function registerAndLogin(
     data: { email, password, name: `OTel ${suffix}` },
   });
   expect(reg.status()).toBe(201);
-  const { data: regData } = await reg.json() as { data: { token: string; workspaceId?: string } };
+  const { data: regData } = await reg.json() as { data: { accessToken: string } };
+  const token = regData.accessToken;
 
-  // Login to get a fresh token
-  const login = await request.post(`${BASE_URL}/api/v1/auth/login`, {
-    data: { email, password },
+  // Create a workspace to get a workspaceId (auth response does not include one)
+  const ws = await request.post(`${BASE_URL}/api/v1/workspaces`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { name: `OTel-WS-${Date.now()}` },
   });
-  expect(login.status()).toBe(200);
-  const { data: loginData } = await login.json() as { data: { token: string; workspaceId: string } };
-  return { token: loginData.token, workspaceId: loginData.workspaceId ?? regData.workspaceId ?? '' };
+  const { data: wsData } = await ws.json() as { data: { id: string } };
+  return { token, workspaceId: wsData.id };
 }
 
 // ---------------------------------------------------------------------------
@@ -86,33 +87,33 @@ test.describe('Card move triggers conflict counter (smoke)', () => {
     const { token, workspaceId } = await registerAndLogin(request, 'cm');
 
     // Create a board
-    const boardRes = await request.post(`${BASE_URL}/api/v1/boards`, {
+    const boardRes = await request.post(`${BASE_URL}/api/v1/workspaces/${workspaceId}/boards`, {
       headers: { Authorization: `Bearer ${token}` },
-      data: { title: 'OTel Board', workspaceId },
+      data: { title: 'OTel Board' },
     });
     expect(boardRes.status()).toBe(201);
     const { data: board } = await boardRes.json() as { data: { id: string } };
 
     // Create a list
-    const listRes = await request.post(`${BASE_URL}/api/v1/lists`, {
+    const listRes = await request.post(`${BASE_URL}/api/v1/boards/${board.id}/lists`, {
       headers: { Authorization: `Bearer ${token}` },
-      data: { title: 'List A', boardId: board.id },
+      data: { title: 'List A' },
     });
     expect(listRes.status()).toBe(201);
     const { data: list } = await listRes.json() as { data: { id: string } };
 
     // Create a second list
-    const list2Res = await request.post(`${BASE_URL}/api/v1/lists`, {
+    const list2Res = await request.post(`${BASE_URL}/api/v1/boards/${board.id}/lists`, {
       headers: { Authorization: `Bearer ${token}` },
-      data: { title: 'List B', boardId: board.id },
+      data: { title: 'List B' },
     });
     expect(list2Res.status()).toBe(201);
     const { data: list2 } = await list2Res.json() as { data: { id: string } };
 
     // Create a card in List A
-    const cardRes = await request.post(`${BASE_URL}/api/v1/cards`, {
+    const cardRes = await request.post(`${BASE_URL}/api/v1/lists/${list.id}/cards`, {
       headers: { Authorization: `Bearer ${token}` },
-      data: { title: 'Card 1', listId: list.id, boardId: board.id },
+      data: { title: 'Card 1' },
     });
     expect(cardRes.status()).toBe(201);
     const { data: card } = await cardRes.json() as { data: { id: string } };

--- a/tests/e2e/table-view.spec.ts
+++ b/tests/e2e/table-view.spec.ts
@@ -15,14 +15,11 @@ const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:3000';
 async function registerAndLogin(request: APIRequestContext, suffix: string): Promise<string> {
   const email = `tv-test-${suffix}-${Date.now()}@example.com`;
   const password = 'TestPassword1!';
-  await request.post(`${BASE_URL}/api/v1/auth/register`, {
+  const regRes = await request.post(`${BASE_URL}/api/v1/auth/register`, {
     data: { email, password, name: `TV ${suffix}` },
   });
-  const loginRes = await request.post(`${BASE_URL}/api/v1/auth/login`, {
-    data: { email, password },
-  });
-  const body = await loginRes.json() as { data: { access_token: string } };
-  return body.data.access_token;
+  const body = await regRes.json() as { data: { accessToken: string } };
+  return body.data.accessToken;
 }
 
 async function createWorkspace(request: APIRequestContext, token: string): Promise<string> {
@@ -41,7 +38,7 @@ async function createBoard(
 ): Promise<{ id: string }> {
   const res = await request.post(`${BASE_URL}/api/v1/workspaces/${workspaceId}/boards`, {
     headers: { Authorization: `Bearer ${token}` },
-    data: { name: `Board-TV-${Date.now()}` },
+    data: { title: `Board-TV-${Date.now()}` },
   });
   const body = await res.json() as { data: { id: string } };
   return body.data;


### PR DESCRIPTION
## Summary

The e2e test helpers drifted from the real API contract, causing ~76 of 187 BDD scenarios to fail with `TypeError: Cannot read properties of undefined (reading 'accessToken')`, plus 429s from the login rate limit.

## Root cause

- Helpers called `POST /api/v1/auth/login` and read `data.access_token`
- The API exposes `POST /api/v1/auth/token` returning `data.accessToken` (the UI already uses this correctly)
- A separate login call after register also hit the login rate limit (10/IP/min) under the full suite

## Changes (test-only, no product behaviour altered)

- Use the register response token directly (register returns `accessToken` on 201), avoiding the redundant, rate-limited login call
- Correct board/list/card creation to the real routes:
  - `POST /api/v1/workspaces/:id/boards` with `{title}`
  - `POST /api/v1/boards/:id/lists` with `{title}`
  - `POST /api/v1/lists/:id/cards` with `{title}`
- `csrf-guard`: point login at `/auth/token` (still reads Set-Cookie)
- `mcp-http-init`: `/auth/token` + `accessToken`

## Verification

- ESLint clean on all 10 touched files
- Typecheck: 146 errors (pre-existing baseline, unchanged; none from touched files)
- Focused e2e run: auth drift gone; remaining failures are separate genuine issues (board-members fake user IDs, board-view-preference 401/404 + shape, otel-metrics OTEL-gated 400s, table-view UI timeouts)