### PR TITLE
fix(e2e): attach replay request listener before reload

### DIFF
--- a/tests/e2e/offline-queue-persistence.spec.ts
+++ b/tests/e2e/offline-queue-persistence.spec.ts
@@ -207,19 +207,18 @@ test.describe('offline mutation queue — IndexedDB persistence', () => {
       enqueuedAt: Date.now(),
     };
 
-    // Seed mutation and reload
+    // Seed mutation, then reload. The listener must be attached BEFORE the
+    // reload because boot hydrates the queue and replay fires as soon as the WS
+    // connects — registering afterwards races and can miss the request.
     await seedMutationInIDB(page, mutation);
-    await page.reload({ waitUntil: 'domcontentloaded' });
 
-    // Intercept the list-creation API call that the queue replay will send
     const replayRequest = page.waitForRequest(
       (req) =>
         req.url().includes(`/api/v1/boards/${boardId}/lists`) && req.method() === 'POST',
       { timeout: 15_000 },
     );
 
-    // Navigate to the board page so the WS connects and replay is triggered
-    await page.goto(`${UI_URL}/b/${boardId}`, { waitUntil: 'networkidle' });
+    await page.reload({ waitUntil: 'domcontentloaded' });
 
     // Verify the replay HTTP call was made
     const replayed = await replayRequest;


### PR DESCRIPTION
## Summary

Fixes a race that only surfaced in the full suite (the second offline-queue test passed in isolation but timed out at 15s in the suite).

## Root cause

`page.waitForRequest(...)` for the replay POST was registered **after** `page.reload()`. But the reload itself triggers boot hydration and the WS-connect replay, so the listener could miss the request entirely and time out. Timing differs between an isolated run and the full suite, which is why it passed standalone.

## Fix

Attach the listener before reloading, and drop the redundant second `goto` (the reload already boots the app and connects the WS, so replay fires from it).

## Verification

- `bunx playwright test tests/e2e/offline-queue-persistence.spec.ts --project=e2e`: **2 passed** three times consecutively (4.3s, 3.7s, 3.3s)
- `bunx eslint`: clean
- `git diff --check`: clean
- No product source changed.
