### PR TITLE
fix(e2e): inject refresh_token cookie in timeline/calendar/offline specs

### DIFF
--- a/tests/e2e/calendar-view.spec.ts
+++ b/tests/e2e/calendar-view.spec.ts
@@ -15,7 +15,7 @@ const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-interface Credentials { email: string; password: string; token: string }
+interface Credentials { email: string; password: string; token: string; refreshToken: string }
 
 async function registerAndLogin(request: APIRequestContext, suffix: string): Promise<Credentials> {
   const email = `cv-test-${suffix}-${Date.now()}@journeyh.io`;
@@ -26,7 +26,9 @@ async function registerAndLogin(request: APIRequestContext, suffix: string): Pro
   // Register returns an accessToken directly (201); avoid a separate login call
   // which is rate-limited (10/IP/min) and would 429 under the full suite.
   const body = await regRes.json() as { data: { accessToken: string } };
-  return { email, password, token: body.data.accessToken };
+  const setCookie = regRes.headers()['set-cookie'] ?? '';
+  const refreshMatch = setCookie.match(/refresh_token=([^;]+)/);
+  return { email, password, token: body.data.accessToken, refreshToken: refreshMatch ? refreshMatch[1] : '' };
 }
 
 async function createWorkspace(request: APIRequestContext, token: string): Promise<string> {
@@ -100,12 +102,11 @@ function isoDate(year: number, month: number, day: number): string {
 
 /** Log in via the browser UI and navigate to a board. */
 async function goToBoard(page: Page, baseUrl: string, boardId: string, creds: Credentials) {
-  await page.goto(`${baseUrl}/login`);
-  await page.fill('input[type="email"]', creds.email);
-  await page.fill('input[type="password"]', creds.password);
-  await page.click('button[type="submit"]');
-  // After login the app redirects to /workspaces — wait for that before navigating to the board
-  await page.waitForURL(`${baseUrl}/workspaces**`, { timeout: 15000 });
+  if (creds.refreshToken) {
+    await page.context().addCookies([
+      { name: 'refresh_token', value: creds.refreshToken, url: `${baseUrl}/api/v1/auth/refresh`, httpOnly: true, sameSite: 'Strict' },
+    ]);
+  }
   await page.goto(`${baseUrl}/b/${boardId}`);
   await page.waitForLoadState('networkidle');
 }

--- a/tests/e2e/notification-type-prefs.spec.ts
+++ b/tests/e2e/notification-type-prefs.spec.ts
@@ -3,7 +3,7 @@ import { test, expect, type APIRequestContext, type Page } from '@playwright/tes
 const API_URL = process.env.TEST_BASE_URL ?? 'http://localhost:3000';
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
-interface Credentials { email: string; password: string; token: string }
+interface Credentials { email: string; password: string; token: string; refreshToken: string }
 
 async function registerAndLogin(request: APIRequestContext, suffix: string): Promise<Credentials> {
   const email = `ntp-test-${suffix}-${Date.now()}@journeyh.io`;
@@ -14,7 +14,9 @@ async function registerAndLogin(request: APIRequestContext, suffix: string): Pro
   // Register returns an accessToken directly (201); avoid a separate login call
   // which is rate-limited (10/IP/min) and would 429 under the full suite.
   const body = await regRes.json() as { data: { accessToken: string } };
-  return { email, password, token: body.data.accessToken };
+  const setCookie = regRes.headers()['set-cookie'] ?? '';
+  const refreshMatch = setCookie.match(/refresh_token=([^;]+)/);
+  return { email, password, token: body.data.accessToken, refreshToken: refreshMatch ? refreshMatch[1] : '' };
 }
 
 async function createWorkspace(request: APIRequestContext, token: string): Promise<string> {
@@ -36,11 +38,11 @@ async function createBoard(request: APIRequestContext, token: string, wsId: stri
 }
 
 async function goToBoard(page: Page, boardId: string, creds: Credentials) {
-  await page.goto(`${UI_URL}/login`);
-  await page.fill('input[type="email"]', creds.email);
-  await page.fill('input[type="password"]', creds.password);
-  await page.click('button[type="submit"]');
-  await page.waitForURL(`${UI_URL}/workspaces**`, { timeout: 15000 });
+  if (creds.refreshToken) {
+    await page.context().addCookies([
+      { name: 'refresh_token', value: creds.refreshToken, url: `${UI_URL}/api/v1/auth/refresh`, httpOnly: true, sameSite: 'Strict' },
+    ]);
+  }
   await page.goto(`${UI_URL}/b/${boardId}`);
   await page.waitForLoadState('networkidle');
 }

--- a/tests/e2e/offline-queue-persistence.spec.ts
+++ b/tests/e2e/offline-queue-persistence.spec.ts
@@ -21,7 +21,7 @@ const STORE = 'mutations';
 async function registerAndLogin(
   request: APIRequestContext,
   suffix: string,
-): Promise<{ token: string; email: string; password: string }> {
+): Promise<{ token: string; email: string; password: string; refreshToken: string }> {
   const email = `oq-test-${suffix}-${Date.now()}@example.com`;
   const password = 'TestPassword1!';
 
@@ -29,7 +29,9 @@ async function registerAndLogin(
     data: { email, password, name: `OQ ${suffix}` },
   });
   const body = await regRes.json() as { data: { accessToken: string } };
-  return { token: body.data.accessToken, email, password };
+  const setCookie = regRes.headers()['set-cookie'] ?? '';
+  const refreshMatch = setCookie.match(/refresh_token=([^;]+)/);
+  return { token: body.data.accessToken, email, password, refreshToken: refreshMatch ? refreshMatch[1] : '' };
 }
 
 async function createWorkspace(request: APIRequestContext, token: string): Promise<string> {
@@ -121,14 +123,13 @@ async function readMutationsFromIDB(page: Page): Promise<unknown[]> {
   );
 }
 
-/** Log in via the UI login form so auth cookies/tokens are set. */
-async function loginViaUi(page: Page, email: string, password: string): Promise<void> {
-  await page.goto(`${UI_URL}/login`);
-  await page.getByLabel(/email/i).fill(email);
-  await page.getByLabel(/password/i).fill(password);
-  await page.getByRole('button', { name: /log in|sign in/i }).click();
-  // Wait until redirected away from /login (i.e. auth succeeded)
-  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 10_000 });
+/** Inject the refresh_token cookie so the app's boot refresh restores auth. */
+async function loginViaCookie(page: Page, refreshToken: string): Promise<void> {
+  if (refreshToken) {
+    await page.context().addCookies([
+      { name: 'refresh_token', value: refreshToken, url: `${UI_URL}/api/v1/auth/refresh`, httpOnly: true, sameSite: 'Strict' },
+    ]);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -140,12 +141,12 @@ test.describe('offline mutation queue — IndexedDB persistence', () => {
     page,
     request,
   }) => {
-    const { token, email, password } = await registerAndLogin(request, 'hydrate');
+    const { token, refreshToken } = await registerAndLogin(request, 'hydrate');
     const workspaceId = await createWorkspace(request, token);
     const boardId = await createBoard(request, token, workspaceId);
 
     // Navigate to app first so the origin is established, then seed IDB
-    await loginViaUi(page, email, password);
+    await loginViaCookie(page, refreshToken);
     await page.goto(`${UI_URL}/b/${boardId}`, { waitUntil: 'domcontentloaded' });
 
     const mutationId = `test-hydrate-${Date.now()}`;
@@ -182,11 +183,11 @@ test.describe('offline mutation queue — IndexedDB persistence', () => {
     page,
     request,
   }) => {
-    const { token, email, password } = await registerAndLogin(request, 'replay');
+    const { token, refreshToken } = await registerAndLogin(request, 'replay');
     const workspaceId = await createWorkspace(request, token);
     const boardId = await createBoard(request, token, workspaceId);
 
-    await loginViaUi(page, email, password);
+    await loginViaCookie(page, refreshToken);
     await page.goto(`${UI_URL}/b/${boardId}`, { waitUntil: 'domcontentloaded' });
 
     const listTitle = `Replayed-List-${Date.now()}`;

--- a/tests/e2e/timeline-bar.spec.ts
+++ b/tests/e2e/timeline-bar.spec.ts
@@ -15,7 +15,7 @@ const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-interface Credentials { email: string; password: string; token: string }
+interface Credentials { email: string; password: string; token: string; refreshToken: string }
 
 async function registerAndLogin(request: APIRequestContext, suffix: string): Promise<Credentials> {
   const email = `tb-test-${suffix}-${Date.now()}@journeyh.io`;
@@ -26,7 +26,9 @@ async function registerAndLogin(request: APIRequestContext, suffix: string): Pro
   // Register returns an accessToken directly (201); avoid a separate login call
   // which is rate-limited (10/IP/min) and would 429 under the full suite.
   const body = await regRes.json() as { data: { accessToken: string } };
-  return { email, password, token: body.data.accessToken };
+  const setCookie = regRes.headers()['set-cookie'] ?? '';
+  const refreshMatch = setCookie.match(/refresh_token=([^;]+)/);
+  return { email, password, token: body.data.accessToken, refreshToken: refreshMatch ? refreshMatch[1] : '' };
 }
 
 async function createWorkspace(request: APIRequestContext, token: string): Promise<string> {
@@ -79,11 +81,11 @@ function offsetDate(offsetDays: number): string {
 }
 
 async function goToTimelineView(page: Page, baseUrl: string, boardId: string, creds: Credentials) {
-  await page.goto(`${baseUrl}/login`);
-  await page.fill('input[type="email"]', creds.email);
-  await page.fill('input[type="password"]', creds.password);
-  await page.click('button[type="submit"]');
-  await page.waitForURL(`${baseUrl}/workspaces**`, { timeout: 15000 });
+  if (creds.refreshToken) {
+    await page.context().addCookies([
+      { name: 'refresh_token', value: creds.refreshToken, url: `${baseUrl}/api/v1/auth/refresh`, httpOnly: true, sameSite: 'Strict' },
+    ]);
+  }
   await page.goto(`${baseUrl}/b/${boardId}`);
   await page.waitForLoadState('networkidle');
   await page.getByTestId('board-view-tab-TIMELINE').click();

--- a/tests/e2e/timeline-drag.spec.ts
+++ b/tests/e2e/timeline-drag.spec.ts
@@ -13,7 +13,7 @@ const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-interface Credentials { email: string; password: string; token: string }
+interface Credentials { email: string; password: string; token: string; refreshToken: string }
 
 async function registerAndLogin(request: APIRequestContext, suffix: string): Promise<Credentials> {
   const email = `td-test-${suffix}-${Date.now()}@journeyh.io`;
@@ -24,7 +24,9 @@ async function registerAndLogin(request: APIRequestContext, suffix: string): Pro
   // Register returns an accessToken directly (201); avoid a separate login call
   // which is rate-limited (10/IP/min) and would 429 under the full suite.
   const body = await regRes.json() as { data: { accessToken: string } };
-  return { email, password, token: body.data.accessToken };
+  const setCookie = regRes.headers()['set-cookie'] ?? '';
+  const refreshMatch = setCookie.match(/refresh_token=([^;]+)/);
+  return { email, password, token: body.data.accessToken, refreshToken: refreshMatch ? refreshMatch[1] : '' };
 }
 
 async function createWorkspace(request: APIRequestContext, token: string): Promise<string> {
@@ -85,11 +87,11 @@ function offsetDate(offsetDays: number): string {
 }
 
 async function goToTimelineView(page: Page, baseUrl: string, boardId: string, creds: Credentials) {
-  await page.goto(`${baseUrl}/login`);
-  await page.fill('input[type="email"]', creds.email);
-  await page.fill('input[type="password"]', creds.password);
-  await page.click('button[type="submit"]');
-  await page.waitForURL(`${baseUrl}/workspaces**`, { timeout: 15000 });
+  if (creds.refreshToken) {
+    await page.context().addCookies([
+      { name: 'refresh_token', value: creds.refreshToken, url: `${baseUrl}/api/v1/auth/refresh`, httpOnly: true, sameSite: 'Strict' },
+    ]);
+  }
   await page.goto(`${baseUrl}/b/${boardId}`);
   await page.waitForLoadState('networkidle');
   await page.getByTestId('board-view-tab-TIMELINE').click();

--- a/tests/e2e/timeline-view.spec.ts
+++ b/tests/e2e/timeline-view.spec.ts
@@ -16,7 +16,7 @@ const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-interface Credentials { email: string; password: string; token: string }
+interface Credentials { email: string; password: string; token: string; refreshToken: string }
 
 async function registerAndLogin(request: APIRequestContext, suffix: string): Promise<Credentials> {
   const email = `tv-test-${suffix}-${Date.now()}@journeyh.io`;
@@ -27,7 +27,9 @@ async function registerAndLogin(request: APIRequestContext, suffix: string): Pro
   // Register returns an accessToken directly (201); avoid a separate login call
   // which is rate-limited (10/IP/min) and would 429 under the full suite.
   const body = await regRes.json() as { data: { accessToken: string } };
-  return { email, password, token: body.data.accessToken };
+  const setCookie = regRes.headers()['set-cookie'] ?? '';
+  const refreshMatch = setCookie.match(/refresh_token=([^;]+)/);
+  return { email, password, token: body.data.accessToken, refreshToken: refreshMatch ? refreshMatch[1] : '' };
 }
 
 async function createWorkspace(request: APIRequestContext, token: string): Promise<string> {
@@ -100,11 +102,11 @@ function offsetDate(offsetDays: number): string {
 }
 
 async function goToBoard(page: Page, baseUrl: string, boardId: string, creds: Credentials) {
-  await page.goto(`${baseUrl}/login`);
-  await page.fill('input[type="email"]', creds.email);
-  await page.fill('input[type="password"]', creds.password);
-  await page.click('button[type="submit"]');
-  await page.waitForURL(`${baseUrl}/workspaces**`, { timeout: 15000 });
+  if (creds.refreshToken) {
+    await page.context().addCookies([
+      { name: 'refresh_token', value: creds.refreshToken, url: `${baseUrl}/api/v1/auth/refresh`, httpOnly: true, sameSite: 'Strict' },
+    ]);
+  }
   await page.goto(`${baseUrl}/b/${boardId}`);
   await page.waitForLoadState('networkidle');
 }


### PR DESCRIPTION
## Summary

6 specs (timeline-view, calendar-view, timeline-drag, timeline-bar, notification-type-prefs, offline-queue-persistence) used their own rate-limited UI form login (`goToBoard`/`loginViaUi`), which 429s under the full suite and times out waiting for `/workspaces`. Register is not rate-limited and sets the HttpOnly `refresh_token` cookie, which the app's boot `refreshTokenThunk` reads to restore auth.

## Changes (test-only)

- Capture `refresh_token` from the register response's `set-cookie` header
- Inject it into the browser context instead of the UI form login

## Verification

- Unblocks timeline-view from 4 to 5 passing (no login timeouts)
- ESLint clean on all 6 files

Test-only; no product behaviour altered.