### PR TITLE
fix(e2e): make offline queue hydration test observe a non-replayed mutation

### DIFF
--- a/tests/e2e/offline-queue-persistence.spec.ts
+++ b/tests/e2e/offline-queue-persistence.spec.ts
@@ -168,12 +168,18 @@ test.describe('offline mutation queue — IndexedDB persistence', () => {
     expect(beforeReload).toHaveLength(1);
     expect((beforeReload[0] as { id: string }).id).toBe(mutationId);
 
+    // Block the replay request so it cannot succeed. On boot the app hydrates the
+    // queue from IndexedDB and then replays on WS connect; a successful replay
+    // removes the mutation. To observe the hydration-only state we make the
+    // replay fail (network error stops replay, leaving the mutation queued).
+    await page.route(`**/api/v1/boards/${boardId}/lists`, (route) => route.abort());
+
     // Hard reload — App.tsx calls loadPersistedMutations() on boot which should
     // hydrate the in-memory queue with this mutation
     await page.reload({ waitUntil: 'networkidle' });
 
-    // After reload, the mutation must still be in IndexedDB (it is only removed
-    // when replay succeeds — not merely on hydration)
+    // After reload the mutation must still be in IndexedDB: it is only removed
+    // when replay succeeds, and we forced the replay to fail.
     const afterReload = await readMutationsFromIDB(page);
     expect(afterReload).toHaveLength(1);
     expect((afterReload[0] as { id: string }).id).toBe(mutationId);


### PR DESCRIPTION
## Summary

Fixes the last failing singleton spec (1/2 -> 2/2). Test-only.

## Root cause

The test asserted that a mutation seeded into IndexedDB is still present after a page reload, on the stated premise that it is "only removed when replay succeeds — not merely on hydration".

That premise was never exercised. On boot `App.tsx` hydrates the queue from IndexedDB, and `useWebSocket.replayQueue()` then replays it as soon as the WS connects. A **successful** replay calls `messageQueue.dequeue()`, which deletes the row from IndexedDB. So the mutation was correctly removed by real, successful replay and the assertion raced actual behaviour.

## Fix

Block the replay request (`page.route(...).abort()`) before reloading. A network error stops replay and leaves the mutation queued, so the hydration-only state can actually be observed — exactly what the test claims to check. The second test (`mutation is removed from IndexedDB after successful replay`) is unchanged and still passes, and now the pair genuinely covers both outcomes.

## Verification

- `bunx playwright test tests/e2e/offline-queue-persistence.spec.ts --project=e2e`: **2 passed** twice consecutively (4.4s, 5.1s)
- `bunx eslint tests/e2e/offline-queue-persistence.spec.ts`: clean
- `git diff --check`: clean
- No product source changed.
