### PR TITLE
fix(e2e): inject refresh_token cookie instead of rate-limited UI login

### DIFF
--- a/tests/e2e/_helpers.ts
+++ b/tests/e2e/_helpers.ts
@@ -78,11 +78,13 @@ export interface Credentials {
   email: string;
   password: string;
   token: string;
+  refreshToken: string;
 }
 
-// Register a user and return credentials (email/password/token). The app
-// authenticates the browser via HttpOnly cookies set by the login/register
-// response, so UI specs must log in through the form (not localStorage).
+// Register a user and return credentials (email/password/token/refreshToken).
+// The app authenticates the browser via HttpOnly cookies set by the register
+// response, so UI specs can inject the refresh_token cookie to restore auth
+// on boot (avoids the rate-limited UI form login).
 export async function registerAndGetCredentials(
   request: APIRequestContext,
   suffix: string,
@@ -93,7 +95,35 @@ export async function registerAndGetCredentials(
     data: { email, password, name: `Test ${suffix}` },
   });
   const body = await regRes.json() as { data: { accessToken: string } };
-  return { email, password, token: body.data.accessToken };
+  const setCookie = regRes.headers()['set-cookie'] ?? '';
+  const refreshMatch = setCookie.match(/refresh_token=([^;]+)/);
+  return {
+    email,
+    password,
+    token: body.data.accessToken,
+    refreshToken: refreshMatch ? refreshMatch[1] : '',
+  };
+}
+
+// Inject the refresh_token cookie into the browser context so the app's boot
+// refreshTokenThunk restores auth. Avoids the rate-limited UI form login
+// (10/IP/min) which 429s under the full suite.
+export async function loginViaCookie(
+  page: import('@playwright/test').Page,
+  uiUrl: string,
+  creds: Credentials,
+): Promise<void> {
+  if (creds.refreshToken) {
+    await page.context().addCookies([
+      {
+        name: 'refresh_token',
+        value: creds.refreshToken,
+        url: `${uiUrl}/api/v1/auth/refresh`,
+        httpOnly: true,
+        sameSite: 'Strict',
+      },
+    ]);
+  }
 }
 
 // Log in through the UI login form so the browser receives the HttpOnly

--- a/tests/e2e/attachment-upload.spec.ts
+++ b/tests/e2e/attachment-upload.spec.ts
@@ -5,7 +5,7 @@
 // Based on: specs/tests/attachment-upload.md
 
 import { test, expect } from '@playwright/test';
-import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaUi, type Credentials } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaCookie, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
@@ -211,7 +211,7 @@ test.describe('Attachment Upload', () => {
     const listId = await createList(request, token, boardId);
     const uiCardId = await createCard(request, token, listId, 'UI Attachment Card');
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -268,7 +268,7 @@ test.describe('Attachment Upload', () => {
       data: { url: 'https://example.com/report.pdf', name: 'report.pdf' },
     });
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 

--- a/tests/e2e/card-description-inline-edit.spec.ts
+++ b/tests/e2e/card-description-inline-edit.spec.ts
@@ -4,7 +4,7 @@
 // Based on: tests/e2e/card-description-inline-edit.md (now deleted)
 
 import { test, expect } from '@playwright/test';
-import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaUi, type Credentials } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaCookie, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
@@ -30,7 +30,7 @@ test.describe('Card Description — Inline Click-to-Edit', () => {
   });
 
   test.beforeEach(async ({ page }) => {
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 

--- a/tests/e2e/custom-fields-board-panel.spec.ts
+++ b/tests/e2e/custom-fields-board-panel.spec.ts
@@ -4,7 +4,7 @@
 // Based on: tests/e2e/custom-fields-board-panel.md (now deleted)
 
 import { test, expect, type APIRequestContext } from '@playwright/test';
-import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, loginViaUi, type Credentials } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, loginViaCookie, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
@@ -17,7 +17,7 @@ async function setupBoardAndNavigate(
   const boardId = await createBoard(request, creds.token, wsId);
 
   // The app authenticates via HttpOnly cookies, so log in through the UI form.
-  await loginViaUi(page, UI_URL, creds);
+  await loginViaCookie(page, UI_URL, creds);
   await page.goto(`${UI_URL}/b/${boardId}`);
   await page.waitForLoadState('networkidle');
 

--- a/tests/e2e/custom-fields-ui.spec.ts
+++ b/tests/e2e/custom-fields-ui.spec.ts
@@ -4,7 +4,7 @@
 // Based on: tests/e2e/custom-fields-ui.md (now deleted)
 
 import { test, expect, type APIRequestContext } from '@playwright/test';
-import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaUi, type Credentials } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaCookie, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
@@ -22,7 +22,7 @@ async function setupBoardWithCard(request: APIRequestContext, page: import('@pla
   const cardId = await createCard(request, creds.token, listId, 'CF UI Test Card');
 
   // The app authenticates via HttpOnly cookies, so log in through the UI form.
-  await loginViaUi(page, UI_URL, creds);
+  await loginViaCookie(page, UI_URL, creds);
   await page.goto(`${UI_URL}/b/${boardId}`);
   await page.waitForLoadState('networkidle');
 

--- a/tests/e2e/delete-confirmation.spec.ts
+++ b/tests/e2e/delete-confirmation.spec.ts
@@ -5,7 +5,7 @@
 // Based on: tests/e2e/delete-confirmation.md (now deleted)
 
 import { test, expect } from '@playwright/test';
-import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaUi, type Credentials } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaCookie, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
@@ -123,7 +123,7 @@ test.describe('Delete Confirmation Flag', () => {
     const boardId = await createBoard(request, token, workspaceId);
     await createList(request, token, boardId);
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -159,7 +159,7 @@ test.describe('Delete Confirmation Flag', () => {
     const boardId = await createBoard(request, token, workspaceId);
     await createList(request, token, boardId);
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -192,7 +192,7 @@ test.describe('Delete Confirmation Flag', () => {
     const listId = await createList(request, token, boardId);
     await createCard(request, token, listId, 'Card A');
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -224,7 +224,7 @@ test.describe('Delete Confirmation Flag', () => {
     const listId = await createList(request, token, boardId);
     await createCard(request, token, listId, 'Card A');
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 

--- a/tests/e2e/list-management.spec.ts
+++ b/tests/e2e/list-management.spec.ts
@@ -4,7 +4,7 @@
 // Soft-skips when the server is not reachable.
 
 import { test, expect } from '@playwright/test';
-import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, loginViaUi, type Credentials } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, loginViaCookie, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
@@ -150,7 +150,7 @@ test.describe('List Management', () => {
   test('Test 6 — UI: Add list button creates a new list on the board', async ({ page }) => {
     if (!token) test.skip(true, 'Server not running — skipping');
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -198,7 +198,7 @@ test.describe('List Management', () => {
     const seedListId = await createList(request, token, boardId);
     void seedListId; // used implicitly via page.goto below
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -241,7 +241,7 @@ test.describe('List Management', () => {
     await createList(request, token, boardId);
     await createList(request, token, boardId);
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 

--- a/tests/e2e/payment-card-price.spec.ts
+++ b/tests/e2e/payment-card-price.spec.ts
@@ -5,7 +5,7 @@
 // Based on: specs/tests/payment-card-price.md
 
 import { test, expect } from '@playwright/test';
-import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaUi, type Credentials } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaCookie, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
@@ -253,7 +253,7 @@ test.describe('Payment — Card Price', () => {
       return;
     }
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -291,7 +291,7 @@ test.describe('Payment — Card Price', () => {
       return;
     }
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 

--- a/tests/e2e/presence-board.spec.ts
+++ b/tests/e2e/presence-board.spec.ts
@@ -6,7 +6,7 @@
 // Soft-skips when the server is not reachable.
 
 import { test, expect, chromium } from '@playwright/test';
-import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, loginViaUi, type Credentials } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, loginViaCookie, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
@@ -156,7 +156,7 @@ test.describe('Board Presence', () => {
 
     try {
       // User A navigates to the board
-      await loginViaUi(pageA, UI_URL, credsA);
+      await loginViaCookie(pageA, UI_URL, credsA);
       await pageA.goto(`${UI_URL}/b/${boardId}`);
       await pageA.waitForLoadState('networkidle');
 
@@ -168,7 +168,7 @@ test.describe('Board Presence', () => {
       }
 
       // User B navigates to the same board in a separate context
-      await loginViaUi(pageB, UI_URL, credsB);
+      await loginViaCookie(pageB, UI_URL, credsB);
       await pageB.goto(`${UI_URL}/b/${boardId}`);
       await pageB.waitForLoadState('networkidle');
 

--- a/tests/e2e/search-filters.spec.ts
+++ b/tests/e2e/search-filters.spec.ts
@@ -4,7 +4,7 @@
 // Soft-skips when the server is not reachable.
 
 import { test, expect } from '@playwright/test';
-import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaUi, type Credentials } from './_helpers';
+import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard, loginViaCookie, type Credentials } from './_helpers';
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
@@ -119,7 +119,7 @@ test.describe('Search Filters', () => {
   test('Test 5 — UI search box filters visible cards by keyword', async ({ page }) => {
     if (!token) test.skip(true, 'Server not running — skipping');
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -152,7 +152,7 @@ test.describe('Search Filters', () => {
   test('Test 6 — UI type filter toggle shows only matching result type', async ({ page }) => {
     if (!token) test.skip(true, 'Server not running — skipping');
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 

--- a/tests/e2e/table-view.spec.ts
+++ b/tests/e2e/table-view.spec.ts
@@ -14,7 +14,7 @@ import {
   createBoard,
   createList,
   createCard,
-  loginViaUi,
+  loginViaCookie,
   type Credentials,
 } from './_helpers';
 
@@ -37,7 +37,7 @@ test.describe('Table View', () => {
     });
 
     // The app authenticates via HttpOnly cookies, so log in through the UI form.
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -64,7 +64,7 @@ test.describe('Table View', () => {
     const listId = await createList(request, creds.token, boardId, 'Backlog');
     const cardId = await createCard(request, creds.token, listId, 'My test card');
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
 
@@ -86,7 +86,7 @@ test.describe('Table View', () => {
     await createCard(request, creds.token, listId, 'Zebra card');
     await createCard(request, creds.token, listId, 'Alpha card');
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
     await page.getByTestId('board-view-tab-TABLE').click();
@@ -114,7 +114,7 @@ test.describe('Table View', () => {
     const listId = await createList(request, creds.token, boardId, 'Sprint');
     const cardId = await createCard(request, creds.token, listId, 'Open me please');
 
-    await loginViaUi(page, UI_URL, creds);
+    await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
     await page.getByTestId('board-view-tab-TABLE').click();


### PR DESCRIPTION
## Summary

The UI form login hits the login rate limit (10/IP/min) and 429s under the full suite, so `loginViaUi` timed out waiting for `/workspaces`. Register is not rate-limited and sets the HttpOnly `refresh_token` cookie, which the app's boot `refreshTokenThunk` reads to restore auth.

## Changes (test-only)

- `registerAndGetCredentials` now captures the `refresh_token` from the register response's `set-cookie` header
- Add `loginViaCookie` to inject that cookie into the browser context
- 10 specs use `loginViaCookie` instead of `loginViaUi`

## Verification

- Unblocks card-description test 1 (no login timeout)
- ESLint clean on all 11 files

Test-only; no product behaviour altered.