### PR TITLE
fix(dates): interpret card date fields in the viewer local timezone

### DIFF
--- a/src/common/utils/dates.test.ts
+++ b/src/common/utils/dates.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test';
+import { localDateKey, parseLocalDate, toLocalDateKey } from './dates';
+
+// These tests guard the two date traps documented in dates.ts:
+//   1. slicing an ISO string yields the UTC date, not the local one;
+//   2. new Date("YYYY-MM-DD") is UTC midnight, so converting it to local time
+//      shifts the day for negative-offset timezones.
+// A date-only string must always survive as the same calendar date, regardless
+// of the runtime timezone, because drag/resize paths persist and re-read it.
+
+describe('localDateKey', () => {
+  it('returns a date-only string verbatim', () => {
+    expect(localDateKey('2026-09-15')).toBe('2026-09-15');
+    expect(localDateKey('2026-01-01')).toBe('2026-01-01');
+    expect(localDateKey('2026-12-31')).toBe('2026-12-31');
+  });
+
+  it('does not shift date-only strings across month and year boundaries', () => {
+    expect(localDateKey('2026-01-01')).toBe('2026-01-01');
+    expect(localDateKey('2026-03-01')).toBe('2026-03-01');
+    expect(localDateKey('2026-12-01')).toBe('2026-12-01');
+  });
+
+  it('converts a full ISO timestamp to a calendar date', () => {
+    expect(localDateKey('2026-09-15T05:00:00.000Z')).toMatch(/^2026-09-1[45]$/);
+  });
+
+  it('returns an empty string for unparseable input', () => {
+    expect(localDateKey('not-a-date')).toBe('');
+  });
+});
+
+describe('parseLocalDate', () => {
+  it('parses a date-only string to local midnight of that date', () => {
+    const d = parseLocalDate('2026-09-15');
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(8); // September
+    expect(d.getDate()).toBe(15);
+    expect(d.getHours()).toBe(0);
+  });
+
+  it('round-trips a date-only string without losing a day', () => {
+    // Regression: new Date("2026-09-15") is UTC midnight, which used to shift
+    // this back to the 14th west of UTC.
+    expect(toLocalDateKey(parseLocalDate('2026-09-15'))).toBe('2026-09-15');
+    expect(toLocalDateKey(parseLocalDate('2026-01-01'))).toBe('2026-01-01');
+    expect(toLocalDateKey(parseLocalDate('2026-12-31'))).toBe('2026-12-31');
+  });
+});
+
+describe('toLocalDateKey', () => {
+  it('formats a local Date as YYYY-MM-DD with zero padding', () => {
+    expect(toLocalDateKey(new Date(2026, 0, 5))).toBe('2026-01-05');
+    expect(toLocalDateKey(new Date(2026, 11, 31))).toBe('2026-12-31');
+  });
+});

--- a/src/common/utils/dates.ts
+++ b/src/common/utils/dates.ts
@@ -1,0 +1,40 @@
+// Date helpers for date-bearing card fields (due_date, start_date, value_date).
+//
+// WHY: these fields are stored as full ISO timestamps (instants). Different
+// surfaces must interpret them the same way — in the viewer's local timezone —
+// or the same card appears on different days depending on which view you open.
+// Slicing the raw ISO string (`iso.slice(0, 10)`) yields the *UTC* date, which
+// disagrees with local-time rendering for anyone not at UTC.
+
+/**
+ * The local calendar date of an ISO timestamp, as "YYYY-MM-DD".
+ * Use this for grouping/keying dates (calendar cells, timeline lanes, badges).
+ */
+export function localDateKey(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${String(y)}-${m}-${day}`;
+}
+
+/**
+ * Parse an ISO timestamp into a Date at local midnight of its local calendar
+ * date. Use this for day-arithmetic and positioning, where only the date part
+ * matters and the time component must not shift the day.
+ */
+export function parseLocalDate(iso: string): Date {
+  const key = localDateKey(iso);
+  if (!key) return new Date(NaN);
+  const [y, m, d] = key.split('-');
+  return new Date(Number(y), Number(m) - 1, Number(d));
+}
+
+/** Format a Date as "YYYY-MM-DD" using its local calendar date. */
+export function toLocalDateKey(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${String(y)}-${m}-${day}`;
+}

--- a/src/common/utils/dates.ts
+++ b/src/common/utils/dates.ts
@@ -1,16 +1,31 @@
 // Date helpers for date-bearing card fields (due_date, start_date, value_date).
 //
-// WHY: these fields are stored as full ISO timestamps (instants). Different
-// surfaces must interpret them the same way — in the viewer's local timezone —
-// or the same card appears on different days depending on which view you open.
-// Slicing the raw ISO string (`iso.slice(0, 10)`) yields the *UTC* date, which
-// disagrees with local-time rendering for anyone not at UTC.
+// WHY: these fields are stored as full ISO timestamps (instants), but some code
+// paths (drag/resize, date inputs) also pass and persist plain "YYYY-MM-DD"
+// date-only strings. Both shapes must resolve to the same calendar date for the
+// viewer, or the same card appears on different days depending on the surface.
+//
+// Two traps this module exists to avoid:
+//   1. `iso.slice(0, 10)` yields the *UTC* date, which disagrees with local-time
+//      rendering for anyone not at UTC.
+//   2. `new Date("YYYY-MM-DD")` is parsed as UTC midnight, so converting it to
+//      local time shifts it back a day for negative-offset timezones. A
+//      date-only string must therefore be treated as a literal calendar date,
+//      never round-tripped through a Date instant.
+
+/** True for a bare "YYYY-MM-DD" string (no time component). */
+function isDateOnly(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(s);
+}
 
 /**
- * The local calendar date of an ISO timestamp, as "YYYY-MM-DD".
+ * The local calendar date of a date field, as "YYYY-MM-DD".
+ * - A date-only string is returned verbatim (it is already a calendar date).
+ * - A full ISO timestamp is converted to the viewer's local calendar date.
  * Use this for grouping/keying dates (calendar cells, timeline lanes, badges).
  */
 export function localDateKey(iso: string): string {
+  if (isDateOnly(iso)) return iso;
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return '';
   const y = d.getFullYear();
@@ -20,9 +35,9 @@ export function localDateKey(iso: string): string {
 }
 
 /**
- * Parse an ISO timestamp into a Date at local midnight of its local calendar
- * date. Use this for day-arithmetic and positioning, where only the date part
- * matters and the time component must not shift the day.
+ * Parse a date field into a Date at local midnight of its calendar date.
+ * Use this for day-arithmetic and positioning, where only the date part matters
+ * and the time component must not shift the day.
  */
 export function parseLocalDate(iso: string): Date {
   const key = localDateKey(iso);

--- a/src/extensions/CalendarView/CalendarView.tsx
+++ b/src/extensions/CalendarView/CalendarView.tsx
@@ -8,6 +8,7 @@ import CalendarMonthGrid from './CalendarMonthGrid';
 import CalendarWeekGrid from './CalendarWeekGrid';
 import { useCalendarDrag } from './useCalendarDrag';
 import translations from './translations/en.json';
+import { localDateKey } from '../../common/utils/dates';
 import type { CalendarMode, CalendarViewProps } from './types';
 import type { Card } from '../Card/api';
 
@@ -20,8 +21,9 @@ function buildCardsByDay(cards: Card[]): Map<string, Card[]> {
   const map = new Map<string, Card[]>();
   for (const card of cards) {
     if (!card.due_date) continue;
-    // Truncate to date portion only (handles ISO timestamps)
-    const key = card.due_date.slice(0, 10);
+    // Key by the viewer's local calendar date so the calendar agrees with the
+    // card tile / meta strip, which also render due dates in local time.
+    const key = localDateKey(card.due_date);
     const existing = map.get(key) ?? [];
     map.set(key, [...existing, card]);
   }

--- a/src/extensions/CalendarView/useCalendarDrag.ts
+++ b/src/extensions/CalendarView/useCalendarDrag.ts
@@ -5,6 +5,7 @@ import { useCallback } from 'react';
 import { apiClient } from '~/common/api/client';
 import { useAppDispatch } from '~/hooks/useAppDispatch';
 import { boardSliceActions } from '../Board/slices/boardSlice';
+import { localDateKey } from '../../common/utils/dates';
 import type { Card } from '../Card/api';
 
 interface UseCalendarDragOptions {
@@ -24,7 +25,7 @@ export function useCalendarDrag({ cards, addToast }: UseCalendarDragOptions): Us
   const handleCardDrop = useCallback(
     async (cardId: string, newDate: string) => {
       const card = cards.find((c) => c.id === cardId);
-      if (!card || card.due_date?.slice(0, 10) === newDate) return;
+      if (!card || (card.due_date && localDateKey(card.due_date) === newDate)) return;
 
       const prevDate = card.due_date;
 

--- a/src/extensions/TimelineView/TimelineBar.tsx
+++ b/src/extensions/TimelineView/TimelineBar.tsx
@@ -21,8 +21,6 @@ const DEFAULT_COLOR = '#3b82f6';
 /** Minimum bar width in pixels (ensures handles are always reachable). */
 const MIN_BAR_WIDTH = HANDLE_WIDTH * 2 + 8;
 
-
-
 function daysBetween(a: Date, b: Date): number {
   return Math.round((b.getTime() - a.getTime()) / (1000 * 60 * 60 * 24));
 }

--- a/src/extensions/TimelineView/TimelineBar.tsx
+++ b/src/extensions/TimelineView/TimelineBar.tsx
@@ -5,6 +5,7 @@
 //
 // TODO: dependency arrows — deferred to a future sprint.
 import translations from './translations/en.json';
+import { parseLocalDate } from '../../common/utils/dates';
 import type { TimelineBarProps } from './types';
 
 /** Width of each resize handle in pixels. */
@@ -20,13 +21,7 @@ const DEFAULT_COLOR = '#3b82f6';
 /** Minimum bar width in pixels (ensures handles are always reachable). */
 const MIN_BAR_WIDTH = HANDLE_WIDTH * 2 + 8;
 
-function parseLocalDate(s: string): Date {
-  // Slice the first 10 chars to handle both "YYYY-MM-DD" and full ISO "YYYY-MM-DDTHH:mm:ss...Z"
-  // DB timestamp columns return full ISO strings; slicing avoids NaN from the time component.
-  const datePart = s.slice(0, 10);
-  const parts = datePart.split('-');
-  return new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]));
-}
+
 
 function daysBetween(a: Date, b: Date): number {
   return Math.round((b.getTime() - a.getTime()) / (1000 * 60 * 60 * 24));

--- a/src/extensions/TimelineView/TimelineRow.tsx
+++ b/src/extensions/TimelineView/TimelineRow.tsx
@@ -7,6 +7,7 @@ import TimelineBar, { ROW_SLOT_HEIGHT } from './TimelineBar';
 import Button from '../../common/components/Button';
 import { useTimelineDrag } from './useTimelineDrag';
 import translations from './translations/en.json';
+import { parseLocalDate } from '../../common/utils/dates';
 import type { TimelineRowProps } from './types';
 import type { Card } from '../Card/api';
 
@@ -16,12 +17,6 @@ const BAR_TOP = 8;
 const BAR_BOTTOM_PAD = 6;
 
 // ── Row-packing helpers ────────────────────────────────────────────────────
-
-function parseLocalDate(s: string): Date {
-  const datePart = s.slice(0, 10);
-  const [y, m, d] = datePart.split('-');
-  return new Date(Number(y), Number(m) - 1, Number(d));
-}
 
 function daysBetween(a: Date, b: Date): number {
   return Math.round((b.getTime() - a.getTime()) / (1000 * 60 * 60 * 24));

--- a/src/extensions/TimelineView/TimelineView.tsx
+++ b/src/extensions/TimelineView/TimelineView.tsx
@@ -8,6 +8,7 @@ import TimelineHeader from './TimelineHeader';
 import TimelineRow from './TimelineRow';
 import TimelineZoomControl from './TimelineZoomControl';
 import translations from './translations/en.json';
+import { localDateKey, toLocalDateKey } from '../../common/utils/dates';
 import type { TimelineViewProps, ZoomLevel, Swimlane } from './types';
 import Button from '../../common/components/Button';
 
@@ -54,7 +55,8 @@ const TimelineView = ({ cards, lists, onCardClick, addToast: _addToast }: Timeli
   // Auto-scroll to today when component first mounts or zoom changes.
   useEffect(() => { scrollToToday(); }, [zoom]);
 
-  const todayIso = useMemo(() => today.toISOString().slice(0, 10), [today]);
+  // Local calendar date of 'today' (toISOString would give the UTC date).
+  const todayIso = useMemo(() => toLocalDateKey(today), [today]);
 
   // Group cards into swimlanes (one per list).
   // Cards are only shown when their due_date is today or in the future.
@@ -67,7 +69,7 @@ const TimelineView = ({ cards, lists, onCardClick, addToast: _addToast }: Timeli
         listTitle: list.title,
         // Only cards with a due_date that is today or in the future are scheduled.
         scheduledCards: listCards
-          .filter((c) => !!c.due_date && c.due_date >= todayIso)
+          .filter((c) => !!c.due_date && localDateKey(c.due_date) >= todayIso)
           .map((c) => (c.start_date ? c : { ...c, start_date: todayIso })),
         // No unscheduled cards — cards with no due_date are not displayed.
         unscheduledCards: [],

--- a/src/extensions/TimelineView/useTimelineDrag.ts
+++ b/src/extensions/TimelineView/useTimelineDrag.ts
@@ -10,6 +10,7 @@ import type { MouseEvent } from 'react';
 import { apiClient } from '~/common/api/client';
 import { useAppDispatch } from '~/hooks/useAppDispatch';
 import { boardSliceActions } from '../Board/slices/boardSlice';
+import { localDateKey, parseLocalDate, toLocalDateKey } from '../../common/utils/dates';
 import type { UseTimelineDragOptions, UseTimelineDragResult, TimelineDragOverride } from './types';
 
 type DragType = 'move' | 'resize-left' | 'resize-right';
@@ -25,21 +26,13 @@ interface DragState {
   currentDueDate: string;
 }
 
-function parseLocalDate(s: string): Date {
-  // Slice the first 10 chars to handle both "YYYY-MM-DD" and full ISO "YYYY-MM-DDTHH:mm:ss...Z"
-  const datePart = s.slice(0, 10);
-  const parts = datePart.split('-');
-  return new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]));
-}
-
-function formatDate(d: Date): string {
-  return `${String(d.getFullYear())}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-}
+// Day math uses the shared date utils so the timeline interprets due_date and
+// start_date in the viewer's local timezone, matching every other surface.
 
 function addDaysToStr(dateStr: string, days: number): string {
   const d = parseLocalDate(dateStr);
   d.setDate(d.getDate() + days);
-  return formatDate(d);
+  return toLocalDateKey(d);
 }
 
 export function useTimelineDrag({
@@ -69,8 +62,8 @@ export function useTimelineDrag({
       e.preventDefault();
       e.stopPropagation();
 
-      const origStart = card.start_date.slice(0, 10);
-      const origDue = card.due_date.slice(0, 10);
+      const origStart = localDateKey(card.start_date);
+      const origDue = localDateKey(card.due_date);
 
       dragRef.current = {
         type,

--- a/tests/e2e/calendar-view.spec.ts
+++ b/tests/e2e/calendar-view.spec.ts
@@ -107,8 +107,18 @@ async function goToBoard(page: Page, baseUrl: string, boardId: string, creds: Cr
       { name: 'refresh_token', value: creds.refreshToken, url: `${baseUrl}/api/v1/auth/refresh`, httpOnly: true, sameSite: 'Strict' },
     ]);
   }
-  await page.goto(`${baseUrl}/b/${boardId}`);
-  await page.waitForLoadState('networkidle');
+  await gotoBoardUntilReady(page, baseUrl, boardId);
+}
+
+// App boot performs an async token refresh; navigating immediately can race and
+// land on /workspaces. Retry until the board view switcher renders.
+async function gotoBoardUntilReady(page: Page, baseUrl: string, boardId: string): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await page.goto(`${baseUrl}/b/${boardId}`);
+    await page.waitForLoadState('networkidle');
+    if (await page.getByTestId('board-view-switcher').isVisible().catch(() => false)) return;
+    await page.waitForTimeout(500);
+  }
 }
 
 test.describe('Calendar View', () => {

--- a/tests/e2e/custom-fields-ui.spec.ts
+++ b/tests/e2e/custom-fields-ui.spec.ts
@@ -28,8 +28,14 @@ async function setupBoardWithCard(request: APIRequestContext): Promise<SetupResu
 
 async function openBoard(page: import('@playwright/test').Page, setup: SetupResult): Promise<void> {
   await loginViaCookie(page, UI_URL, setup.creds);
-  await page.goto(`${UI_URL}/b/${setup.boardId}`);
-  await page.waitForLoadState('networkidle');
+  // App boot performs an async token refresh; navigating immediately can race
+  // and land on /workspaces. Retry until the card tile renders.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await page.goto(`${UI_URL}/b/${setup.boardId}`);
+    await page.waitForLoadState('networkidle');
+    if (await page.locator('[aria-label^="Card:"]').first().isVisible().catch(() => false)) return;
+    await page.waitForTimeout(500);
+  }
 }
 
 async function createFieldViaApi(

--- a/tests/e2e/timeline-drag.spec.ts
+++ b/tests/e2e/timeline-drag.spec.ts
@@ -80,10 +80,31 @@ async function getCard(request: APIRequestContext, token: string, cardId: string
   return body.data;
 }
 
+
+/** Local calendar date ("YYYY-MM-DD") of an ISO timestamp. */
+function localDateKey(iso: string): string {
+  const d = new Date(iso);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${String(y)}-${m}-${day}`;
+}
+
 function offsetDate(offsetDays: number): string {
   const d = new Date();
   d.setDate(d.getDate() + offsetDays);
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+// App boot performs an async token refresh; navigating immediately can race and
+// land on /workspaces. Retry until the board view switcher renders.
+async function gotoBoardUntilReady(page: Page, baseUrl: string, boardId: string): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await page.goto(`${baseUrl}/b/${boardId}`);
+    await page.waitForLoadState('networkidle');
+    if (await page.getByTestId('board-view-switcher').isVisible().catch(() => false)) return;
+    await page.waitForTimeout(500);
+  }
 }
 
 async function goToTimelineView(page: Page, baseUrl: string, boardId: string, creds: Credentials) {
@@ -92,8 +113,7 @@ async function goToTimelineView(page: Page, baseUrl: string, boardId: string, cr
       { name: 'refresh_token', value: creds.refreshToken, url: `${baseUrl}/api/v1/auth/refresh`, httpOnly: true, sameSite: 'Strict' },
     ]);
   }
-  await page.goto(`${baseUrl}/b/${boardId}`);
-  await page.waitForLoadState('networkidle');
+  await gotoBoardUntilReady(page, baseUrl, boardId);
   await page.getByTestId('board-view-tab-TIMELINE').click();
   await expect(page.getByTestId('timeline-view')).toBeVisible({ timeout: 10000 });
 }
@@ -110,8 +130,8 @@ async function dragHandle(page: Page, handleTestId: string, deltaX: number) {
   await page.mouse.move(startX, startY);
   await page.mouse.down();
   // Move in small steps to trigger all mousemove events.
-  const steps = Math.abs(deltaX) / 4;
-  await page.mouse.move(startX + deltaX, startY, { steps: Math.max(steps, 4) });
+  const steps = Math.max(Math.ceil(Math.abs(deltaX) / 4), 4);
+  await page.mouse.move(startX + deltaX, startY, { steps });
   await page.mouse.up();
 }
 
@@ -242,9 +262,11 @@ test.describe('Timeline Drag / Resize', () => {
     // Error toast should appear.
     await expect(page.getByText(/failed to update card dates/i)).toBeVisible({ timeout: 8000 });
 
-    // After revert, the server-side dates should remain unchanged.
+    // After revert, the server-side dates should remain unchanged. Compare on
+    // the local calendar date: the server stores these as instants, so slicing
+    // the raw UTC string would shift the day for non-UTC servers.
     const serverCard = await getCard(request, creds.token, cardId);
-    expect(serverCard.start_date?.slice(0, 10)).toBe(startDate);
-    expect(serverCard.due_date?.slice(0, 10)).toBe(dueDate);
+    expect(serverCard.start_date ? localDateKey(serverCard.start_date) : null).toBe(startDate);
+    expect(serverCard.due_date ? localDateKey(serverCard.due_date) : null).toBe(dueDate);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the due-date timezone inconsistency (the parked product bug). Card date fields are now interpreted in the viewer's local timezone on every surface, so the calendar and timeline agree with the card tile / meta strip / table. Also unblocks the acceptance gate.

## Root cause

`due_date` and `start_date` are stored as ISO **instants**, but surfaces disagreed on how to read them:

| Surface | Rendered |
|---|---|
| CardItem due badge | local date + time |
| CardMetaStrip | local date + time |
| CardTile | local date |
| TableRow | local date |
| **CalendarView** | **raw UTC slice** (`iso.slice(0, 10)`) |
| **TimelineView** | **raw UTC slice** |

On a `+07` server, `due_date: "2026-09-15"` is stored as `2026-09-14T17:00:00Z`, so Calendar and Timeline showed the card on the **14th** while the card surfaces showed the **15th**.

Note: these fields are genuinely instants — the date picker has a time input (`H:MM AM`, defaults 12:00 PM) and persists it. So the fix is *not* to convert them to date-only; it is to interpret them consistently in local time. (I initially proposed date-only normalisation; that would have destroyed user-set times and hidden them in the UI. Corrected before writing code.)

## Changes

New `src/common/utils/dates.ts`: `localDateKey`, `parseLocalDate`, `toLocalDateKey`.

Applied everywhere a date field is keyed, grouped, compared, or used for day arithmetic:

- `CalendarView` — `buildCardsByDay`
- `useCalendarDrag` — no-op comparison
- `TimelineBar`, `TimelineRow`, `useTimelineDrag` — day math and drag originals
- `TimelineView` — `todayIso` (was `toISOString().slice(0,10)`, i.e. the UTC date) and the `scheduledCards` filter

Test-side blockers fixed so the acceptance gate runs reliably:

- Retry board navigation until it renders (the boot-refresh race), in `calendar-view`, `timeline-drag`, `custom-fields-ui`.
- Integer mouse-move `steps` (`10.5` was rejected by Playwright).
- Compare server dates on the local calendar date rather than the UTC slice.

## Verification

- `calendar-view` + `timeline-drag` + `timeline-view` + `timeline-bar`: **27 passed** twice consecutively (19.4s, 15.4s)
- Full suite: **156 passed / 0 failed / 20 skipped** (previously 150/17/20 — the 7 parked calendar/timeline failures now pass, and the 3 payment failures are excluded by standing rule; attachments remain parked)
- `bunx eslint`: no new findings (5 pre-existing errors in these files, unchanged)
- `bunx tsc --noEmit`: 146 errors, unchanged
- `git diff --check`: clean
