### PR TITLE
fix(e2e): align card description inline edit spec with tiptap and fresh cookie auth

### DIFF
--- a/tests/e2e/card-description-inline-edit.spec.ts
+++ b/tests/e2e/card-description-inline-edit.spec.ts
@@ -8,13 +8,28 @@ import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, crea
 
 const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
+const descriptionViewSelector = '[aria-label="Description (click to edit)"], [aria-label="Add a description (click to edit)"], [data-testid="card-description"], [data-testid="description-view"]';
+const markdownEditorSelector = 'textarea[data-testid*="description"], textarea[name*="description"], [data-testid="description-editor"], textarea[placeholder="Write markdown..."]';
+const richEditorSelector = '.ProseMirror[contenteditable="true"]';
+
+async function openMarkdownEditor(page: import('@playwright/test').Page) {
+  await page.locator(descriptionViewSelector).first().click();
+  await page.getByRole('button', { name: 'Markdown' }).click();
+  const textarea = page.locator(markdownEditorSelector).first();
+  await textarea.waitFor({ state: 'visible', timeout: 5000 });
+  return textarea;
+}
+
 test.describe('Card Description — Inline Click-to-Edit', () => {
   let creds: Credentials;
   let token: string;
   let boardId: string;
   let cardId: string;
 
-  test.beforeAll(async ({ request }) => {
+  test.beforeEach(async ({ request, page }) => {
+    // Create fresh credentials per test because refresh_token cookies are
+    // rotated during app boot; reusing one across fresh browser contexts makes
+    // later tests inject a stale cookie and land on the login page.
     creds = await registerAndGetCredentials(request, 'desc-edit');
     token = creds.token;
     const wsId = await createWorkspace(request, token);
@@ -27,9 +42,7 @@ test.describe('Card Description — Inline Click-to-Edit', () => {
       headers: { Authorization: `Bearer ${token}` },
       data: { description: 'Original text' },
     });
-  });
 
-  test.beforeEach(async ({ page }) => {
     await loginViaCookie(page, UI_URL, creds);
     await page.goto(`${UI_URL}/b/${boardId}`);
     await page.waitForLoadState('networkidle');
@@ -40,9 +53,7 @@ test.describe('Card Description — Inline Click-to-Edit', () => {
   });
 
   test('Test 1 — Enter edit mode by clicking description area', async ({ page }) => {
-    const descArea = page.locator(
-      '[data-testid="card-description"], [data-testid="description-view"], [aria-label*="description"]',
-    ).first();
+    const descArea = page.locator(descriptionViewSelector).first();
 
     // Explicit "Edit" button should NOT be present
     await expect(page.getByRole('button', { name: /^Edit$/i })).not.toBeVisible();
@@ -50,12 +61,10 @@ test.describe('Card Description — Inline Click-to-Edit', () => {
     // Click the description area to enter edit mode
     await descArea.click();
 
-    // Textarea should appear with focus
-    const textarea = page.locator(
-      'textarea[data-testid*="description"], textarea[name*="description"], [data-testid="description-editor"]',
-    ).first();
-    await expect(textarea).toBeVisible({ timeout: 5000 });
-    await expect(textarea).toBeFocused();
+    // Rich text editor should appear with focus
+    const editor = page.locator(richEditorSelector).first();
+    await expect(editor).toBeVisible({ timeout: 5000 });
+    await expect(editor).toBeFocused();
 
     // Save and Cancel buttons should appear
     await expect(page.getByRole('button', { name: /save/i })).toBeVisible();
@@ -63,15 +72,7 @@ test.describe('Card Description — Inline Click-to-Edit', () => {
   });
 
   test('Test 2 — Save with Ctrl+Enter', async ({ page }) => {
-    const descArea = page.locator(
-      '[data-testid="card-description"], [data-testid="description-view"], [aria-label*="description"]',
-    ).first();
-    await descArea.click();
-
-    const textarea = page.locator(
-      'textarea[data-testid*="description"], textarea[name*="description"], [data-testid="description-editor"]',
-    ).first();
-    await textarea.waitFor({ state: 'visible', timeout: 5000 });
+    const textarea = await openMarkdownEditor(page);
     await textarea.fill('**Bold description** with _italic_ text');
 
     // Ctrl+Enter to save
@@ -81,27 +82,19 @@ test.describe('Card Description — Inline Click-to-Edit', () => {
     await expect(textarea).not.toBeVisible({ timeout: 5000 });
 
     // Rendered output should contain bold element
-    const descContainer = page.locator('[data-testid="card-description"], [data-testid="description-view"]').first();
+    const descContainer = page.locator('[aria-label="Description (click to edit)"], [aria-label="Add a description (click to edit)"], [data-testid="card-description"], [data-testid="description-view"]').first();
     await expect(descContainer.locator('strong, b')).toBeVisible({ timeout: 5000 });
 
     // Close and reopen to verify persistence
     await page.keyboard.press('Escape');
     await page.locator('[aria-label^="Card:"]').first().click();
     await page.waitForSelector('[data-testid="card-modal"], [role="dialog"][aria-label^="Card:"]', { timeout: 8000 });
-    const descContainerReopened = page.locator('[data-testid="card-description"], [data-testid="description-view"]').first();
+    const descContainerReopened = page.locator('[aria-label="Description (click to edit)"], [aria-label="Add a description (click to edit)"], [data-testid="card-description"], [data-testid="description-view"]').first();
     await expect(descContainerReopened.locator('strong, b')).toBeVisible({ timeout: 5000 });
   });
 
   test('Test 3 — Cancel with Escape restores original text', async ({ page }) => {
-    const descArea = page.locator(
-      '[data-testid="card-description"], [data-testid="description-view"], [aria-label*="description"]',
-    ).first();
-    await descArea.click();
-
-    const textarea = page.locator(
-      'textarea[data-testid*="description"], textarea[name*="description"], [data-testid="description-editor"]',
-    ).first();
-    await textarea.waitFor({ state: 'visible', timeout: 5000 });
+    const textarea = await openMarkdownEditor(page);
     await textarea.fill('Temporary unsaved text');
 
     await textarea.press('Escape');
@@ -110,20 +103,12 @@ test.describe('Card Description — Inline Click-to-Edit', () => {
     await expect(textarea).not.toBeVisible({ timeout: 5000 });
 
     // Original text should still be shown (the .md says "Original text" but we saved bold in test 2 — use contains check)
-    const descContainer = page.locator('[data-testid="card-description"], [data-testid="description-view"]').first();
+    const descContainer = page.locator('[aria-label="Description (click to edit)"], [aria-label="Add a description (click to edit)"], [data-testid="card-description"], [data-testid="description-view"]').first();
     await expect(descContainer.getByText('Temporary unsaved text')).not.toBeVisible({ timeout: 3000 });
   });
 
   test('Test 4 — Save with Save button', async ({ page }) => {
-    const descArea = page.locator(
-      '[data-testid="card-description"], [data-testid="description-view"], [aria-label*="description"]',
-    ).first();
-    await descArea.click();
-
-    const textarea = page.locator(
-      'textarea[data-testid*="description"], textarea[name*="description"], [data-testid="description-editor"]',
-    ).first();
-    await textarea.waitFor({ state: 'visible', timeout: 5000 });
+    const textarea = await openMarkdownEditor(page);
     await textarea.fill('Saved via button');
 
     await page.getByRole('button', { name: /save/i }).click();
@@ -133,17 +118,9 @@ test.describe('Card Description — Inline Click-to-Edit', () => {
   });
 
   test('Test 5 — Cancel with Cancel button', async ({ page }) => {
-    const descArea = page.locator(
-      '[data-testid="card-description"], [data-testid="description-view"], [aria-label*="description"]',
-    ).first();
-    await descArea.click();
-
-    const textarea = page.locator(
-      'textarea[data-testid*="description"], textarea[name*="description"], [data-testid="description-editor"]',
-    ).first();
-    await textarea.waitFor({ state: 'visible', timeout: 5000 });
-
+    const descArea = page.locator(descriptionViewSelector).first();
     const prevText = await descArea.textContent();
+    const textarea = await openMarkdownEditor(page);
     await textarea.fill('Will not be saved');
 
     await page.getByRole('button', { name: /cancel/i }).click();
@@ -171,27 +148,17 @@ test.describe('Card Description — Inline Click-to-Edit', () => {
     const placeholder = page.getByText(/add a more detailed description/i);
     await expect(placeholder).toBeVisible({ timeout: 5000 });
 
-    // Placeholder should be clickable — click enters edit mode
+    // Placeholder should be clickable — click enters rich-text edit mode
     await placeholder.click();
-    const textarea = page.locator(
-      'textarea[data-testid*="description"], textarea[name*="description"], [data-testid="description-editor"]',
-    ).first();
-    await expect(textarea).toBeVisible({ timeout: 5000 });
+    await expect(page.locator(richEditorSelector).first()).toBeVisible({ timeout: 5000 });
   });
 
   test('Test 7 — Keyboard accessibility: Enter on view element enters edit mode', async ({ page }) => {
-    const descView = page.locator('[role="button"][tabindex="0"]').filter({ hasText: /description|Original text|Saved via button/ }).first();
-    if (await descView.count() === 0) {
-      test.skip(true, 'Could not locate description view element with role=button tabIndex=0');
-      return;
-    }
+    const descView = page.locator('[aria-label="Description (click to edit)"], [aria-label="Add a description (click to edit)"]').first();
 
     await descView.focus();
     await descView.press('Enter');
 
-    const textarea = page.locator(
-      'textarea[data-testid*="description"], textarea[name*="description"], [data-testid="description-editor"]',
-    ).first();
-    await expect(textarea).toBeVisible({ timeout: 5000 });
+    await expect(page.locator(richEditorSelector).first()).toBeVisible({ timeout: 5000 });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the failing `tests/e2e/card-description-inline-edit.spec.ts` suite (previously 0/7 or 4/7 passing with timeouts).

## Root Causes

1. **Stale cookie on test reuse:** `beforeAll` registered a single user and re-used the same refresh token cookie across tests. Because Chimedeck rotates refresh tokens during boot/refresh, subsequent tests injected a revoked cookie, bounced to `/login`, and timed out waiting for board elements.
2. **Editor architecture mismatch:** `CardDescriptionTiptap` defaults to the rich-text Tiptap editor (`.ProseMirror[contenteditable="true"]`), not a raw markdown `textarea`. Tests expecting an immediate textarea after clicking the description preview timed out unless they switched to the Markdown tab.

## Changes (test-only)

- Moved fixture creation to `beforeEach` so every test gets a fresh user, workspace, board, card, and valid cookie.
- Aligned click-to-edit, placeholder-click, and keyboard accessibility tests to expect the rich-text editor (`.ProseMirror[contenteditable="true"]`).
- Added `openMarkdownEditor` helper to click the `Markdown` mode button before markdown-specific textarea interactions.
- Updated preview selectors to include `[aria-label="Description (click to edit)"]` and `[aria-label="Add a description (click to edit)"]`.

## Verification

- `bunx playwright test tests/e2e/card-description-inline-edit.spec.ts --project=e2e --reporter=line`: 7 passed (12.5s)
- `bunx eslint tests/e2e/card-description-inline-edit.spec.ts`: clean (exit 0)
- Test-only changes; no application code modified.