### PR TITLE
fix(e2e): align list sanitization tests with title field

### DIFF
--- a/tests/e2e/input-sanitization.spec.ts
+++ b/tests/e2e/input-sanitization.spec.ts
@@ -103,23 +103,22 @@ test.describe('Input Sanitization — XSS Prevention', () => {
   test('Test 7 — XSS payload in list name is stripped', async ({ request }) => {
     const res = await request.post(`${BASE_URL}/api/v1/boards/${boardId}/lists`, {
       headers: { Authorization: `Bearer ${token}` },
-      data: { name: '<script>xss()</script>Backlog', position: 99 },
+      data: { title: '<script>xss()</script>Backlog' },
     });
     expect(res.status()).toBe(201);
     const body = await res.json();
-    expect(body.data.name ?? body.data.title).toBe('Backlog');
-    expect((body.data.name ?? body.data.title) as string).not.toContain('<script>');
+    expect(body.data.title).toBe('Backlog');
+    expect(body.data.title as string).not.toContain('<script>');
   });
 
   test('Test 8 — XSS payload in list name update is stripped', async ({ request }) => {
     const res = await request.patch(`${BASE_URL}/api/v1/lists/${listId}`, {
       headers: { Authorization: `Bearer ${token}` },
-      data: { name: '<img src=x onerror=alert(1)>Sprint 1' },
+      data: { title: '<img src=x onerror=alert(1)>Sprint 1' },
     });
     expect(res.status()).toBe(200);
     const body = await res.json();
-    const name = body.data.name ?? body.data.title;
-    expect(name).toBe('Sprint 1');
+    expect(body.data.title).toBe('Sprint 1');
   });
 
   test('Test 9 — XSS in comment content stripped; safe Markdown preserved', async ({ request }) => {


### PR DESCRIPTION
## Summary

Fixes the 2 failing tests in `tests/e2e/input-sanitization.spec.ts` (9/11 -> 11/11). Test-only.

## Root cause

The list create/update APIs accept `{ title }`, not `{ name }`. Tests 7 and 8 sent `{ name: ... }`, so the server returned 400 `title is required` and the tests asserted on a non-existent response shape - they never actually exercised sanitization.

Verified against the live API:

    POST /boards/:id/lists  { name: "<script>xss()</script>Backlog", position: 99 }
    -> 400 {"error":{"code":"bad-request","message":"title is required"}}

    POST /boards/:id/lists  { title: "<script>xss()</script>Backlog" }
    -> 201 {"data":{...,"title":"Backlog"}}

## Changes

- Test 7: send `{ title }`, assert `data.title` is `Backlog` and contains no `<script>`.
- Test 8: send `{ title }` on PATCH, assert `data.title` is `Sprint 1`.
- Dropped the `name ?? title` fallbacks, which masked the wrong field name.

Server-side sanitization is unchanged and still asserted.

## Verification

- `bunx playwright test tests/e2e/input-sanitization.spec.ts --project=e2e`: 11 passed twice consecutively (1.1s, 925ms)
- `bunx eslint tests/e2e/input-sanitization.spec.ts`: clean
- `git diff --check`: clean
- No product source changed.
