### PR TITLE
fix(e2e): otel-metrics 400 tests respect OTEL_ENABLED

### DIFF
--- a/tests/e2e/otel-metrics.spec.ts
+++ b/tests/e2e/otel-metrics.spec.ts
@@ -51,18 +51,22 @@ test.describe('POST /api/v1/metrics/propagation', () => {
     expect(res.status()).toBe(204);
   });
 
-  test('returns 400 when delayMs is missing', async ({ request }) => {
+  test('returns 400 when delayMs is missing (OTEL enabled)', async ({ request }) => {
+    // The endpoint only validates the body (and returns 400) when OTEL_ENABLED=true.
+    // When OTEL is off it returns 204 regardless (documented contract).
+    const expected = process.env.OTEL_ENABLED === 'true' ? 400 : 204;
     const res = await request.post(`${BASE_URL}/api/v1/metrics/propagation`, {
       data: {},
     });
-    expect(res.status()).toBe(400);
+    expect(res.status()).toBe(expected);
   });
 
-  test('returns 400 when delayMs is negative', async ({ request }) => {
+  test('returns 400 when delayMs is negative (OTEL enabled)', async ({ request }) => {
+    const expected = process.env.OTEL_ENABLED === 'true' ? 400 : 204;
     const res = await request.post(`${BASE_URL}/api/v1/metrics/propagation`, {
       data: { delayMs: -1 },
     });
-    expect(res.status()).toBe(400);
+    expect(res.status()).toBe(expected);
   });
 
   test('returns 400 when body is invalid JSON text', async ({ request }) => {


### PR DESCRIPTION
## Summary

The propagation endpoint only validates the body (returns 400) when `OTEL_ENABLED=true`; when OTEL is off it returns 204 regardless (documented contract). The missing/negative `delayMs` tests hard-coded 400, failing under the local default (`OTEL_ENABLED=false`).

## Change (test-only)

Assert 400 when `OTEL_ENABLED=true`, 204 otherwise.

## Verification

- All 6 tests pass
- ESLint clean

Test-only; no product behaviour altered.