### PR TITLE
fix(e2e): UI specs navigate to UI server and correct board route

### DIFF
--- a/tests/e2e/attachment-upload.spec.ts
+++ b/tests/e2e/attachment-upload.spec.ts
@@ -211,7 +211,7 @@ test.describe('Attachment Upload', () => {
 
     await page.goto(UI_URL);
     await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
-    await page.goto(`${UI_URL}/boards/${boardId}`);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     // Open card modal
@@ -269,7 +269,7 @@ test.describe('Attachment Upload', () => {
 
     await page.goto(UI_URL);
     await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
-    await page.goto(`${UI_URL}/boards/${boardId}`);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     const cardEl = page.locator(`[data-card-id="${uiCardId}"], [data-testid="card-${uiCardId}"]`).first();

--- a/tests/e2e/card-description-inline-edit.spec.ts
+++ b/tests/e2e/card-description-inline-edit.spec.ts
@@ -30,7 +30,7 @@ test.describe('Card Description — Inline Click-to-Edit', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(UI_URL);
     await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
-    await page.goto(`${UI_URL}/boards/${boardId}`);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     // Open the card modal
@@ -162,7 +162,7 @@ test.describe('Card Description — Inline Click-to-Edit', () => {
     const lId = await createList(request, token, bId);
     await createCard(request, token, lId, 'No Description Card');
 
-    await page.goto(`${UI_URL}/boards/${bId}`);
+    await page.goto(`${UI_URL}/b/${bId}`);
     await page.waitForLoadState('networkidle');
     await page.locator('[data-testid="card-tile"], .card-tile, [class*="card"]').first().click();
     await page.waitForSelector('[data-testid="card-modal"], [role="dialog"]', { timeout: 8000 });

--- a/tests/e2e/custom-fields-board-panel.spec.ts
+++ b/tests/e2e/custom-fields-board-panel.spec.ts
@@ -22,7 +22,7 @@ async function setupBoardAndNavigate(
     ({ t }: { t: string }) => localStorage.setItem('auth_token', t),
     { t: token },
   );
-  await page.goto(`${UI_URL}/boards/${boardId}`);
+  await page.goto(`${UI_URL}/b/${boardId}`);
   await page.waitForLoadState('networkidle');
 
   return { token, boardId };

--- a/tests/e2e/custom-fields-ui.spec.ts
+++ b/tests/e2e/custom-fields-ui.spec.ts
@@ -23,7 +23,7 @@ async function setupBoardWithCard(request: APIRequestContext, page: import('@pla
 
   await page.goto(`${UI_URL}`);
   await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
-  await page.goto(`${UI_URL}/boards/${boardId}`);
+  await page.goto(`${UI_URL}/b/${boardId}`);
   await page.waitForLoadState('networkidle');
 
   return { token, boardId, cardId };

--- a/tests/e2e/delete-confirmation.spec.ts
+++ b/tests/e2e/delete-confirmation.spec.ts
@@ -123,7 +123,7 @@ test.describe('Delete Confirmation Flag', () => {
 
     await page.goto(UI_URL);
     await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
-    await page.goto(`${UI_URL}/boards/${boardId}`);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     // Open board settings / action menu
@@ -160,7 +160,7 @@ test.describe('Delete Confirmation Flag', () => {
 
     await page.goto(UI_URL);
     await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
-    await page.goto(`${UI_URL}/boards/${boardId}`);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     const settingsBtn = page.locator(
@@ -194,7 +194,7 @@ test.describe('Delete Confirmation Flag', () => {
 
     await page.goto(UI_URL);
     await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
-    await page.goto(`${UI_URL}/boards/${boardId}`);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     // Open list action menu
@@ -227,7 +227,7 @@ test.describe('Delete Confirmation Flag', () => {
 
     await page.goto(UI_URL);
     await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
-    await page.goto(`${UI_URL}/boards/${boardId}`);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     const listMenu = page.locator('[data-testid="list-menu"], [aria-label*="list menu"], button[title*="list"]').first();

--- a/tests/e2e/list-management.spec.ts
+++ b/tests/e2e/list-management.spec.ts
@@ -150,7 +150,7 @@ test.describe('List Management', () => {
 
     await page.goto(UI_URL);
     await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
-    await page.goto(`${UI_URL}/boards/${boardId}`);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     const addListBtn = page.locator(
@@ -199,7 +199,7 @@ test.describe('List Management', () => {
 
     await page.goto(UI_URL);
     await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
-    await page.goto(`${UI_URL}/boards/${boardId}`);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     // Find any editable list header
@@ -243,7 +243,7 @@ test.describe('List Management', () => {
 
     await page.goto(UI_URL);
     await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
-    await page.goto(`${UI_URL}/boards/${boardId}`);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     const lists = page.locator(

--- a/tests/e2e/notification-type-prefs.spec.ts
+++ b/tests/e2e/notification-type-prefs.spec.ts
@@ -42,7 +42,7 @@ async function goToBoard(page: Page, boardId: string, creds: Credentials) {
   await page.fill('input[type="password"]', creds.password);
   await page.click('button[type="submit"]');
   await page.waitForURL(`${UI_URL}/workspaces**`, { timeout: 15000 });
-  await page.goto(`${UI_URL}/boards/${boardId}`);
+  await page.goto(`${UI_URL}/b/${boardId}`);
   await page.waitForLoadState('networkidle');
 }
 

--- a/tests/e2e/offline-queue-persistence.spec.ts
+++ b/tests/e2e/offline-queue-persistence.spec.ts
@@ -10,6 +10,7 @@
 import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
 
 const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:3000';
+const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 const DB_NAME = 'kanban-offline-queue';
 const STORE = 'mutations';
 
@@ -122,7 +123,7 @@ async function readMutationsFromIDB(page: Page): Promise<unknown[]> {
 
 /** Log in via the UI login form so auth cookies/tokens are set. */
 async function loginViaUi(page: Page, email: string, password: string): Promise<void> {
-  await page.goto(`${BASE_URL}/login`);
+  await page.goto(`${UI_URL}/login`);
   await page.getByLabel(/email/i).fill(email);
   await page.getByLabel(/password/i).fill(password);
   await page.getByRole('button', { name: /log in|sign in/i }).click();
@@ -145,7 +146,7 @@ test.describe('offline mutation queue — IndexedDB persistence', () => {
 
     // Navigate to app first so the origin is established, then seed IDB
     await loginViaUi(page, email, password);
-    await page.goto(`${BASE_URL}/boards/${boardId}`, { waitUntil: 'domcontentloaded' });
+    await page.goto(`${UI_URL}/b/${boardId}`, { waitUntil: 'domcontentloaded' });
 
     const mutationId = `test-hydrate-${Date.now()}`;
     const mutation = {
@@ -186,7 +187,7 @@ test.describe('offline mutation queue — IndexedDB persistence', () => {
     const boardId = await createBoard(request, token, workspaceId);
 
     await loginViaUi(page, email, password);
-    await page.goto(`${BASE_URL}/boards/${boardId}`, { waitUntil: 'domcontentloaded' });
+    await page.goto(`${UI_URL}/b/${boardId}`, { waitUntil: 'domcontentloaded' });
 
     const listTitle = `Replayed-List-${Date.now()}`;
     const mutationId = `test-replay-${Date.now()}`;
@@ -211,7 +212,7 @@ test.describe('offline mutation queue — IndexedDB persistence', () => {
     );
 
     // Navigate to the board page so the WS connects and replay is triggered
-    await page.goto(`${BASE_URL}/boards/${boardId}`, { waitUntil: 'networkidle' });
+    await page.goto(`${UI_URL}/b/${boardId}`, { waitUntil: 'networkidle' });
 
     // Verify the replay HTTP call was made
     const replayed = await replayRequest;

--- a/tests/e2e/payment-card-price.spec.ts
+++ b/tests/e2e/payment-card-price.spec.ts
@@ -253,7 +253,7 @@ test.describe('Payment — Card Price', () => {
 
     await page.goto(UI_URL);
     await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
-    await page.goto(`${UI_URL}/boards/${boardId}`);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     // A price badge or money indicator should be visible on the card
@@ -292,7 +292,7 @@ test.describe('Payment — Card Price', () => {
 
     await page.goto(UI_URL);
     await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
-    await page.goto(`${UI_URL}/boards/${boardId}`);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     // Price badge should not be visible when monetisation is off

--- a/tests/e2e/presence-board.spec.ts
+++ b/tests/e2e/presence-board.spec.ts
@@ -154,7 +154,7 @@ test.describe('Board Presence', () => {
       // User A navigates to the board
       await pageA.goto(UI_URL);
       await pageA.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: tokenA });
-      await pageA.goto(`${UI_URL}/boards/${boardId}`);
+      await pageA.goto(`${UI_URL}/b/${boardId}`);
       await pageA.waitForLoadState('networkidle');
 
       // Verify User A can see the board (soft-skip if board page not found)
@@ -167,7 +167,7 @@ test.describe('Board Presence', () => {
       // User B navigates to the same board in a separate context
       await pageB.goto(UI_URL);
       await pageB.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: tokenB });
-      await pageB.goto(`${UI_URL}/boards/${boardId}`);
+      await pageB.goto(`${UI_URL}/b/${boardId}`);
       await pageB.waitForLoadState('networkidle');
 
       // Give WebSocket / polling-based presence a moment to propagate

--- a/tests/e2e/search-filters.spec.ts
+++ b/tests/e2e/search-filters.spec.ts
@@ -119,7 +119,7 @@ test.describe('Search Filters', () => {
 
     await page.goto(UI_URL);
     await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
-    await page.goto(`${UI_URL}/boards/${boardId}`);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     // Locate the search input — try common selectors
@@ -153,7 +153,7 @@ test.describe('Search Filters', () => {
 
     await page.goto(UI_URL);
     await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
-    await page.goto(`${UI_URL}/boards/${boardId}`);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     // Locate a type-filter control — button or select

--- a/tests/e2e/table-view.spec.ts
+++ b/tests/e2e/table-view.spec.ts
@@ -9,6 +9,7 @@
 import { test, expect, type APIRequestContext } from '@playwright/test';
 
 const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:3000';
+const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -89,19 +90,19 @@ test.describe('Table View', () => {
     });
 
     // Log in via the UI
-    await page.goto(`${BASE_URL}/login`);
+    await page.goto(`${UI_URL}/login`);
     await page.fill('input[type="email"]', `tv-test-headers-${Date.now() - 100}@example.com`);
 
     // Re-login properly using API token in localStorage
     await page.evaluate(
       ([url, tok]) => {
         localStorage.setItem('access_token', tok as string);
-        window.location.href = `${url}/boards/${(tok as string).slice(-8)}`;
+        window.location.href = `${url}/b/${(tok as string).slice(-8)}`;
       },
       [BASE_URL, token],
     );
 
-    await page.goto(`${BASE_URL}/boards/${board.id}`);
+    await page.goto(`${UI_URL}/b/${board.id}`);
     await page.waitForLoadState('networkidle');
 
     // BoardViewSwitcher should be visible
@@ -127,7 +128,7 @@ test.describe('Table View', () => {
     const listId = await createList(request, token, board.id, 'Backlog');
     const cardId = await createCard(request, token, listId, 'My test card');
 
-    await page.goto(`${BASE_URL}/boards/${board.id}`);
+    await page.goto(`${UI_URL}/b/${board.id}`);
     await page.waitForLoadState('networkidle');
 
     // Switch to TABLE view via the switcher
@@ -148,7 +149,7 @@ test.describe('Table View', () => {
     await createCard(request, token, listId, 'Zebra card');
     await createCard(request, token, listId, 'Alpha card');
 
-    await page.goto(`${BASE_URL}/boards/${board.id}`);
+    await page.goto(`${UI_URL}/b/${board.id}`);
     await page.waitForLoadState('networkidle');
     await page.getByTestId('board-view-tab-TABLE').click();
     await expect(page.getByTestId('table-view')).toBeVisible();
@@ -175,7 +176,7 @@ test.describe('Table View', () => {
     const listId = await createList(request, token, board.id, 'Sprint');
     const cardId = await createCard(request, token, listId, 'Open me please');
 
-    await page.goto(`${BASE_URL}/boards/${board.id}`);
+    await page.goto(`${UI_URL}/b/${board.id}`);
     await page.waitForLoadState('networkidle');
     await page.getByTestId('board-view-tab-TABLE').click();
     await expect(page.getByTestId('table-view')).toBeVisible();

--- a/tests/e2e/table-view.spec.ts
+++ b/tests/e2e/table-view.spec.ts
@@ -99,7 +99,7 @@ test.describe('Table View', () => {
         localStorage.setItem('access_token', tok as string);
         window.location.href = `${url}/b/${(tok as string).slice(-8)}`;
       },
-      [BASE_URL, token],
+      [UI_URL, token],
     );
 
     await page.goto(`${UI_URL}/b/${board.id}`);

--- a/tests/e2e/timeline-bar.spec.ts
+++ b/tests/e2e/timeline-bar.spec.ts
@@ -11,6 +11,7 @@
 import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
 
 const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:3000';
+const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -84,7 +85,7 @@ async function goToTimelineView(page: Page, baseUrl: string, boardId: string, cr
   await page.fill('input[type="password"]', creds.password);
   await page.click('button[type="submit"]');
   await page.waitForURL(`${baseUrl}/workspaces**`, { timeout: 15000 });
-  await page.goto(`${baseUrl}/boards/${boardId}`);
+  await page.goto(`${baseUrl}/b/${boardId}`);
   await page.waitForLoadState('networkidle');
   await page.getByTestId('board-view-tab-TIMELINE').click();
   await expect(page.getByTestId('timeline-view')).toBeVisible({ timeout: 10000 });
@@ -104,7 +105,7 @@ test.describe('Timeline Bar Rendering', () => {
       due_date: offsetDate(4),
     });
 
-    await goToTimelineView(page, BASE_URL, board.id, creds);
+    await goToTimelineView(page, UI_URL, board.id, creds);
 
     // Bar should be rendered inside the correct swimlane
     const barArea = page.getByTestId(`timeline-bar-area-${listId}`);
@@ -128,7 +129,7 @@ test.describe('Timeline Bar Rendering', () => {
       due_date: offsetDate(6),
     });
 
-    await goToTimelineView(page, BASE_URL, board.id, creds);
+    await goToTimelineView(page, UI_URL, board.id, creds);
 
     await expect(page.getByTestId(`timeline-bar-resize-left-${cardId}`)).toBeVisible();
     await expect(page.getByTestId(`timeline-bar-resize-right-${cardId}`)).toBeVisible();
@@ -145,7 +146,7 @@ test.describe('Timeline Bar Rendering', () => {
       due_date: offsetDate(7),
     });
 
-    await goToTimelineView(page, BASE_URL, board.id, creds);
+    await goToTimelineView(page, UI_URL, board.id, creds);
 
     const bar = page.getByTestId(`timeline-bar-${cardId}`);
     await expect(bar).toContainText('My Task Title');
@@ -162,7 +163,7 @@ test.describe('Timeline Bar Rendering', () => {
     await patchCard(request, creds.token, cardId1, { start_date: offsetDate(-2), due_date: offsetDate(3) });
     await patchCard(request, creds.token, cardId2, { start_date: offsetDate(1), due_date: offsetDate(5) });
 
-    await goToTimelineView(page, BASE_URL, board.id, creds);
+    await goToTimelineView(page, UI_URL, board.id, creds);
 
     // Both bars should be visible in their respective swimlanes
     await expect(page.getByTestId(`timeline-bar-${cardId1}`)).toBeVisible();
@@ -177,7 +178,7 @@ test.describe('Timeline Bar Rendering', () => {
     const cardId = await createCard(request, creds.token, listId, 'NoDatesCard');
     // Intentionally no dates
 
-    await goToTimelineView(page, BASE_URL, board.id, creds);
+    await goToTimelineView(page, UI_URL, board.id, creds);
 
     // Should NOT have a bar
     await expect(page.getByTestId(`timeline-bar-${cardId}`)).not.toBeVisible();

--- a/tests/e2e/timeline-drag.spec.ts
+++ b/tests/e2e/timeline-drag.spec.ts
@@ -9,6 +9,7 @@
 import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
 
 const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:3000';
+const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -90,7 +91,7 @@ async function goToTimelineView(page: Page, baseUrl: string, boardId: string, cr
   await page.fill('input[type="password"]', creds.password);
   await page.click('button[type="submit"]');
   await page.waitForURL(`${baseUrl}/workspaces**`, { timeout: 15000 });
-  await page.goto(`${baseUrl}/boards/${boardId}`);
+  await page.goto(`${baseUrl}/b/${boardId}`);
   await page.waitForLoadState('networkidle');
   await page.getByTestId('board-view-tab-TIMELINE').click();
   await expect(page.getByTestId('timeline-view')).toBeVisible({ timeout: 10000 });
@@ -127,7 +128,7 @@ test.describe('Timeline Drag / Resize', () => {
     const dueDate = offsetDate(3);
     await patchCard(request, creds.token, cardId, { start_date: startDate, due_date: dueDate });
 
-    await goToTimelineView(page, BASE_URL, board.id, creds);
+    await goToTimelineView(page, UI_URL, board.id, creds);
 
     // Intercept the PATCH request so we can verify it is made.
     const patchPromise = page.waitForRequest(
@@ -155,7 +156,7 @@ test.describe('Timeline Drag / Resize', () => {
     const dueDate = offsetDate(5);
     await patchCard(request, creds.token, cardId, { start_date: startDate, due_date: dueDate });
 
-    await goToTimelineView(page, BASE_URL, board.id, creds);
+    await goToTimelineView(page, UI_URL, board.id, creds);
 
     const patchPromise = page.waitForRequest(
       (req) => req.method() === 'PATCH' && req.url().includes(`/cards/${cardId}`),
@@ -182,7 +183,7 @@ test.describe('Timeline Drag / Resize', () => {
     const dueDate = offsetDate(6);
     await patchCard(request, creds.token, cardId, { start_date: startDate, due_date: dueDate });
 
-    await goToTimelineView(page, BASE_URL, board.id, creds);
+    await goToTimelineView(page, UI_URL, board.id, creds);
 
     const patchPromise = page.waitForRequest(
       (req) => req.method() === 'PATCH' && req.url().includes(`/cards/${cardId}`),
@@ -224,7 +225,7 @@ test.describe('Timeline Drag / Resize', () => {
     const dueDate = offsetDate(4);
     await patchCard(request, creds.token, cardId, { start_date: startDate, due_date: dueDate });
 
-    await goToTimelineView(page, BASE_URL, board.id, creds);
+    await goToTimelineView(page, UI_URL, board.id, creds);
 
     // Intercept the PATCH and force a 500 error.
     await page.route(`**/api/v1/cards/${cardId}`, (route) => {


### PR DESCRIPTION
## Summary

14 UI specs used `BASE_URL` (the API server, 3000) for `page.goto`, so the browser hit the API's `/login` (404) and never rendered the login form — every UI test timed out. They also navigated to `/boards/:id`, but the board detail route is `/b/:id` (no `/boards/:id` route exists; falls to NotFound).

## Changes (test-only)

- Add `UI_URL` (`TEST_UI_URL`, 5173) where missing and use it for page navigation
- Navigate to `/b/:boardId` instead of `/boards/:boardId`

## Verification

- Unblocks timeline-bar from 0 to 4 passing
- ESLint clean on all 14 files

Test-only; no product behaviour altered.