### PR TITLE
fix(seeds): honour FLAG_USE_LOCAL_STORAGE in the Trello import

### DIFF
--- a/db/seeds/trello-import.ts
+++ b/db/seeds/trello-import.ts
@@ -51,7 +51,11 @@ const DATABASE_URL =
 
 const S3_BUCKET    = Bun.env['S3_BUCKET'] ?? 'chimedeck';
 const S3_REGION    = Bun.env['S3_REGION'] ?? 'us-east-1';
-const S3_ENDPOINT  = Bun.env['S3_ENDPOINT'] || undefined;
+// Honour FLAG_USE_LOCAL_STORAGE the same way server/config/env.ts does, so a
+// dev with the flag on does not accidentally write seed attachments to real
+// AWS. An explicit S3_ENDPOINT still wins.
+const USE_LOCAL_STORAGE = Bun.env['FLAG_USE_LOCAL_STORAGE'] === 'true';
+const S3_ENDPOINT  = Bun.env['S3_ENDPOINT'] || (USE_LOCAL_STORAGE ? 'http://localhost:4566' : undefined);
 const S3_BASE_URL  = S3_ENDPOINT
   ? `${S3_ENDPOINT}/${S3_BUCKET}`
   : `https://${S3_BUCKET}.s3.${S3_REGION}.amazonaws.com`;


### PR DESCRIPTION
## Summary

Follow-up to #322. `db/seeds/trello-import.ts` resolved S3 config on its own and only reacted to `S3_ENDPOINT`:

```ts
const S3_ENDPOINT = Bun.env['S3_ENDPOINT'] || undefined;
```

So a developer with `FLAG_USE_LOCAL_STORAGE=true` still had `S3_ENDPOINT` empty, and the seed script would write seed attachments to **real AWS** rather than LocalStack. Same class of bug as #322, in a second place.

It now applies the same rule as `server/config/env.ts`: the flag defaults the endpoint to `http://localhost:4566`, and an explicit `S3_ENDPOINT` still wins.

## Verification

| Case | Resolved endpoint |
|---|---|
| flag on, no endpoint | `http://localhost:4566` |
| flag off (production) | `undefined` — unchanged, real AWS |
| flag on, explicit `S3_ENDPOINT` | that endpoint |

ESLint unchanged at 5 pre-existing errors; `tsc` unchanged at 146.

Found by the independent review of #322, which noticed the second config path while grepping for `FLAG_USE_LOCAL_STORAGE`.
