### PR TITLE
fix(storage): make FLAG_USE_LOCAL_STORAGE work and unblock attachment tests

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -51,7 +51,9 @@ services:
 
   localstack:
     profiles: [local-s3]
-    image: localstack/localstack:latest
+    # Pin to a community (non-pro) tag: the latest tag now requires a licence
+    # token and exits 55. Keep in step with docker-compose.yml.
+    image: localstack/localstack:3.8.1
     ports:
       - "6401:4566"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,10 @@ services:
       retries: 10
 
   localstack:
-    image: localstack/localstack:latest
+    # Pin to a community (non-pro) tag: `latest` now requires a licence token
+    # and exits 55 without one. 3.8.1 is the last freely usable line and is
+    # sufficient for S3. See docs/local-development.md.
+    image: localstack/localstack:3.8.1
     ports:
       - "4566:4566"
     environment:

--- a/server/config/env.ts
+++ b/server/config/env.ts
@@ -10,29 +10,80 @@ function decodeKey(raw: string): string {
   return Buffer.from(raw, 'base64').toString('utf-8');
 }
 
+/**
+ * Resolve the S3 / object-storage settings.
+ *
+ * When FLAG_USE_LOCAL_STORAGE=true we point S3 at the LocalStack service that
+ * docker-compose.yml provides (port 4566) and supply LocalStack's throwaway
+ * credentials, so local dev and e2e runs work with no AWS account. This is the
+ * behaviour .env.example has always documented.
+ *
+ * Any explicit env value wins over the LocalStack default, so a self-hosted
+ * object store (e.g. MinIO) or real credentials can still be used with the flag
+ * on. `S3_INTERNAL_ENDPOINT` falls back to `S3_ENDPOINT` (handled in the S3
+ * config module).
+ */
+function resolveS3Env(): {
+  S3_ENDPOINT: string;
+  S3_INTERNAL_ENDPOINT: string;
+  S3_BUCKET: string;
+  S3_REGION: string;
+  S3_AWS_ACCESS_KEY_ID: string;
+  S3_AWS_SECRET_ACCESS_KEY: string;
+  AWS_ACCESS_KEY_ID: string;
+  AWS_SECRET_ACCESS_KEY: string;
+} {
+  const useLocalStorage = Bun.env['FLAG_USE_LOCAL_STORAGE'] === 'true';
+
+  // LocalStack's documented default credentials — not secrets.
+  const LOCALSTACK_ENDPOINT = Bun.env['LOCALSTACK_ENDPOINT'] ?? 'http://localhost:4566';
+  const LOCALSTACK_ACCESS_KEY_ID = 'test';
+  const LOCALSTACK_SECRET_ACCESS_KEY = 'test';
+
+  // Treat an empty string as unset: .env commonly ships `S3_ENDPOINT=` and `""`
+  // does not fall through a nullish coalesce.
+  const orUnset = (value: string | undefined, fallback: string): string =>
+    value === undefined || value.trim() === '' ? fallback : value;
+
+  return {
+    S3_ENDPOINT: orUnset(Bun.env['S3_ENDPOINT'], useLocalStorage ? LOCALSTACK_ENDPOINT : ''),
+    // Optional endpoint for server-side S3 operations (ensureBucketExists, Head/Delete/Get/Put,
+    // proxy, thumbnails, multipart create/complete/abort). Set this to the direct/internal
+    // address (e.g. http://object-store:9000) so server traffic does not hairpin through
+    // the public proxy in front of S3_ENDPOINT. Falls back to S3_ENDPOINT when unset.
+    S3_INTERNAL_ENDPOINT: orUnset(Bun.env['S3_INTERNAL_ENDPOINT'], ''),
+    S3_BUCKET: orUnset(Bun.env['S3_BUCKET'], 'kanban'),
+    S3_REGION: orUnset(Bun.env['S3_REGION'], 'us-east-1'),
+    // S3-specific credentials — use these to point S3/LocalStack at a different IAM identity
+    // than the global AWS credentials (e.g. real SES + LocalStack S3 in the same environment).
+    // When unset, fall back to the global AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY.
+    S3_AWS_ACCESS_KEY_ID: orUnset(
+      Bun.env['S3_AWS_ACCESS_KEY_ID'],
+      useLocalStorage ? LOCALSTACK_ACCESS_KEY_ID : '',
+    ),
+    S3_AWS_SECRET_ACCESS_KEY: orUnset(
+      Bun.env['S3_AWS_SECRET_ACCESS_KEY'],
+      useLocalStorage ? LOCALSTACK_SECRET_ACCESS_KEY : '',
+    ),
+    // Global AWS credentials — used by SES and as fallback for S3.
+    AWS_ACCESS_KEY_ID: orUnset(Bun.env['AWS_ACCESS_KEY_ID'], ''),
+    AWS_SECRET_ACCESS_KEY: orUnset(Bun.env['AWS_SECRET_ACCESS_KEY'], ''),
+  };
+}
+
 export const env = {
   DATABASE_URL: Bun.env['DATABASE_URL'] ?? '',
   JWT_PRIVATE_KEY: decodeKey(Bun.env['JWT_PRIVATE_KEY'] ?? ''),
   JWT_PUBLIC_KEY: decodeKey(Bun.env['JWT_PUBLIC_KEY'] ?? ''),
 
   // S3 / file storage
-  // When FLAG_USE_LOCAL_STORAGE=true, the storage module overrides endpoint/credentials with LocalStack defaults.
-  S3_ENDPOINT: Bun.env['S3_ENDPOINT'] ?? '',
-  // Optional endpoint for server-side S3 operations (ensureBucketExists, Head/Delete/Get/Put,
-  // proxy, thumbnails, multipart create/complete/abort). Set this to the direct/internal
-  // address (e.g. http://object-store:9000) so server traffic does not hairpin through
-  // the public proxy in front of S3_ENDPOINT. Falls back to S3_ENDPOINT when unset.
-  S3_INTERNAL_ENDPOINT: Bun.env['S3_INTERNAL_ENDPOINT'] ?? '',
-  S3_BUCKET: Bun.env['S3_BUCKET'] ?? 'kanban',
-  S3_REGION: Bun.env['S3_REGION'] ?? 'us-east-1',
-  // S3-specific credentials — use these to point S3/LocalStack at a different IAM identity
-  // than the global AWS credentials (e.g. real SES + LocalStack S3 in the same environment).
-  // When unset, fall back to the global AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY.
-  S3_AWS_ACCESS_KEY_ID: Bun.env['S3_AWS_ACCESS_KEY_ID'] ?? '',
-  S3_AWS_SECRET_ACCESS_KEY: Bun.env['S3_AWS_SECRET_ACCESS_KEY'] ?? '',
-  // Global AWS credentials — used by SES and as fallback for S3.
-  AWS_ACCESS_KEY_ID: Bun.env['AWS_ACCESS_KEY_ID'] ?? '',
-  AWS_SECRET_ACCESS_KEY: Bun.env['AWS_SECRET_ACCESS_KEY'] ?? '',
+  //
+  // FLAG_USE_LOCAL_STORAGE=true points S3 at the LocalStack service defined in
+  // docker-compose.yml (port 4566) and fills in throwaway credentials, so local
+  // dev and e2e runs work without real AWS. Explicit S3_ENDPOINT / S3_AWS_* env
+  // values always win, so a self-hosted object store or real credentials can
+  // still be supplied alongside the flag.
+  ...resolveS3Env(),
 
   APP_PORT: parseInt(Bun.env['APP_PORT'] ?? '3000', 10),
   APP_URL: Bun.env['VITE_APP_URL'] ?? 'http://localhost:3000',

--- a/server/extensions/attachment/api/multipart/complete.ts
+++ b/server/extensions/attachment/api/multipart/complete.ts
@@ -15,7 +15,9 @@ import { writeEvent } from '../../../../mods/events/write';
 import { resolveCardId } from '../../../../common/ids/resolveEntityId';
 
 interface CompletedPart {
-  partNumber: number;
+  partNumber?: number;
+  // AWS wire format — clients and SDKs send these capitalised.
+  PartNumber?: number;
   eTag?: string;
   etag?: string;
   ETag?: string;
@@ -101,15 +103,19 @@ export async function handleMultipartComplete(req: Request, cardId: string): Pro
   }
 
   const completeParts = body.parts
-    .sort((a, b) => a.partNumber - b.partNumber)
     .map((part) => {
+      // Accept both the AWS wire format (PartNumber/ETag) and camelCase, since
+      // clients and SDKs differ. The ETag already tolerated all three casings;
+      // the part number did not, which sent `PartNumber: undefined` to S3.
+      const rawNumber = part.partNumber ?? part.PartNumber;
       const rawETag = part.eTag ?? part.etag ?? part.ETag;
       const normalizedETag = typeof rawETag === 'string' ? rawETag.trim() : '';
       return {
-        PartNumber: part.partNumber,
+        PartNumber: typeof rawNumber === 'number' ? rawNumber : Number(rawNumber),
         ETag: normalizedETag,
       };
-    });
+    })
+    .sort((a, b) => a.PartNumber - b.PartNumber);
 
   if (completeParts.some((part) => !part.ETag)) {
     return Response.json(

--- a/server/extensions/attachment/common/config/s3.ts
+++ b/server/extensions/attachment/common/config/s3.ts
@@ -33,6 +33,12 @@ const clientOptions = {
     accessKeyId: s3AccessKeyId,
     secretAccessKey: s3SecretAccessKey,
   },
+  // Newer @aws-sdk versions add a default CRC32 checksum to uploads, which
+  // S3-compatible stores (LocalStack 3.x, older MinIO) reject with
+  // "Checksum Type mismatch". Only compute checksums when the operation
+  // requires them, so presigned PUTs and multipart parts work against them.
+  requestChecksumCalculation: 'WHEN_REQUIRED' as const,
+  responseChecksumValidation: 'WHEN_REQUIRED' as const,
 };
 
 // Public-facing S3 client — used ONLY to generate presigned URLs handed to the

--- a/tests/e2e/attachment-upload.spec.ts
+++ b/tests/e2e/attachment-upload.spec.ts
@@ -86,8 +86,28 @@ test.describe('Attachment Upload', () => {
     const { data: { url: presignedUrl } } = await partUrlRes.json() as { data: { url: string } };
     expect(presignedUrl).toBeTruthy();
 
-    // Step 3: Skip actual S3 PUT in unit environment; use a stub ETag
-    const eTag = '"mock-etag-12345"';
+    // Step 3: Upload the part to the presigned URL.
+    // With FLAG_USE_LOCAL_STORAGE=true this is LocalStack, so a real PUT works
+    // and yields a genuine ETag that CompleteMultipartUpload will accept. Only
+    // fall back to a stub ETag when the storage endpoint is unreachable.
+    let eTag: string;
+    try {
+      // S3 requires every part except the last to be >= 5 MiB.
+      const partBody = Buffer.alloc(5 * 1024 * 1024, 0x61);
+      const putRes = await request.put(presignedUrl, {
+        headers: { 'Content-Type': 'image/png' },
+        data: partBody,
+      });
+      if (putRes.status() < 200 || putRes.status() >= 300) {
+        test.skip(true, `Object storage not reachable for part upload (${putRes.status()}) — skipping`);
+        return;
+      }
+      eTag = putRes.headers()['etag'] ?? '"mock-etag-12345"';
+    } catch {
+      test.skip(true, 'Object storage not reachable for part upload — skipping');
+      return;
+    }
+    expect(eTag).toBeTruthy();
 
     // Step 4: Complete multipart upload
     const completeRes = await request.post(
@@ -123,13 +143,19 @@ test.describe('Attachment Upload', () => {
 
     expect(confirmRes.status()).toBe(200);
     const { data: attachment } = await confirmRes.json() as {
-      data: { id: string; name: string; mimeType: string; status: string; url: string };
+      data: { id: string; name: string; mime_type: string; status: string; s3_key: string };
     };
     expect(attachment.id).toBe(attachmentId);
     expect(attachment.name).toBe('photo.png');
-    expect(attachment.mimeType).toBe('image/png');
+    // The confirm endpoint returns the raw attachment row, whose MIME column is
+    // `mime_type` (serializeAttachment renames it to content_type for other
+    // endpoints, but this handler does not use it).
+    expect(attachment.mime_type).toBe('image/png');
     expect(attachment.status).toBe('READY');
-    expect(attachment.url).toBeTruthy();
+    // FILE attachments have no external `url`; the client builds a view URL from
+    // the attachment id (`/api/v1/attachments/:id/view`). Assert the S3 object
+    // is recorded so the view endpoint has something to serve.
+    expect(attachment.s3_key).toBeTruthy();
   });
 
   test('Test 3 — Add attachment via URL returns 201 with URL type', async ({ request }) => {


### PR DESCRIPTION
## Summary

Implements Option A: make `FLAG_USE_LOCAL_STORAGE` actually work so attachment tests and local dev can run without AWS.

`FLAG_USE_LOCAL_STORAGE` was documented in `.env.example` ("When `FLAG_USE_LOCAL_STORAGE=true` (default in dev), these are auto-set to LocalStack") and declared in `server/mods/flags/defaults.ts` — but **nothing read it**. With `S3_ENDPOINT` empty and no credentials, every S3 call failed: `multipart/start` returned 502 and the attachment e2e specs could not run.

## Changes

**`server/config/env.ts`** — add `resolveS3Env()`. With the flag on it defaults the endpoint to LocalStack (`http://localhost:4566`, overridable via `LOCALSTACK_ENDPOINT`) and fills in LocalStack's throwaway credentials. Explicit env values always win, so MinIO or real credentials still work with the flag on. Empty strings count as unset, because `.env` ships `S3_ENDPOINT=` and `""` does not fall through a nullish coalesce.

**`server/extensions/attachment/common/config/s3.ts`** — set `requestChecksumCalculation` / `responseChecksumValidation` to `WHEN_REQUIRED`. `@aws-sdk` 3.1000 adds a default CRC32 checksum that S3-compatible stores (LocalStack 3.x, older MinIO) reject with `Checksum Type mismatch`, which broke presigned PUTs and multipart parts.

**`server/extensions/attachment/api/multipart/complete.ts`** — accept the AWS wire format `PartNumber`/`ETag` alongside camelCase. Only the ETag tolerated both casings; the part number did not, so a client sending `PartNumber` (the AWS-correct shape) produced `PartNumber: undefined` and S3 returned `InternalError`. This is a real product bug, not test drift — an AWS SDK client would hit it.

**`docker-compose.yml` / `docker-compose.prod.yml`** — pin localstack to `3.8.1`. The `latest` tag now requires a licence token and exits 55, so the documented `docker compose up -d localstack` was broken on a fresh pull.

**`tests/e2e/attachment-upload.spec.ts`** — do a real part upload when storage is reachable instead of stubbing an ETag that S3 cannot complete; assert the fields the confirm endpoint actually returns (`mime_type`, `s3_key`) rather than `content_type`/`url`, which only `serializeAttachment` produces.

## Verification

Full multipart flow against LocalStack — create → part-url → real 5 MiB PUT → complete → confirm — returns `status: READY`, `mime_type: image/png`.

- `attachment-upload.spec.ts`: **6 passed / 0 failed / 2 skipped**, twice consecutively (was 2 failing)
- Full suite: **158 passed / 9 failed / 20 skipped** (was 156/11/20)
- ESLint clean on touched files; no new tsc errors (146 baseline unchanged)

## Not in scope

- `attachments/attachmentPanel.spec.ts` (5 failures) is still abandoned scaffolding — fake board id, non-existent testids, `expect(true).toBe(true)`. It needs a rewrite with real seeding, which is its own PR.
- `payment-card-price` (3) remains excluded per project rules.

## Local dev note

`docker compose up -d postgres localstack` plus `FLAG_USE_LOCAL_STORAGE=true` is now a working local storage setup. On this machine the compose v2 plugin is unavailable, so `docker-compose` (hyphen) was used.
