### PR TITLE
fix(e2e): recover custom fields UI spec

### DIFF
--- a/tests/e2e/custom-fields-ui.spec.ts
+++ b/tests/e2e/custom-fields-ui.spec.ts
@@ -10,23 +10,26 @@ const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 
 interface SetupResult {
   creds: Credentials;
+  token: string;
   boardId: string;
   cardId: string;
 }
 
-async function setupBoardWithCard(request: APIRequestContext, page: import('@playwright/test').Page): Promise<SetupResult> {
+async function setupBoardWithCard(request: APIRequestContext): Promise<SetupResult> {
   const creds = await registerAndGetCredentials(request, 'cf-ui');
   const wsId = await createWorkspace(request, creds.token);
   const boardId = await createBoard(request, creds.token, wsId);
   const listId = await createList(request, creds.token, boardId);
   const cardId = await createCard(request, creds.token, listId, 'CF UI Test Card');
 
-  // The app authenticates via HttpOnly cookies, so log in through the UI form.
-  await loginViaCookie(page, UI_URL, creds);
-  await page.goto(`${UI_URL}/b/${boardId}`);
-  await page.waitForLoadState('networkidle');
+  return { creds, token: creds.token, boardId, cardId };
+}
 
-  return { creds, boardId, cardId };
+
+async function openBoard(page: import('@playwright/test').Page, setup: SetupResult): Promise<void> {
+  await loginViaCookie(page, UI_URL, setup.creds);
+  await page.goto(`${UI_URL}/b/${setup.boardId}`);
+  await page.waitForLoadState('networkidle');
 }
 
 async function createFieldViaApi(
@@ -39,7 +42,10 @@ async function createFieldViaApi(
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   });
-  const body = await res.json() as { data: { id: string } };
+  const body = await res.json() as { data?: { id: string }; error?: unknown };
+  if (!res.ok || !body.data?.id) {
+    throw new Error(`Failed to create custom field (${res.status}): ${JSON.stringify(body)}`);
+  }
   return body.data.id;
 }
 
@@ -50,22 +56,22 @@ async function openCardModal(page: import('@playwright/test').Page) {
 
 test.describe('Custom Fields UI — Card Modal Value Editing', () => {
   test('TEXT field — edit and save value in card modal, badge on tile', async ({ request, page }) => {
-    const { token, boardId } = await setupBoardWithCard(request, page);
+    const setup = await setupBoardWithCard(request);
+    const { token, boardId } = setup;
     await createFieldViaApi(token, boardId, {
       name: 'Notes',
       field_type: 'TEXT',
       show_on_card: true,
       position: 0,
     });
-    await page.reload();
-    await page.waitForLoadState('networkidle');
+    await openBoard(page, setup);
 
     await openCardModal(page);
 
     const customFieldsSection = page.getByText(/custom fields/i);
     await expect(customFieldsSection).toBeVisible({ timeout: 5000 });
 
-    const notesInput = page.getByLabel(/Notes/i).or(page.locator('input[placeholder*="Notes"], textarea[placeholder*="Notes"]'));
+    const notesInput = page.getByRole('textbox', { name: 'Notes value' });
     await notesInput.click();
     await notesInput.fill('Hello world');
     await notesInput.press('Tab');
@@ -76,51 +82,52 @@ test.describe('Custom Fields UI — Card Modal Value Editing', () => {
   });
 
   test('NUMBER field — edit value in card modal, badge on tile', async ({ request, page }) => {
-    const { token, boardId } = await setupBoardWithCard(request, page);
+    const setup = await setupBoardWithCard(request);
+    const { token, boardId } = setup;
     await createFieldViaApi(token, boardId, {
       name: 'Story Points',
       field_type: 'NUMBER',
       show_on_card: true,
       position: 0,
     });
-    await page.reload();
-    await page.waitForLoadState('networkidle');
+    await openBoard(page, setup);
 
     await openCardModal(page);
 
-    const numInput = page.getByLabel(/Story Points/i).or(page.locator('input[type="number"]'));
+    const numInput = page.getByRole('spinbutton', { name: 'Story Points value' }).or(page.locator('input[type="number"]')).first();
     await numInput.click();
     await numInput.fill('8');
     await numInput.press('Enter');
 
     await page.keyboard.press('Escape');
 
-    await expect(page.getByText('8')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[aria-label="Story Points: 8"], [title="Story Points: 8"]').first()).toBeVisible({ timeout: 5000 });
   });
 
   test('CHECKBOX field — toggle value in card modal', async ({ request, page }) => {
-    const { token, boardId } = await setupBoardWithCard(request, page);
+    const setup = await setupBoardWithCard(request);
+    const { token, boardId } = setup;
     await createFieldViaApi(token, boardId, {
       name: 'Reviewed',
       field_type: 'CHECKBOX',
       show_on_card: true,
       position: 0,
     });
-    await page.reload();
-    await page.waitForLoadState('networkidle');
+    await openBoard(page, setup);
 
     await openCardModal(page);
 
-    const checkbox = page.getByLabel(/Reviewed/i);
+    const checkbox = page.getByRole('checkbox', { name: 'Reviewed' });
     await expect(checkbox).not.toBeChecked();
-    await checkbox.check();
-    await expect(checkbox).toBeChecked();
+    await checkbox.click();
+    await expect(page.locator('[aria-label="Reviewed: ✓"], [title="Reviewed: ✓"]').first()).toBeVisible({ timeout: 5000 });
 
     await page.keyboard.press('Escape');
   });
 
   test('DROPDOWN field — select option in card modal', async ({ request, page }) => {
-    const { token, boardId } = await setupBoardWithCard(request, page);
+    const setup = await setupBoardWithCard(request);
+    const { token, boardId } = setup;
     await createFieldViaApi(token, boardId, {
       name: 'Priority',
       field_type: 'DROPDOWN',
@@ -132,8 +139,7 @@ test.describe('Custom Fields UI — Card Modal Value Editing', () => {
       show_on_card: true,
       position: 0,
     });
-    await page.reload();
-    await page.waitForLoadState('networkidle');
+    await openBoard(page, setup);
 
     await openCardModal(page);
 
@@ -146,19 +152,19 @@ test.describe('Custom Fields UI — Card Modal Value Editing', () => {
   });
 
   test('Clear a field value removes badge from tile', async ({ request, page }) => {
-    const { token, boardId } = await setupBoardWithCard(request, page);
+    const setup = await setupBoardWithCard(request);
+    const { token, boardId } = setup;
     await createFieldViaApi(token, boardId, {
       name: 'Notes',
       field_type: 'TEXT',
       show_on_card: true,
       position: 0,
     });
-    await page.reload();
-    await page.waitForLoadState('networkidle');
+    await openBoard(page, setup);
 
     await openCardModal(page);
 
-    const notesInput = page.getByLabel(/Notes/i).or(page.locator('input[placeholder*="Notes"]'));
+    const notesInput = page.getByRole('textbox', { name: 'Notes value' });
     await notesInput.fill('Hello world');
     await notesInput.press('Tab');
 
@@ -176,19 +182,19 @@ test.describe('Custom Fields UI — Card Modal Value Editing', () => {
   });
 
   test('show_on_card=false — no badge on tile', async ({ request, page }) => {
-    const { token, boardId } = await setupBoardWithCard(request, page);
+    const setup = await setupBoardWithCard(request);
+    const { token, boardId } = setup;
     await createFieldViaApi(token, boardId, {
       name: 'Internal Notes',
       field_type: 'TEXT',
       show_on_card: false,
       position: 0,
     });
-    await page.reload();
-    await page.waitForLoadState('networkidle');
+    await openBoard(page, setup);
 
     await openCardModal(page);
 
-    const notesInput = page.getByLabel(/Internal Notes/i).or(page.locator('input[placeholder*="Internal Notes"]'));
+    const notesInput = page.getByRole('textbox', { name: 'Internal Notes value' });
     await notesInput.fill('private text');
     await notesInput.press('Tab');
     await page.keyboard.press('Escape');


### PR DESCRIPTION
## Summary

Fixes `tests/e2e/custom-fields-ui.spec.ts` after the card tile/modal selector drift was unblocked.

## Root causes

- `SetupResult` did not expose `token`, but tests destructured `const { token, boardId } = ...`, so custom-field API creation sent `Authorization: Bearer undefined` and failed at `body.data.id`.
- The spec loaded the browser board before creating each custom field, then reloaded. Because app boot refresh rotates auth cookies and access state is in memory, that reload could land on `/login`.
- A few assertions/selectors were too broad after badges rendered, e.g. `getByText('8')` matching timestamps and `getByLabel(/Notes/i)` matching the badge, input, and clear button.
- Checkbox save is async; the persisted value is reflected by the rendered `Reviewed: ✓` badge.

## Changes (test-only)

- Return `token` from setup fixture.
- Create custom fields before opening the UI board; then inject cookie and navigate once.
- Add explicit custom-field API failure diagnostics.
- Use exact accessible field controls/badge labels:
  - `Notes value`
  - `Story Points value` / `Story Points: 8`
  - `Internal Notes value`
  - `Reviewed: ✓`
- Preserve product behaviour; no source changes.

## Verification

- `bunx playwright test tests/e2e/custom-fields-ui.spec.ts --project=e2e --reporter=line`: 6 passed (10.2s)
- `bunx eslint tests/e2e/custom-fields-ui.spec.ts`: clean
- `git diff --check`: clean