### PR TITLE
fix(e2e): correct custom-field value number and guest invite contracts

### DIFF
--- a/tests/e2e/custom-field-values-api.spec.ts
+++ b/tests/e2e/custom-field-values-api.spec.ts
@@ -115,7 +115,9 @@ test.describe('Custom Field Values API', () => {
     const res = await upsertValue(request, token, cardId, numFieldId, 42);
     expect(res.status()).toBe(201);
     const body = await res.json();
-    expect(body.data.value_number).toBe(42);
+    // The NUMERIC column serialises as a decimal string (e.g. "42.0000"); the
+    // API type is `string | number | null` and the client coerces with Number().
+    expect(Number(body.data.value_number)).toBe(42);
   });
 
   test('PUT — NUMBER value wrong type returns 400', async ({ request }) => {

--- a/tests/e2e/member-joined-event.spec.ts
+++ b/tests/e2e/member-joined-event.spec.ts
@@ -49,7 +49,7 @@ async function createBoard(
 }
 
 async function getUserId(request: APIRequestContext, token: string): Promise<string> {
-  const res = await request.get(`${BASE_URL}/api/v1/me`, {
+  const res = await request.get(`${BASE_URL}/api/v1/users/me`, {
     headers: { Authorization: `Bearer ${token}` },
   });
   const body = await res.json() as { data: { id: string } };
@@ -71,10 +71,11 @@ test.describe('member_joined event', () => {
     const guest = await registerAndLogin(request, 'mj-guest');
     const guestUserId = await getUserId(request, guest.token);
 
-    // Invite the guest to the board
+    // Invite the guest to the board. The guests endpoint accepts an email and
+    // resolves (or creates) the user, so pass the guest's email.
     const inviteRes = await request.post(`${BASE_URL}/api/v1/boards/${boardId}/guests`, {
       headers: { Authorization: `Bearer ${owner.token}` },
-      data: { userId: guestUserId },
+      data: { email: guest.email },
     });
     expect(inviteRes.status()).toBe(201);
 
@@ -104,12 +105,11 @@ test.describe('member_joined event', () => {
     const boardId = await createBoard(request, owner.token, workspaceId);
 
     const guest = await registerAndLogin(request, 'mj-ver-guest');
-    const guestUserId = await getUserId(request, guest.token);
 
     // Trigger at least one event (board_created fires on board creation; invite fires member_joined)
     await request.post(`${BASE_URL}/api/v1/boards/${boardId}/guests`, {
       headers: { Authorization: `Bearer ${owner.token}` },
-      data: { userId: guestUserId },
+      data: { email: guest.email },
     });
 
     const eventsRes = await request.get(`${BASE_URL}/api/v1/boards/${boardId}/events?since=0`, {


### PR DESCRIPTION
## Summary

Recovers `tests/e2e/custom-field-values-api.spec.ts` and `tests/e2e/member-joined-event.spec.ts` (14/18 -> 18/18). Test-only.

## Root causes

### custom-field-values-api (2 failures, one cascading)

1. **NUMBER serialisation:** the DB column is NUMERIC and serialises as a decimal string (`"42.0000"`). The API type is `value_number: string | number | null`, and the client coerces with `Number(...)`. The test asserted strict `toBe(42)`. Now asserts `Number(body.data.value_number)`.
2. **Cascade into DELETE:** the failing NUMBER test caused Playwright to restart the worker mid-suite, which re-ran `beforeAll` and created a fresh card/field. The DELETE test then referenced a card with no value and got 404. Fixing (1) removes the restart and the DELETE test passes.

Diagnosed by instrumenting the spec: `beforeAll` observably re-ran mid-run with a different `cardId`, proving the worker-restart cascade.

### member-joined-event (2 failures)

- **Wrong user endpoint:** `getUserId` called `/api/v1/me`, which does not exist (404). Correct path is `/api/v1/users/me`.
- **Wrong guest invite contract:** the board guests endpoint accepts `{ email }` and resolves (or creates) the user. The tests sent `{ userId }` and got 400 `invalid-email`. Switched both invites to the guest's email. The event payload (`scope: 'board'`, `userId`, `role: 'GUEST'`) is unchanged and still asserted.

## Verification

- `bunx playwright test tests/e2e/custom-field-values-api.spec.ts tests/e2e/member-joined-event.spec.ts --project=e2e`: **18 passed** twice consecutively (1.6s, 1.4s)
- `bunx eslint` on both files: clean
- `git diff --check`: clean
- No product source changed; no debug scaffolding left behind.
