### PR TITLE
fix(e2e): log in via UI form instead of localStorage token injection

### DIFF
--- a/tests/e2e/_helpers.ts
+++ b/tests/e2e/_helpers.ts
@@ -73,3 +73,39 @@ export async function createCard(
   const body = await res.json() as { data: { id: string } };
   return body.data.id;
 }
+
+export interface Credentials {
+  email: string;
+  password: string;
+  token: string;
+}
+
+// Register a user and return credentials (email/password/token). The app
+// authenticates the browser via HttpOnly cookies set by the login/register
+// response, so UI specs must log in through the form (not localStorage).
+export async function registerAndGetCredentials(
+  request: APIRequestContext,
+  suffix: string,
+): Promise<Credentials> {
+  const email = `e2e-${suffix}-${Date.now()}@example.com`;
+  const password = 'TestPassword1!';
+  const regRes = await request.post(`${BASE_URL}/api/v1/auth/register`, {
+    data: { email, password, name: `Test ${suffix}` },
+  });
+  const body = await regRes.json() as { data: { accessToken: string } };
+  return { email, password, token: body.data.accessToken };
+}
+
+// Log in through the UI login form so the browser receives the HttpOnly
+// auth cookies. The app does not persist auth to localStorage.
+export async function loginViaUi(
+  page: import('@playwright/test').Page,
+  uiUrl: string,
+  creds: Credentials,
+): Promise<void> {
+  await page.goto(`${uiUrl}/login`);
+  await page.fill('input[type="email"]', creds.email);
+  await page.fill('input[type="password"]', creds.password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL(`${uiUrl}/workspaces**`, { timeout: 15000 });
+}

--- a/tests/e2e/attachment-upload.spec.ts
+++ b/tests/e2e/attachment-upload.spec.ts
@@ -5,11 +5,12 @@
 // Based on: specs/tests/attachment-upload.md
 
 import { test, expect } from '@playwright/test';
-import { BASE_URL, registerAndLogin, createWorkspace, createBoard, createList, createCard } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaUi, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 test.describe('Attachment Upload', () => {
+  let creds: Credentials;
   let token: string;
   let cardId: string;
 
@@ -20,7 +21,8 @@ test.describe('Attachment Upload', () => {
       return;
     }
 
-    token = await registerAndLogin(request, 'attach');
+    creds = await registerAndGetCredentials(request, 'attach');
+    token = creds.token;
     const workspaceId = await createWorkspace(request, token);
     const boardId = await createBoard(request, token, workspaceId);
     const listId = await createList(request, token, boardId);
@@ -209,8 +211,7 @@ test.describe('Attachment Upload', () => {
     const listId = await createList(request, token, boardId);
     const uiCardId = await createCard(request, token, listId, 'UI Attachment Card');
 
-    await page.goto(UI_URL);
-    await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
+    await loginViaUi(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -267,8 +268,7 @@ test.describe('Attachment Upload', () => {
       data: { url: 'https://example.com/report.pdf', name: 'report.pdf' },
     });
 
-    await page.goto(UI_URL);
-    await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
+    await loginViaUi(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 

--- a/tests/e2e/card-description-inline-edit.spec.ts
+++ b/tests/e2e/card-description-inline-edit.spec.ts
@@ -4,17 +4,19 @@
 // Based on: tests/e2e/card-description-inline-edit.md (now deleted)
 
 import { test, expect } from '@playwright/test';
-import { BASE_URL, registerAndLogin, createWorkspace, createBoard, createList, createCard } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaUi, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 test.describe('Card Description — Inline Click-to-Edit', () => {
+  let creds: Credentials;
   let token: string;
   let boardId: string;
   let cardId: string;
 
   test.beforeAll(async ({ request }) => {
-    token = await registerAndLogin(request, 'desc-edit');
+    creds = await registerAndGetCredentials(request, 'desc-edit');
+    token = creds.token;
     const wsId = await createWorkspace(request, token);
     boardId = await createBoard(request, token, wsId);
     const listId = await createList(request, token, boardId);
@@ -28,8 +30,7 @@ test.describe('Card Description — Inline Click-to-Edit', () => {
   });
 
   test.beforeEach(async ({ page }) => {
-    await page.goto(UI_URL);
-    await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
+    await loginViaUi(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 

--- a/tests/e2e/custom-fields-board-panel.spec.ts
+++ b/tests/e2e/custom-fields-board-panel.spec.ts
@@ -4,28 +4,24 @@
 // Based on: tests/e2e/custom-fields-board-panel.md (now deleted)
 
 import { test, expect, type APIRequestContext } from '@playwright/test';
-import { BASE_URL, registerAndLogin, createWorkspace, createBoard } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, loginViaUi, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 async function setupBoardAndNavigate(
   request: APIRequestContext,
   page: import('@playwright/test').Page,
-): Promise<{ token: string; boardId: string }> {
-  const token = await registerAndLogin(request, 'cf-panel');
-  const wsId = await createWorkspace(request, token);
-  const boardId = await createBoard(request, token, wsId);
+): Promise<{ creds: Credentials; boardId: string }> {
+  const creds = await registerAndGetCredentials(request, 'cf-panel');
+  const wsId = await createWorkspace(request, creds.token);
+  const boardId = await createBoard(request, creds.token, wsId);
 
-  // Navigate to the board using the API token via cookie/localStorage auth
-  await page.goto(`${UI_URL}`);
-  await page.evaluate(
-    ({ t }: { t: string }) => localStorage.setItem('auth_token', t),
-    { t: token },
-  );
+  // The app authenticates via HttpOnly cookies, so log in through the UI form.
+  await loginViaUi(page, UI_URL, creds);
   await page.goto(`${UI_URL}/b/${boardId}`);
   await page.waitForLoadState('networkidle');
 
-  return { token, boardId };
+  return { creds, boardId };
 }
 
 test.describe('Custom Fields Board Settings Panel', () => {

--- a/tests/e2e/custom-fields-ui.spec.ts
+++ b/tests/e2e/custom-fields-ui.spec.ts
@@ -4,29 +4,29 @@
 // Based on: tests/e2e/custom-fields-ui.md (now deleted)
 
 import { test, expect, type APIRequestContext } from '@playwright/test';
-import { BASE_URL, registerAndLogin, createWorkspace, createBoard, createList, createCard } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaUi, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 interface SetupResult {
-  token: string;
+  creds: Credentials;
   boardId: string;
   cardId: string;
 }
 
 async function setupBoardWithCard(request: APIRequestContext, page: import('@playwright/test').Page): Promise<SetupResult> {
-  const token = await registerAndLogin(request, 'cf-ui');
-  const wsId = await createWorkspace(request, token);
-  const boardId = await createBoard(request, token, wsId);
-  const listId = await createList(request, token, boardId);
-  const cardId = await createCard(request, token, listId, 'CF UI Test Card');
+  const creds = await registerAndGetCredentials(request, 'cf-ui');
+  const wsId = await createWorkspace(request, creds.token);
+  const boardId = await createBoard(request, creds.token, wsId);
+  const listId = await createList(request, creds.token, boardId);
+  const cardId = await createCard(request, creds.token, listId, 'CF UI Test Card');
 
-  await page.goto(`${UI_URL}`);
-  await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
+  // The app authenticates via HttpOnly cookies, so log in through the UI form.
+  await loginViaUi(page, UI_URL, creds);
   await page.goto(`${UI_URL}/b/${boardId}`);
   await page.waitForLoadState('networkidle');
 
-  return { token, boardId, cardId };
+  return { creds, boardId, cardId };
 }
 
 async function createFieldViaApi(

--- a/tests/e2e/delete-confirmation.spec.ts
+++ b/tests/e2e/delete-confirmation.spec.ts
@@ -5,16 +5,18 @@
 // Based on: tests/e2e/delete-confirmation.md (now deleted)
 
 import { test, expect } from '@playwright/test';
-import { BASE_URL, registerAndLogin, createWorkspace, createBoard, createList, createCard } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaUi, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 test.describe('Delete Confirmation Flag', () => {
+  let creds: Credentials;
   let token: string;
   let workspaceId: string;
 
   test.beforeAll(async ({ request }) => {
-    token = await registerAndLogin(request, 'del-confirm');
+    creds = await registerAndGetCredentials(request, 'del-confirm');
+    token = creds.token;
     workspaceId = await createWorkspace(request, token);
   });
 
@@ -121,8 +123,7 @@ test.describe('Delete Confirmation Flag', () => {
     const boardId = await createBoard(request, token, workspaceId);
     await createList(request, token, boardId);
 
-    await page.goto(UI_URL);
-    await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
+    await loginViaUi(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -158,8 +159,7 @@ test.describe('Delete Confirmation Flag', () => {
     const boardId = await createBoard(request, token, workspaceId);
     await createList(request, token, boardId);
 
-    await page.goto(UI_URL);
-    await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
+    await loginViaUi(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -192,8 +192,7 @@ test.describe('Delete Confirmation Flag', () => {
     const listId = await createList(request, token, boardId);
     await createCard(request, token, listId, 'Card A');
 
-    await page.goto(UI_URL);
-    await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
+    await loginViaUi(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -225,8 +224,7 @@ test.describe('Delete Confirmation Flag', () => {
     const listId = await createList(request, token, boardId);
     await createCard(request, token, listId, 'Card A');
 
-    await page.goto(UI_URL);
-    await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
+    await loginViaUi(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 

--- a/tests/e2e/list-management.spec.ts
+++ b/tests/e2e/list-management.spec.ts
@@ -4,11 +4,12 @@
 // Soft-skips when the server is not reachable.
 
 import { test, expect } from '@playwright/test';
-import { BASE_URL, registerAndLogin, createWorkspace, createBoard, createList } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, loginViaUi, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 test.describe('List Management', () => {
+  let creds: Credentials;
   let token: string;
   let boardId: string;
   const run = Date.now();
@@ -20,7 +21,8 @@ test.describe('List Management', () => {
       return;
     }
 
-    token = await registerAndLogin(request, `list-${run}`);
+    creds = await registerAndGetCredentials(request, `list-${run}`);
+    token = creds.token;
     const workspaceId = await createWorkspace(request, token);
     boardId = await createBoard(request, token, workspaceId);
   });
@@ -148,8 +150,7 @@ test.describe('List Management', () => {
   test('Test 6 — UI: Add list button creates a new list on the board', async ({ page }) => {
     if (!token) test.skip(true, 'Server not running — skipping');
 
-    await page.goto(UI_URL);
-    await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
+    await loginViaUi(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -197,8 +198,7 @@ test.describe('List Management', () => {
     const seedListId = await createList(request, token, boardId);
     void seedListId; // used implicitly via page.goto below
 
-    await page.goto(UI_URL);
-    await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
+    await loginViaUi(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -241,8 +241,7 @@ test.describe('List Management', () => {
     await createList(request, token, boardId);
     await createList(request, token, boardId);
 
-    await page.goto(UI_URL);
-    await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
+    await loginViaUi(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 

--- a/tests/e2e/payment-card-price.spec.ts
+++ b/tests/e2e/payment-card-price.spec.ts
@@ -5,11 +5,12 @@
 // Based on: specs/tests/payment-card-price.md
 
 import { test, expect } from '@playwright/test';
-import { BASE_URL, registerAndLogin, createWorkspace, createBoard, createList, createCard } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaUi, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 test.describe('Payment — Card Price', () => {
+  let creds: Credentials;
   let token: string;
   let boardId: string;
   let cardId: string;
@@ -21,7 +22,8 @@ test.describe('Payment — Card Price', () => {
       return;
     }
 
-    token = await registerAndLogin(request, 'cardprice');
+    creds = await registerAndGetCredentials(request, 'cardprice');
+    token = creds.token;
     const workspaceId = await createWorkspace(request, token);
     boardId = await createBoard(request, token, workspaceId);
     const listId = await createList(request, token, boardId);
@@ -251,8 +253,7 @@ test.describe('Payment — Card Price', () => {
       return;
     }
 
-    await page.goto(UI_URL);
-    await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
+    await loginViaUi(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -290,8 +291,7 @@ test.describe('Payment — Card Price', () => {
       return;
     }
 
-    await page.goto(UI_URL);
-    await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
+    await loginViaUi(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 

--- a/tests/e2e/presence-board.spec.ts
+++ b/tests/e2e/presence-board.spec.ts
@@ -6,11 +6,13 @@
 // Soft-skips when the server is not reachable.
 
 import { test, expect, chromium } from '@playwright/test';
-import { BASE_URL, registerAndLogin, createWorkspace, createBoard, createList } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, loginViaUi, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 test.describe('Board Presence', () => {
+  let credsA: Credentials;
+  let credsB: Credentials;
   let tokenA: string;
   let tokenB: string;
   let boardId: string;
@@ -24,13 +26,15 @@ test.describe('Board Presence', () => {
     }
 
     // User A creates the board
-    tokenA = await registerAndLogin(request, `presA-${run}`);
+    credsA = await registerAndGetCredentials(request, `presA-${run}`);
+    tokenA = credsA.token;
     const workspaceId = await createWorkspace(request, tokenA);
     boardId = await createBoard(request, tokenA, workspaceId);
     await createList(request, tokenA, boardId);
 
     // User B — a second independent user
-    tokenB = await registerAndLogin(request, `presB-${run}`);
+    credsB = await registerAndGetCredentials(request, `presB-${run}`);
+    tokenB = credsB.token;
   });
 
   test('Test 1 — GET /boards/:id/presence returns active viewer list', async ({ request }) => {
@@ -152,8 +156,7 @@ test.describe('Board Presence', () => {
 
     try {
       // User A navigates to the board
-      await pageA.goto(UI_URL);
-      await pageA.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: tokenA });
+      await loginViaUi(pageA, UI_URL, credsA);
       await pageA.goto(`${UI_URL}/b/${boardId}`);
       await pageA.waitForLoadState('networkidle');
 
@@ -165,8 +168,7 @@ test.describe('Board Presence', () => {
       }
 
       // User B navigates to the same board in a separate context
-      await pageB.goto(UI_URL);
-      await pageB.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: tokenB });
+      await loginViaUi(pageB, UI_URL, credsB);
       await pageB.goto(`${UI_URL}/b/${boardId}`);
       await pageB.waitForLoadState('networkidle');
 

--- a/tests/e2e/search-filters.spec.ts
+++ b/tests/e2e/search-filters.spec.ts
@@ -4,11 +4,12 @@
 // Soft-skips when the server is not reachable.
 
 import { test, expect } from '@playwright/test';
-import { BASE_URL, registerAndLogin, createWorkspace, createBoard, createList, createCard } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaUi, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 test.describe('Search Filters', () => {
+  let creds: Credentials;
   let token: string;
   let boardId: string;
   let otherBoardId: string;
@@ -21,7 +22,8 @@ test.describe('Search Filters', () => {
       return;
     }
 
-    token = await registerAndLogin(request, `search-${run}`);
+    creds = await registerAndGetCredentials(request, `search-${run}`);
+    token = creds.token;
     const workspaceId = await createWorkspace(request, token);
     boardId = await createBoard(request, token, workspaceId);
     otherBoardId = await createBoard(request, token, workspaceId);
@@ -117,8 +119,7 @@ test.describe('Search Filters', () => {
   test('Test 5 — UI search box filters visible cards by keyword', async ({ page }) => {
     if (!token) test.skip(true, 'Server not running — skipping');
 
-    await page.goto(UI_URL);
-    await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
+    await loginViaUi(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -151,8 +152,7 @@ test.describe('Search Filters', () => {
   test('Test 6 — UI type filter toggle shows only matching result type', async ({ page }) => {
     if (!token) test.skip(true, 'Server not running — skipping');
 
-    await page.goto(UI_URL);
-    await page.evaluate(({ t }: { t: string }) => localStorage.setItem('auth_token', t), { t: token });
+    await loginViaUi(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 

--- a/tests/e2e/table-view.spec.ts
+++ b/tests/e2e/table-view.spec.ts
@@ -6,103 +6,39 @@
 // - Clicking a column header sorts the table.
 // - Clicking a card title opens the card detail modal.
 
-import { test, expect, type APIRequestContext } from '@playwright/test';
+import { test, expect } from '@playwright/test';
+import {
+  BASE_URL,
+  registerAndGetCredentials,
+  createWorkspace,
+  createBoard,
+  createList,
+  createCard,
+  loginViaUi,
+  type Credentials,
+} from './_helpers';
 
-const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:3000';
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
-
-// ── Helpers ────────────────────────────────────────────────────────────────
-
-async function registerAndLogin(request: APIRequestContext, suffix: string): Promise<string> {
-  const email = `tv-test-${suffix}-${Date.now()}@example.com`;
-  const password = 'TestPassword1!';
-  const regRes = await request.post(`${BASE_URL}/api/v1/auth/register`, {
-    data: { email, password, name: `TV ${suffix}` },
-  });
-  const body = await regRes.json() as { data: { accessToken: string } };
-  return body.data.accessToken;
-}
-
-async function createWorkspace(request: APIRequestContext, token: string): Promise<string> {
-  const res = await request.post(`${BASE_URL}/api/v1/workspaces`, {
-    headers: { Authorization: `Bearer ${token}` },
-    data: { name: `WS-TV-${Date.now()}` },
-  });
-  const body = await res.json() as { data: { id: string } };
-  return body.data.id;
-}
-
-async function createBoard(
-  request: APIRequestContext,
-  token: string,
-  workspaceId: string,
-): Promise<{ id: string }> {
-  const res = await request.post(`${BASE_URL}/api/v1/workspaces/${workspaceId}/boards`, {
-    headers: { Authorization: `Bearer ${token}` },
-    data: { title: `Board-TV-${Date.now()}` },
-  });
-  const body = await res.json() as { data: { id: string } };
-  return body.data;
-}
-
-async function createList(
-  request: APIRequestContext,
-  token: string,
-  boardId: string,
-  title: string,
-): Promise<string> {
-  const res = await request.post(`${BASE_URL}/api/v1/boards/${boardId}/lists`, {
-    headers: { Authorization: `Bearer ${token}` },
-    data: { title },
-  });
-  const body = await res.json() as { data: { id: string } };
-  return body.data.id;
-}
-
-async function createCard(
-  request: APIRequestContext,
-  token: string,
-  listId: string,
-  title: string,
-): Promise<string> {
-  const res = await request.post(`${BASE_URL}/api/v1/lists/${listId}/cards`, {
-    headers: { Authorization: `Bearer ${token}` },
-    data: { title },
-  });
-  const body = await res.json() as { data: { id: string } };
-  return body.data.id;
-}
 
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 test.describe('Table View', () => {
   test('Table view renders column headers after switching to TABLE', async ({ page, request }) => {
-    const token = await registerAndLogin(request, 'headers');
-    const wsId = await createWorkspace(request, token);
-    const board = await createBoard(request, token, wsId);
-    const listId = await createList(request, token, board.id, 'To Do');
-    await createCard(request, token, listId, 'Alpha card');
+    const creds: Credentials = await registerAndGetCredentials(request, 'headers');
+    const wsId = await createWorkspace(request, creds.token);
+    const boardId = await createBoard(request, creds.token, wsId);
+    const listId = await createList(request, creds.token, boardId, 'To Do');
+    await createCard(request, creds.token, listId, 'Alpha card');
 
     // Set TABLE view preference so the board loads in TABLE mode
-    await request.put(`${BASE_URL}/api/v1/boards/${board.id}/view-preference`, {
-      headers: { Authorization: `Bearer ${token}` },
+    await request.put(`${BASE_URL}/api/v1/boards/${boardId}/view-preference`, {
+      headers: { Authorization: `Bearer ${creds.token}` },
       data: { viewType: 'TABLE' },
     });
 
-    // Log in via the UI
-    await page.goto(`${UI_URL}/login`);
-    await page.fill('input[type="email"]', `tv-test-headers-${Date.now() - 100}@example.com`);
-
-    // Re-login properly using API token in localStorage
-    await page.evaluate(
-      ([url, tok]) => {
-        localStorage.setItem('access_token', tok as string);
-        window.location.href = `${url}/b/${(tok as string).slice(-8)}`;
-      },
-      [UI_URL, token],
-    );
-
-    await page.goto(`${UI_URL}/b/${board.id}`);
+    // The app authenticates via HttpOnly cookies, so log in through the UI form.
+    await loginViaUi(page, UI_URL, creds);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     // BoardViewSwitcher should be visible
@@ -122,13 +58,14 @@ test.describe('Table View', () => {
   });
 
   test('Table view renders card rows', async ({ page, request }) => {
-    const token = await registerAndLogin(request, 'rows');
-    const wsId = await createWorkspace(request, token);
-    const board = await createBoard(request, token, wsId);
-    const listId = await createList(request, token, board.id, 'Backlog');
-    const cardId = await createCard(request, token, listId, 'My test card');
+    const creds: Credentials = await registerAndGetCredentials(request, 'rows');
+    const wsId = await createWorkspace(request, creds.token);
+    const boardId = await createBoard(request, creds.token, wsId);
+    const listId = await createList(request, creds.token, boardId, 'Backlog');
+    const cardId = await createCard(request, creds.token, listId, 'My test card');
 
-    await page.goto(`${UI_URL}/b/${board.id}`);
+    await loginViaUi(page, UI_URL, creds);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
     // Switch to TABLE view via the switcher
@@ -142,14 +79,15 @@ test.describe('Table View', () => {
   });
 
   test('Clicking a column header changes sort order', async ({ page, request }) => {
-    const token = await registerAndLogin(request, 'sort');
-    const wsId = await createWorkspace(request, token);
-    const board = await createBoard(request, token, wsId);
-    const listId = await createList(request, token, board.id, 'Work');
-    await createCard(request, token, listId, 'Zebra card');
-    await createCard(request, token, listId, 'Alpha card');
+    const creds: Credentials = await registerAndGetCredentials(request, 'sort');
+    const wsId = await createWorkspace(request, creds.token);
+    const boardId = await createBoard(request, creds.token, wsId);
+    const listId = await createList(request, creds.token, boardId, 'Work');
+    await createCard(request, creds.token, listId, 'Zebra card');
+    await createCard(request, creds.token, listId, 'Alpha card');
 
-    await page.goto(`${UI_URL}/b/${board.id}`);
+    await loginViaUi(page, UI_URL, creds);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
     await page.getByTestId('board-view-tab-TABLE').click();
     await expect(page.getByTestId('table-view')).toBeVisible();
@@ -170,13 +108,14 @@ test.describe('Table View', () => {
   });
 
   test('Clicking card title opens card detail modal', async ({ page, request }) => {
-    const token = await registerAndLogin(request, 'modal');
-    const wsId = await createWorkspace(request, token);
-    const board = await createBoard(request, token, wsId);
-    const listId = await createList(request, token, board.id, 'Sprint');
-    const cardId = await createCard(request, token, listId, 'Open me please');
+    const creds: Credentials = await registerAndGetCredentials(request, 'modal');
+    const wsId = await createWorkspace(request, creds.token);
+    const boardId = await createBoard(request, creds.token, wsId);
+    const listId = await createList(request, creds.token, boardId, 'Sprint');
+    const cardId = await createCard(request, creds.token, listId, 'Open me please');
 
-    await page.goto(`${UI_URL}/b/${board.id}`);
+    await loginViaUi(page, UI_URL, creds);
+    await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
     await page.getByTestId('board-view-tab-TABLE').click();
     await expect(page.getByTestId('table-view')).toBeVisible();


### PR DESCRIPTION
## Summary

The app authenticates via HttpOnly cookies (refresh + access tokens) set by the login/register response — it does NOT persist auth to localStorage. 10 specs injected `auth_token` into localStorage, which the app ignores, so on reload it booted unauthenticated and showed the login page; every UI test then timed out waiting for board elements.

## Changes (test-only)

- Add `registerAndGetCredentials` + `loginViaUi` helpers to `_helpers.ts`
- Update 10 specs to register via API (for the token) then log in through the UI form so the browser receives the HttpOnly cookies

## Verification

- Unblocks board rendering for card-description, custom-fields, table-view, delete-confirmation, list-management, search-filters, attachment-upload, payment-card-price, presence-board
- ESLint clean on all 11 files

Test-only; no product behaviour altered.