### PR TITLE
fix(e2e): use register token directly to avoid login rate limit

### DIFF
--- a/tests/e2e/calendar-view.spec.ts
+++ b/tests/e2e/calendar-view.spec.ts
@@ -20,13 +20,12 @@ interface Credentials { email: string; password: string; token: string }
 async function registerAndLogin(request: APIRequestContext, suffix: string): Promise<Credentials> {
   const email = `cv-test-${suffix}-${Date.now()}@journeyh.io`;
   const password = 'TestPassword1!';
-  await request.post(`${BASE_URL}/api/v1/auth/register`, {
+  const regRes = await request.post(`${BASE_URL}/api/v1/auth/register`, {
     data: { email, password, name: `CV ${suffix}` },
   });
-  const loginRes = await request.post(`${BASE_URL}/api/v1/auth/token`, {
-    data: { email, password },
-  });
-  const body = await loginRes.json() as { data: { accessToken: string } };
+  // Register returns an accessToken directly (201); avoid a separate login call
+  // which is rate-limited (10/IP/min) and would 429 under the full suite.
+  const body = await regRes.json() as { data: { accessToken: string } };
   return { email, password, token: body.data.accessToken };
 }
 

--- a/tests/e2e/notification-type-prefs.spec.ts
+++ b/tests/e2e/notification-type-prefs.spec.ts
@@ -8,13 +8,12 @@ interface Credentials { email: string; password: string; token: string }
 async function registerAndLogin(request: APIRequestContext, suffix: string): Promise<Credentials> {
   const email = `ntp-test-${suffix}-${Date.now()}@journeyh.io`;
   const password = 'TestPassword1!';
-  await request.post(`${API_URL}/api/v1/auth/register`, {
+  const regRes = await request.post(`${API_URL}/api/v1/auth/register`, {
     data: { email, password, name: `NTP ${suffix}` },
   });
-  const loginRes = await request.post(`${API_URL}/api/v1/auth/token`, {
-    data: { email, password },
-  });
-  const body = await loginRes.json() as { data: { accessToken: string } };
+  // Register returns an accessToken directly (201); avoid a separate login call
+  // which is rate-limited (10/IP/min) and would 429 under the full suite.
+  const body = await regRes.json() as { data: { accessToken: string } };
   return { email, password, token: body.data.accessToken };
 }
 

--- a/tests/e2e/timeline-bar.spec.ts
+++ b/tests/e2e/timeline-bar.spec.ts
@@ -20,13 +20,12 @@ interface Credentials { email: string; password: string; token: string }
 async function registerAndLogin(request: APIRequestContext, suffix: string): Promise<Credentials> {
   const email = `tb-test-${suffix}-${Date.now()}@journeyh.io`;
   const password = 'TestPassword1!';
-  await request.post(`${BASE_URL}/api/v1/auth/register`, {
+  const regRes = await request.post(`${BASE_URL}/api/v1/auth/register`, {
     data: { email, password, name: `TB ${suffix}` },
   });
-  const loginRes = await request.post(`${BASE_URL}/api/v1/auth/token`, {
-    data: { email, password },
-  });
-  const body = await loginRes.json() as { data: { accessToken: string } };
+  // Register returns an accessToken directly (201); avoid a separate login call
+  // which is rate-limited (10/IP/min) and would 429 under the full suite.
+  const body = await regRes.json() as { data: { accessToken: string } };
   return { email, password, token: body.data.accessToken };
 }
 

--- a/tests/e2e/timeline-drag.spec.ts
+++ b/tests/e2e/timeline-drag.spec.ts
@@ -18,13 +18,12 @@ interface Credentials { email: string; password: string; token: string }
 async function registerAndLogin(request: APIRequestContext, suffix: string): Promise<Credentials> {
   const email = `td-test-${suffix}-${Date.now()}@journeyh.io`;
   const password = 'TestPassword1!';
-  await request.post(`${BASE_URL}/api/v1/auth/register`, {
+  const regRes = await request.post(`${BASE_URL}/api/v1/auth/register`, {
     data: { email, password, name: `TD ${suffix}` },
   });
-  const loginRes = await request.post(`${BASE_URL}/api/v1/auth/token`, {
-    data: { email, password },
-  });
-  const body = await loginRes.json() as { data: { accessToken: string } };
+  // Register returns an accessToken directly (201); avoid a separate login call
+  // which is rate-limited (10/IP/min) and would 429 under the full suite.
+  const body = await regRes.json() as { data: { accessToken: string } };
   return { email, password, token: body.data.accessToken };
 }
 

--- a/tests/e2e/timeline-view.spec.ts
+++ b/tests/e2e/timeline-view.spec.ts
@@ -21,13 +21,12 @@ interface Credentials { email: string; password: string; token: string }
 async function registerAndLogin(request: APIRequestContext, suffix: string): Promise<Credentials> {
   const email = `tv-test-${suffix}-${Date.now()}@journeyh.io`;
   const password = 'TestPassword1!';
-  await request.post(`${BASE_URL}/api/v1/auth/register`, {
+  const regRes = await request.post(`${BASE_URL}/api/v1/auth/register`, {
     data: { email, password, name: `TV ${suffix}` },
   });
-  const loginRes = await request.post(`${BASE_URL}/api/v1/auth/token`, {
-    data: { email, password },
-  });
-  const body = await loginRes.json() as { data: { accessToken: string } };
+  // Register returns an accessToken directly (201); avoid a separate login call
+  // which is rate-limited (10/IP/min) and would 429 under the full suite.
+  const body = await regRes.json() as { data: { accessToken: string } };
   return { email, password, token: body.data.accessToken };
 }
 


### PR DESCRIPTION
## Summary

5 specs did a separate `POST /auth/token` login call after register, which hits the login rate limit (10/IP/min) and 429s under the full suite — `body.data` is undefined, so reading `accessToken` throws. Register returns an accessToken directly (201), so the redundant login call is dropped.

## Changes (test-only)

- calendar-view, timeline-view, timeline-drag, timeline-bar, notification-type-prefs: capture token from register response instead of a separate login call

## Verification

- Unblocks calendar-view from 0 to 6 passing
- ESLint clean on all 5 files

Test-only; no product behaviour altered.