### PR TITLE
fix(e2e): createList helper sends title not name

### DIFF
--- a/tests/e2e/_helpers.ts
+++ b/tests/e2e/_helpers.ts
@@ -54,7 +54,7 @@ export async function createList(
 ): Promise<string> {
   const res = await request.post(`${BASE_URL}/api/v1/boards/${boardId}/lists`, {
     headers: { Authorization: `Bearer ${token}` },
-    data: { name: `List-${Date.now()}`, position: 0 },
+    data: { title: `List-${Date.now()}` },
   });
   const body = await res.json() as { data: { id: string } };
   return body.data.id;


### PR DESCRIPTION
## Summary

The shared `createList` helper in `tests/e2e/_helpers.ts` sent `{ name, position: 0 }`, but the list create API (`POST /api/v1/boards/:id/lists`) requires `{ title }` and returns 400 otherwise. This affected ~11 specs importing the helper.

## Change (test-only)

`data: { name: ... , position: 0 }` → `data: { title: ... }`

## Verification

- ESLint clean on the touched file
- Direct API call with `{title}` returns 201 with the list object
- Focused e2e run (custom-field-values-api, input-sanitization, business-logic-invariants): 23 passed; the 5 failures are pre-existing and unrelated (XSS card title, custom-field-value PUT, PATCH board-archived)