### PR TITLE
fix(e2e): remove dead-endpoint guards in two specs (9 tests never ran)

### DIFF
--- a/tests/e2e/business-logic-invariants.spec.ts
+++ b/tests/e2e/business-logic-invariants.spec.ts
@@ -5,7 +5,7 @@
 // Based on: tests/e2e/business-logic-invariants-1.md (now deleted)
 
 import { test, expect } from '@playwright/test';
-import { BASE_URL, registerAndLogin, createWorkspace, createBoard, createList, createCard } from './_helpers';
+import { BASE_URL, registerAndLogin, registerAndGetCredentials, createWorkspace, createBoard, createList, createCard } from './_helpers';
 
 test.describe('Business Logic Invariants', () => {
   test.describe('Part 1 — Archived Board Read-Only Guard', () => {
@@ -81,21 +81,23 @@ test.describe('Business Logic Invariants', () => {
       token = await registerAndLogin(request, 'ws-owner');
       workspaceId = await createWorkspace(request, token);
 
-      // Fetch current user id
-      const meRes = await request.get(`${BASE_URL}/api/v1/me`, {
+      // Fetch the current user id. Fail loudly rather than leaving userId
+      // unset, which previously made every test in this block soft-skip and
+      // masked the fact that the route was wrong.
+      const meRes = await request.get(`${BASE_URL}/api/v1/users/me`, {
         headers: { Authorization: `Bearer ${token}` },
       });
-      if (meRes.status() === 200) {
-        const meBody = await meRes.json();
-        userId = meBody.data?.id ?? meBody.id;
+      if (meRes.status() !== 200) {
+        throw new Error(`GET /api/v1/users/me returned ${meRes.status()}`);
+      }
+      const meBody = await meRes.json();
+      userId = meBody.data?.id ?? meBody.id;
+      if (!userId) {
+        throw new Error('GET /api/v1/users/me returned no id');
       }
     });
 
     test('DELETE last owner returns 422 workspace-must-have-one-owner', async ({ request }) => {
-      if (!userId) {
-        test.skip(true, 'Could not fetch current user ID via /api/v1/me');
-        return;
-      }
       const res = await request.delete(
         `${BASE_URL}/api/v1/workspaces/${workspaceId}/members/${userId}`,
         { headers: { Authorization: `Bearer ${token}` } },
@@ -107,10 +109,6 @@ test.describe('Business Logic Invariants', () => {
     });
 
     test('PATCH role change for last owner returns 422', async ({ request }) => {
-      if (!userId) {
-        test.skip(true, 'Could not fetch current user ID via /api/v1/me');
-        return;
-      }
       const res = await request.patch(
         `${BASE_URL}/api/v1/workspaces/${workspaceId}/members/${userId}`,
         {
@@ -125,34 +123,20 @@ test.describe('Business Logic Invariants', () => {
     });
 
     test('Role change succeeds when a second OWNER is promoted first', async ({ request }) => {
-      if (!userId) {
-        test.skip(true, 'Could not fetch current user ID via /api/v1/me');
-        return;
-      }
 
-      // Register second user and invite as OWNER
-      const secondToken = await registerAndLogin(request, 'ws-owner2');
-      const meRes = await request.get(`${BASE_URL}/api/v1/me`, {
-        headers: { Authorization: `Bearer ${secondToken}` },
-      });
-      const secondUserId = meRes.status() === 200
-        ? (await meRes.json()).data?.id ?? (await meRes.json()).id
-        : null;
+      // Register a second user. POST /workspaces/:id/members adds an existing
+      // user by email (not id), so we need the credentials, not just a token.
+      const secondCreds = await registerAndGetCredentials(request, 'ws-owner2');
 
-      if (!secondUserId) {
-        test.skip(true, 'Could not fetch second user ID');
-        return;
-      }
-
-      // Add second user as OWNER
+      // Promote the second user to OWNER.
       const inviteRes = await request.post(`${BASE_URL}/api/v1/workspaces/${workspaceId}/members`, {
         headers: { Authorization: `Bearer ${token}` },
-        data: { userId: secondUserId, role: 'OWNER' },
+        data: { email: secondCreds.email, role: 'OWNER' },
       });
-      // Accept 200, 201, or 204 for success
       expect(inviteRes.status()).toBeLessThan(300);
 
-      // Now demoting the first OWNER should succeed (second OWNER still present)
+      // With a second OWNER present, demoting the first must succeed rather than
+      // tripping the >=1 owner invariant.
       const patchRes = await request.patch(
         `${BASE_URL}/api/v1/workspaces/${workspaceId}/members/${userId}`,
         {
@@ -160,9 +144,16 @@ test.describe('Business Logic Invariants', () => {
           data: { role: 'ADMIN' },
         },
       );
-      // Either succeeds (200/204) or already blocked if second member invite didn't fully work
-      // TODO: adjust based on actual invitation flow once fully implemented
-      expect([200, 204, 422]).toContain(patchRes.status());
+      expect([200, 204]).toContain(patchRes.status());
+
+      // The second user is now an owner; the invariant held.
+      const membersRes = await request.get(`${BASE_URL}/api/v1/workspaces/${workspaceId}/members`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      expect(membersRes.status()).toBe(200);
+      const membersBody = await membersRes.json();
+      const owners = (membersBody.data ?? []).filter((m: { role: string }) => m.role === 'OWNER');
+      expect(owners.length).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/tests/e2e/search-filters.spec.ts
+++ b/tests/e2e/search-filters.spec.ts
@@ -11,6 +11,7 @@ const UI_URL = process.env.TEST_UI_URL ?? 'http://localhost:5173';
 test.describe('Search Filters', () => {
   let creds: Credentials;
   let token: string;
+  let workspaceId: string;
   let boardId: string;
   let otherBoardId: string;
   const run = Date.now();
@@ -24,7 +25,7 @@ test.describe('Search Filters', () => {
 
     creds = await registerAndGetCredentials(request, `search-${run}`);
     token = creds.token;
-    const workspaceId = await createWorkspace(request, token);
+    workspaceId = await createWorkspace(request, token);
     boardId = await createBoard(request, token, workspaceId);
     otherBoardId = await createBoard(request, token, workspaceId);
 
@@ -40,17 +41,14 @@ test.describe('Search Filters', () => {
   test('Test 1 — Search returns cards matching the query term', async ({ request }) => {
     if (!token) test.skip(true, 'Server not running — skipping');
 
-    const res = await request.get(`${BASE_URL}/api/v1/search?q=Alpha+Card+${run}`, {
+    // Real route is workspace-scoped: GET /api/v1/workspaces/:id/search.
+    // There is no global /api/v1/search.
+    const res = await request.get(`${BASE_URL}/api/v1/workspaces/${workspaceId}/search?q=Alpha+Card+${run}`, {
       headers: { Authorization: `Bearer ${token}` },
     });
 
-    if (res.status() === 404 || res.status() === 501) {
-      test.skip(true, 'Search endpoint not yet implemented — skipping');
-      return;
-    }
-
     expect(res.status()).toBe(200);
-    const body = await res.json() as { data: Array<{ title: string }> };
+    const body = await res.json() as { data: Array<{ title: string; type: string }> };
     expect(Array.isArray(body.data)).toBe(true);
     const titles = body.data.map((c) => c.title);
     expect(titles.some((t) => t.includes(`Alpha Card ${run}`))).toBe(true);
@@ -59,38 +57,28 @@ test.describe('Search Filters', () => {
   test('Test 2 — Search with type=card filter returns only card results', async ({ request }) => {
     if (!token) test.skip(true, 'Server not running — skipping');
 
-    const res = await request.get(`${BASE_URL}/api/v1/search?q=${run}&type=card`, {
+    const res = await request.get(`${BASE_URL}/api/v1/workspaces/${workspaceId}/search?q=${run}&type=card`, {
       headers: { Authorization: `Bearer ${token}` },
     });
-
-    if (res.status() === 404 || res.status() === 501) {
-      test.skip(true, 'Type-filter on search endpoint not yet implemented — skipping');
-      return;
-    }
 
     expect(res.status()).toBe(200);
     const body = await res.json() as { data: Array<{ type?: string; title: string }> };
     expect(Array.isArray(body.data)).toBe(true);
-    // Every returned item must be a card (type field absent or equal to 'card')
+    expect(body.data.length).toBeGreaterThan(0);
+    // Every returned item must be a card.
     for (const item of body.data) {
-      if (item.type !== undefined) {
-        expect(item.type).toBe('card');
-      }
+      expect(item.type).toBe('card');
     }
   });
 
   test('Test 3 — Search scoped to a specific board excludes other-board cards', async ({ request }) => {
     if (!token) test.skip(true, 'Server not running — skipping');
 
+    // Board-scoped search has its own route: GET /api/v1/boards/:id/search.
     const res = await request.get(
-      `${BASE_URL}/api/v1/search?q=${run}&boardId=${boardId}`,
+      `${BASE_URL}/api/v1/boards/${boardId}/search?q=${run}`,
       { headers: { Authorization: `Bearer ${token}` } },
     );
-
-    if (res.status() === 404 || res.status() === 501) {
-      test.skip(true, 'Board-scoped search not yet implemented — skipping');
-      return;
-    }
 
     expect(res.status()).toBe(200);
     const body = await res.json() as { data: Array<{ title: string }> };
@@ -106,74 +94,72 @@ test.describe('Search Filters', () => {
   test('Test 4 — Unauthenticated search returns 401', async ({ request }) => {
     if (!token) test.skip(true, 'Server not running — skipping');
 
-    const res = await request.get(`${BASE_URL}/api/v1/search?q=anything`);
-
-    if (res.status() === 404 || res.status() === 501) {
-      test.skip(true, 'Search endpoint not yet implemented — skipping');
-      return;
-    }
+    const res = await request.get(`${BASE_URL}/api/v1/workspaces/${workspaceId}/search?q=anything`);
 
     expect(res.status()).toBe(401);
   });
 
-  test('Test 5 — UI search box filters visible cards by keyword', async ({ page }) => {
+  // The board page has no inline search input. Search is a modal palette opened
+  // from the header "Search" button (also Cmd/Ctrl+K), with an input whose
+  // placeholder is "Search boards and cards…" and All/Boards/Cards filter tabs.
+  async function openSearchPalette(page: import('@playwright/test').Page): Promise<void> {
+    await page.getByRole('button', { name: /search/i }).first().click();
+    await page.getByPlaceholder('Search boards and cards…').waitFor({ timeout: 8000 });
+  }
+
+  test('Test 5 — UI search palette finds a card by keyword', async ({ request, page }) => {
     if (!token) test.skip(true, 'Server not running — skipping');
 
-    await loginViaCookie(page, UI_URL, creds);
-    await page.goto(`${UI_URL}/b/${boardId}`);
+    // Fresh user/board so the palette only sees these cards.
+    const uiCreds = await registerAndGetCredentials(request, `search-ui5-${run}`);
+    const uiToken = uiCreds.token;
+    const uiWorkspaceId = await createWorkspace(request, uiToken);
+    const uiBoardId = await createBoard(request, uiToken, uiWorkspaceId);
+    const uiListId = await createList(request, uiToken, uiBoardId);
+    await createCard(request, uiToken, uiListId, `Alpha Card ${run}`);
+    await createCard(request, uiToken, uiListId, `Beta Task ${run}`);
+
+    await loginViaCookie(page, UI_URL, uiCreds);
+    await page.goto(`${UI_URL}/b/${uiBoardId}`);
     await page.waitForLoadState('networkidle');
+    await openSearchPalette(page);
 
-    // Locate the search input — try common selectors
-    const searchInput = page.locator(
-      '[data-testid="search-input"], input[placeholder*="Search"], input[type="search"]',
-    ).first();
+    const paletteInput = page.getByPlaceholder('Search boards and cards…');
+    await paletteInput.fill(`Alpha Card ${run}`);
 
-    if (await searchInput.count() === 0) {
-      test.skip(true, 'Search input not found in UI — skipping UI search test');
-      return;
-    }
-
-    await searchInput.fill(`Alpha Card ${run}`);
-    await page.waitForTimeout(400);
-
-    // The matching card should remain visible
-    const matchCard = page.locator(`[data-testid*="card"], .card-title`).filter({ hasText: `Alpha Card ${run}` }).first();
-    if (await matchCard.count() > 0) {
-      await expect(matchCard).toBeVisible({ timeout: 5000 });
-    }
-
-    // The non-matching card should be hidden or absent
-    const noMatchCard = page.locator(`[data-testid*="card"], .card-title`).filter({ hasText: `Beta Task ${run}` }).first();
-    if (await noMatchCard.count() > 0) {
-      await expect(noMatchCard).toBeHidden({ timeout: 5000 });
-    }
+    // Scope to the palette: the board grid behind the modal still shows every
+    // card, so a page-wide text check would match non-results too.
+    const palette = page.locator('[role="dialog"]').last();
+    await expect(palette.getByText(`Alpha Card ${run}`).first()).toBeVisible({ timeout: 8000 });
+    // The non-matching card must not be offered as a result.
+    await expect(palette.getByText(`Beta Task ${run}`)).toHaveCount(0);
   });
 
-  test('Test 6 — UI type filter toggle shows only matching result type', async ({ page }) => {
+  test('Test 6 — UI type filter narrows results to cards', async ({ request, page }) => {
     if (!token) test.skip(true, 'Server not running — skipping');
 
-    await loginViaCookie(page, UI_URL, creds);
-    await page.goto(`${UI_URL}/b/${boardId}`);
+    const uiCreds = await registerAndGetCredentials(request, `search-ui6-${run}`);
+    const uiToken = uiCreds.token;
+    const uiWorkspaceId = await createWorkspace(request, uiToken);
+    const uiBoardId = await createBoard(request, uiToken, uiWorkspaceId);
+    const uiListId = await createList(request, uiToken, uiBoardId);
+    await createCard(request, uiToken, uiListId, `Alpha Card ${run}`);
+
+    await loginViaCookie(page, UI_URL, uiCreds);
+    await page.goto(`${UI_URL}/b/${uiBoardId}`);
     await page.waitForLoadState('networkidle');
+    await openSearchPalette(page);
 
-    // Locate a type-filter control — button or select
-    const typeFilter = page.locator(
-      '[data-testid="filter-type"], [aria-label*="filter"], select[name*="type"]',
-    ).first();
+    const paletteInput = page.getByPlaceholder('Search boards and cards…');
+    await paletteInput.fill(run.toString());
 
-    if (await typeFilter.count() === 0) {
-      test.skip(true, 'Type filter control not found in UI — skipping');
-      return;
-    }
+    // The palette exposes All / Boards / Cards tabs (role=tab, not button).
+    const cardsTab = page.getByRole('tab', { name: 'Cards', exact: true }).first();
+    await expect(cardsTab).toBeVisible({ timeout: 8000 });
+    await cardsTab.click();
 
-    await typeFilter.click();
-    // Select "card" option if it appears in a dropdown
-    const cardOption = page.locator('option[value="card"], [data-value="card"], li:has-text("Card")').first();
-    if (await cardOption.count() > 0) {
-      await cardOption.click();
-    }
-
-    await page.waitForTimeout(300);
-    await expect(typeFilter).toBeVisible();
+    // With the Cards filter chosen the seeded card is still listed.
+    const palette = page.locator('[role="dialog"]').last();
+    await expect(palette.getByText(`Alpha Card ${run}`).first()).toBeVisible({ timeout: 8000 });
   });
 });


### PR DESCRIPTION
## Summary

Nine tests across two specs had **never executed**. Each guarded itself with:

```ts
if (res.status() === 404 || res.status() === 501) {
  test.skip(true, '… endpoint not yet implemented');
  return;
}
```

…and then called a route that does not exist. The guard can never fail, so when the real routes shipped under different shapes the tests kept skipping silently. They reported as *skipped*, which read as fine in every green suite run.

Found by asking "which 18 tests are skipped?" — the `line` reporter prints only a count.

## business-logic-invariants — 3 skipped → all pass

- `GET /api/v1/me` 404s. The route is `/api/v1/users/me`. The `beforeAll` fetch swallowed the failure and left `userId` unset, which made three tests skip. It now **throws on a non-200**, so a wrong route fails loudly instead of silently skipping.
- Removed the three now-unreachable `if (!userId) test.skip(...)` guards.
- The invite payload sent `{ userId, role }`; `POST /workspaces/:id/members` takes the user's **email**. Switched to `registerAndGetCredentials` to obtain it.
- Tightened a weak assertion that accepted `[200, 204, 422]` for an operation its own title says must succeed. It now requires 2xx and verifies an OWNER remains.

## search-filters — 6 skipped → all pass

- `GET /api/v1/search` does not exist. Real routes: `GET /api/v1/workspaces/:id/search` and `GET /api/v1/boards/:id/search`.
- Test 3's board scoping used an ignored `?boardId=` query param; it now uses the board route.
- Tests 5/6 looked for a board-page search input that does not exist. Search is a **modal palette** opened from the header Search button, with input placeholder `Search boards and cards…` and All/Boards/Cards tabs (`role=tab`).
- Test 5 asserted page-wide text, but the board grid behind the modal still renders every card — a false pass waiting to happen. Scoped to the palette dialog.

## Verification

- Both specs: **13 passed / 0 failed / 0 skipped**, three consecutive runs (was 4 passed / 9 skipped)
- ESLint clean on both files
- No product code changed — test-only

## Not masked

Two things I deliberately did **not** paper over:

1. The `[200, 204, 422]` tolerance was removed rather than kept — the test asserts the invariant holds when a second owner exists, so tolerating 422 would have contradicted its own name.
2. Where a route exists but the guard's premise was wrong, the guard is gone entirely rather than re-pointed at a status that happens to pass. `fetch` failures now throw.

## Remaining skips

4 dead-endpoint skips remain in `list-management` (method mismatches) and `presence-board` (routes may genuinely be GET-only), plus 3 UI-selector skips. `payment-card-price` keeps its 2 — covered by the standing payments exclusion. Those are the next batch.
