### PR TITLE
fix(e2e): card-tile and card-modal selectors match actual DOM

### DIFF
--- a/tests/e2e/card-description-inline-edit.spec.ts
+++ b/tests/e2e/card-description-inline-edit.spec.ts
@@ -35,8 +35,8 @@ test.describe('Card Description — Inline Click-to-Edit', () => {
     await page.waitForLoadState('networkidle');
 
     // Open the card modal
-    await page.locator('[data-testid="card-tile"], .card-tile, [class*="card"]').first().click();
-    await page.waitForSelector('[data-testid="card-modal"], [role="dialog"]', { timeout: 8000 });
+    await page.locator('[aria-label^="Card:"]').first().click();
+    await page.waitForSelector('[data-testid="card-modal"], [role="dialog"][aria-label^="Card:"]', { timeout: 8000 });
   });
 
   test('Test 1 — Enter edit mode by clicking description area', async ({ page }) => {
@@ -86,8 +86,8 @@ test.describe('Card Description — Inline Click-to-Edit', () => {
 
     // Close and reopen to verify persistence
     await page.keyboard.press('Escape');
-    await page.locator('[data-testid="card-tile"], .card-tile, [class*="card"]').first().click();
-    await page.waitForSelector('[data-testid="card-modal"], [role="dialog"]', { timeout: 8000 });
+    await page.locator('[aria-label^="Card:"]').first().click();
+    await page.waitForSelector('[data-testid="card-modal"], [role="dialog"][aria-label^="Card:"]', { timeout: 8000 });
     const descContainerReopened = page.locator('[data-testid="card-description"], [data-testid="description-view"]').first();
     await expect(descContainerReopened.locator('strong, b')).toBeVisible({ timeout: 5000 });
   });
@@ -165,8 +165,8 @@ test.describe('Card Description — Inline Click-to-Edit', () => {
 
     await page.goto(`${UI_URL}/b/${bId}`);
     await page.waitForLoadState('networkidle');
-    await page.locator('[data-testid="card-tile"], .card-tile, [class*="card"]').first().click();
-    await page.waitForSelector('[data-testid="card-modal"], [role="dialog"]', { timeout: 8000 });
+    await page.locator('[aria-label^="Card:"]').first().click();
+    await page.waitForSelector('[data-testid="card-modal"], [role="dialog"][aria-label^="Card:"]', { timeout: 8000 });
 
     const placeholder = page.getByText(/add a more detailed description/i);
     await expect(placeholder).toBeVisible({ timeout: 5000 });

--- a/tests/e2e/custom-fields-ui.spec.ts
+++ b/tests/e2e/custom-fields-ui.spec.ts
@@ -44,8 +44,8 @@ async function createFieldViaApi(
 }
 
 async function openCardModal(page: import('@playwright/test').Page) {
-  await page.locator('[data-testid="card-tile"], .card-tile, [class*="card"]').first().click();
-  await page.waitForSelector('[data-testid="card-modal"], [role="dialog"], [aria-label*="card"]', { timeout: 5000 });
+  await page.locator('[aria-label^="Card:"]').first().click();
+  await page.waitForSelector('[data-testid="card-modal"], [role="dialog"][aria-label^="Card:"]', { timeout: 5000 });
 }
 
 test.describe('Custom Fields UI — Card Modal Value Editing', () => {
@@ -194,7 +194,7 @@ test.describe('Custom Fields UI — Card Modal Value Editing', () => {
     await page.keyboard.press('Escape');
 
     // The card tile should NOT show the value as a badge
-    const tile = page.locator('[data-testid="card-tile"], .card-tile, [class*="card"]').first();
+    const tile = page.locator('[aria-label^="Card:"]').first();
     await expect(tile.getByText('private text')).not.toBeVisible({ timeout: 3000 });
   });
 });


### PR DESCRIPTION
## Summary

`CardTile` renders as `div[role=button][aria-label^="Card:"]` with no card-tile testid, so the old selector timed out. The card modal has `aria-label="Card: <title>"` and a hidden mobile sidebar also uses `role="dialog"`, so the generic `[role=dialog]` selector matched the wrong element first.

## Changes (test-only)

- Use `[aria-label^="Card:"]` to open the card modal
- Target the modal as `[role="dialog"][aria-label^="Card:"]` to avoid the hidden mobile sidebar

## Verification

- Both specs (card-description-inline-edit, custom-fields-ui) now pass the card-tile and modal-open steps (previously timed out on the selector)
- ESLint clean on both files

Test-only; no product behaviour altered.