### PR TITLE
fix(e2e): board-members spec uses real users and correct API contract

### DIFF
--- a/tests/e2e/board-members.spec.ts
+++ b/tests/e2e/board-members.spec.ts
@@ -12,7 +12,7 @@ async function registerAndLogin(request: APIRequestContext, suffix: string) {
     data: { email, password, name: `BM ${suffix}` },
   });
   const body = await regRes.json();
-  return { token: body.data.accessToken, email };
+  return { token: body.data.accessToken, userId: body.data.user.id, email };
 }
 
 async function createWorkspace(request: APIRequestContext, token: string) {
@@ -33,38 +33,60 @@ async function createBoard(request: APIRequestContext, token: string, workspaceI
   return body.data.id;
 }
 
+// Register a second user and add them to the workspace so they can be added to a board.
+async function addWorkspaceMember(request: APIRequestContext, token: string, workspaceId: string, email: string) {
+  const res = await request.post(`${BASE_URL}/api/v1/workspaces/${workspaceId}/members`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { email, role: 'MEMBER' },
+  });
+  return res;
+}
+
 test.describe('Board member API flows', () => {
   test('GET /boards/:id/members returns explicit board members', async ({ request }) => {
-    const { token } = await registerAndLogin(request, 'get');
-    const wsId = await createWorkspace(request, token);
-    const boardId = await createBoard(request, token, wsId);
-    // Add member
-    await request.post(`${BASE_URL}/api/v1/boards/${boardId}/members`, {
-      headers: { Authorization: `Bearer ${token}` },
-      data: { userId: 'user-2', role: 'MEMBER' },
+    const owner = await registerAndLogin(request, 'get');
+    const wsId = await createWorkspace(request, owner.token);
+    const boardId = await createBoard(request, owner.token, wsId);
+
+    // Register a second user and add them to the workspace, then to the board.
+    const member = await registerAndLogin(request, 'get2');
+    const addWs = await addWorkspaceMember(request, owner.token, wsId, member.email);
+    expect(addWs.status()).toBe(201);
+    const addBoard = await request.post(`${BASE_URL}/api/v1/boards/${boardId}/members`, {
+      headers: { Authorization: `Bearer ${owner.token}` },
+      data: { userId: member.userId, role: 'MEMBER' },
     });
+    expect(addBoard.status()).toBe(201);
+
     // List members
     const res = await request.get(`${BASE_URL}/api/v1/boards/${boardId}/members`, {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: { Authorization: `Bearer ${owner.token}` },
     });
     const body = await res.json();
     expect(Array.isArray(body.data)).toBe(true);
-    expect(body.data.some((m: { userId?: string }) => m.userId === 'user-2')).toBe(true);
+    expect(body.data.some((m: { user_id?: string }) => m.user_id === member.userId)).toBe(true);
   });
 
   test('POST /boards/:id/members adds/updates member idempotently', async ({ request }) => {
-    const { token } = await registerAndLogin(request, 'post');
-    const wsId = await createWorkspace(request, token);
-    const boardId = await createBoard(request, token, wsId);
+    const owner = await registerAndLogin(request, 'post');
+    const wsId = await createWorkspace(request, owner.token);
+    const boardId = await createBoard(request, owner.token, wsId);
+
+    const member = await registerAndLogin(request, 'post2');
+    const addWs = await addWorkspaceMember(request, owner.token, wsId, member.email);
+    expect(addWs.status()).toBe(201);
+
     // Add member
-    await request.post(`${BASE_URL}/api/v1/boards/${boardId}/members`, {
-      headers: { Authorization: `Bearer ${token}` },
-      data: { userId: 'user-3', role: 'MEMBER' },
+    const addRes = await request.post(`${BASE_URL}/api/v1/boards/${boardId}/members`, {
+      headers: { Authorization: `Bearer ${owner.token}` },
+      data: { userId: member.userId, role: 'MEMBER' },
     });
+    expect(addRes.status()).toBe(201);
+
     // Update role idempotently
     const res = await request.post(`${BASE_URL}/api/v1/boards/${boardId}/members`, {
-      headers: { Authorization: `Bearer ${token}` },
-      data: { userId: 'user-3', role: 'ADMIN' },
+      headers: { Authorization: `Bearer ${owner.token}` },
+      data: { userId: member.userId, role: 'ADMIN' },
     });
     expect(res.status()).toBe(200);
     const body = await res.json();
@@ -72,40 +94,41 @@ test.describe('Board member API flows', () => {
   });
 
   test('PATCH /boards/:id/members/:userId changes role, rejects demotion of last ADMIN', async ({ request }) => {
-    const { token } = await registerAndLogin(request, 'patch');
-    const wsId = await createWorkspace(request, token);
-    const boardId = await createBoard(request, token, wsId);
-    // Try demoting last ADMIN
-    const res = await request.patch(`${BASE_URL}/api/v1/boards/${boardId}/members/${token}`, {
-      headers: { Authorization: `Bearer ${token}` },
+    const owner = await registerAndLogin(request, 'patch');
+    const wsId = await createWorkspace(request, owner.token);
+    const boardId = await createBoard(request, owner.token, wsId);
+
+    // The creator is the only ADMIN on the board; demoting them must be rejected.
+    const res = await request.patch(`${BASE_URL}/api/v1/boards/${boardId}/members/${owner.userId}`, {
+      headers: { Authorization: `Bearer ${owner.token}` },
       data: { role: 'MEMBER' },
     });
     expect([409, 403]).toContain(res.status());
     const body = await res.json();
-    expect(body.name).toMatch(/last-admin/);
+    expect(body.name).toMatch(/last-board-admin/);
   });
 
   test('DELETE /boards/:id/members/:userId removes member, rejects removal of last ADMIN', async ({ request }) => {
-    const { token } = await registerAndLogin(request, 'delete');
-    const wsId = await createWorkspace(request, token);
-    const boardId = await createBoard(request, token, wsId);
-    // Try removing last ADMIN
-    const res = await request.delete(`${BASE_URL}/api/v1/boards/${boardId}/members/${token}`, {
-      headers: { Authorization: `Bearer ${token}` },
+    const owner = await registerAndLogin(request, 'delete');
+    const wsId = await createWorkspace(request, owner.token);
+    const boardId = await createBoard(request, owner.token, wsId);
+
+    // The creator is the only ADMIN on the board; removing them must be rejected.
+    const res = await request.delete(`${BASE_URL}/api/v1/boards/${boardId}/members/${owner.userId}`, {
+      headers: { Authorization: `Bearer ${owner.token}` },
     });
     expect([409, 403]).toContain(res.status());
     const body = await res.json();
-    expect(body.name).toMatch(/last-admin/);
+    expect(body.name).toMatch(/last-board-admin/);
   });
 
   test('Board visibility: GUESTs see only boards with guest access', async ({ request }) => {
-    const { token } = await registerAndLogin(request, 'guest');
-    const wsId = await createWorkspace(request, token);
-    const boardId = await createBoard(request, token, wsId, 'PUBLIC');
-    // Simulate GUEST role (would need to set up guest access)
-    // For now, check that PUBLIC board is visible
+    const owner = await registerAndLogin(request, 'guest');
+    const wsId = await createWorkspace(request, owner.token);
+    const boardId = await createBoard(request, owner.token, wsId, 'PUBLIC');
+    // Check that PUBLIC board is visible to the owner
     const res = await request.get(`${BASE_URL}/api/v1/workspaces/${wsId}/boards`, {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: { Authorization: `Bearer ${owner.token}` },
     });
     const body = await res.json();
     expect(body.data.some((b: { id?: string }) => b.id === boardId)).toBe(true);


### PR DESCRIPTION
## Summary

The `board-members.spec.ts` used fake user IDs (`user-2`/`user-3`, and the JWT as `:userId`) that aren't workspace members, so the API correctly returned 422/404. It also asserted the wrong response field (`userId` vs `user_id`) and error name (`last-admin` vs `last-board-admin`).

## Changes (test-only)

- Register a real second user and add them to the workspace before adding to the board (`POST /workspaces/:id/members` then `POST /boards/:id/members`)
- Use the creator's real `user.id` for the last-ADMIN PATCH/DELETE guards
- Assert `user_id` (GET response shape) and `last-board-admin` error name

## Verification

- All 5 tests pass
- ESLint clean

Test-only; no product behaviour altered.