### PR TITLE
test(e2e): presence join asserts viewer identity; correct over-broad comment

### DIFF
--- a/tests/e2e/presence-board.spec.ts
+++ b/tests/e2e/presence-board.spec.ts
@@ -9,6 +9,38 @@ import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, crea
 
 const WS_URL = (process.env.TEST_BASE_URL ?? 'http://localhost:3000').replace(/^http/, 'ws');
 
+// Open a realtime WebSocket, subscribe to the board, and resolve once the server
+// accepts the subscription. Used by the join and leave tests.
+function subscribeToBoard(token: string, boardId: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`${WS_URL}/api/v1/ws?token=${encodeURIComponent(token)}`);
+    const timer = setTimeout(() => reject(new Error('WS subscribe timed out')), 8000);
+    ws.addEventListener('open', () => {
+      ws.send(JSON.stringify({ type: 'subscribe', board_id: boardId }));
+    });
+    ws.addEventListener('message', (event) => {
+      try {
+        const msg = JSON.parse(String(event.data)) as { type?: string; name?: string };
+        if (msg.type === 'error') {
+          clearTimeout(timer);
+          reject(new Error(`WS error: ${msg.name ?? 'unknown'}`));
+        }
+        // Any non-error message after subscribe means the subscription was accepted.
+        if (msg.type !== 'error') {
+          clearTimeout(timer);
+          resolve(ws);
+        }
+      } catch {
+        // ignore non-JSON frames
+      }
+    });
+    ws.addEventListener('error', () => {
+      clearTimeout(timer);
+      reject(new Error('WS connection error'));
+    });
+  });
+}
+
 test.describe('Board Presence', () => {
   let credsA: Credentials;
   let credsB: Credentials;
@@ -66,62 +98,43 @@ test.describe('Board Presence', () => {
   // to /boards/:id/presence return 404 by design.
   //
   // Two tests here previously asserted those endpoints (and skipped themselves
-  // when they 404'd, so they never ran). The real join/leave behaviour is covered
-  // by Test 2 below, which drives two WebSocket subscribers and reads the list
-  // back over REST. Asserting the absence of a REST endpoint would test nothing.
+  // when they 404'd, so they never ran). The real behaviour is covered over the
+  // WebSocket path instead: Test 2 covers join (two subscribers appear by id),
+  // Test 3 covers leave (one disconnects and disappears while the other stays).
+  // Asserting the absence of a REST endpoint would test nothing.
 
   test('Test 2 — Second user joining the board is reflected in the presence list', async ({ request }) => {
     if (!tokenA || !tokenB) test.skip(true, 'Server not running — skipping');
 
-    // Presence is populated by the realtime WebSocket layer: a client subscribes
-    // to a board over /api/v1/ws and the server records presence:<boardId>:<userId>.
-    const sockets: WebSocket[] = [];
-    const subscribe = (token: string): Promise<void> =>
-      new Promise((resolve, reject) => {
-        const ws = new WebSocket(`${WS_URL}/api/v1/ws?token=${encodeURIComponent(token)}`);
-        sockets.push(ws);
-        const timer = setTimeout(() => reject(new Error('WS subscribe timed out')), 8000);
-        ws.addEventListener('open', () => {
-          ws.send(JSON.stringify({ type: 'subscribe', board_id: boardId }));
-        });
-        ws.addEventListener('message', (event) => {
-          try {
-            const msg = JSON.parse(String(event.data)) as { type?: string; name?: string };
-            if (msg.type === 'error') {
-              clearTimeout(timer);
-              reject(new Error(`WS error: ${msg.name ?? 'unknown'}`));
-            }
-            // Any non-error message after subscribe means the subscription was accepted.
-            if (msg.type !== 'error') {
-              clearTimeout(timer);
-              resolve();
-            }
-          } catch {
-            // ignore non-JSON frames
-          }
-        });
-        ws.addEventListener('error', () => {
-          clearTimeout(timer);
-          reject(new Error('WS connection error'));
-        });
+    const idOf = async (token: string): Promise<string> => {
+      const res = await request.get(`${BASE_URL}/api/v1/users/me`, {
+        headers: { Authorization: `Bearer ${token}` },
       });
-
-    try {
-      await subscribe(tokenA);
-      await subscribe(tokenB);
-
-      // Presence keys are set on subscribe; allow the cache write to settle.
-      await new Promise((r) => setTimeout(r, 300));
-
-      const listRes = await request.get(`${BASE_URL}/api/v1/boards/${boardId}/presence`, {
+      expect(res.status()).toBe(200);
+      return ((await res.json()) as { data: { id: string } }).data.id;
+    };
+    const readPresenceIds = async (): Promise<string[]> => {
+      const res = await request.get(`${BASE_URL}/api/v1/boards/${boardId}/presence`, {
         headers: { Authorization: `Bearer ${tokenA}` },
       });
-      expect(listRes.status()).toBe(200);
-      const body = await listRes.json() as { data: Array<{ id: string }> };
-      // The presence list should contain both subscribers.
-      expect(body.data.length).toBeGreaterThanOrEqual(2);
+      expect(res.status()).toBe(200);
+      return ((await res.json()) as { data: Array<{ id: string }> }).data.map((u) => u.id);
+    };
+
+    const idA = await idOf(tokenA);
+    const idB = await idOf(tokenB);
+
+    const socketA = await subscribeToBoard(tokenA, boardId);
+    const socketB = await subscribeToBoard(tokenB, boardId);
+
+    try {
+      // Both specific subscribers must be listed by id — not merely "two users".
+      await expect
+        .poll(readPresenceIds, { timeout: 8000 })
+        .toEqual(expect.arrayContaining([idA, idB]));
     } finally {
-      for (const ws of sockets) ws.close();
+      socketA.close();
+      socketB.close();
     }
   });
 
@@ -131,34 +144,6 @@ test.describe('Board Presence', () => {
     // Subscribe both, confirm both present, then close B's socket and confirm B
     // disappears. This covers the unsubscribe -> cache.del(presence:<boardId>:<userId>)
     // path that the removed REST leave test never reached.
-    const openSocket = (token: string): Promise<WebSocket> =>
-      new Promise((resolve, reject) => {
-        const ws = new WebSocket(`${WS_URL}/api/v1/ws?token=${encodeURIComponent(token)}`);
-        const timer = setTimeout(() => reject(new Error('WS subscribe timed out')), 8000);
-        ws.addEventListener('open', () => {
-          ws.send(JSON.stringify({ type: 'subscribe', board_id: boardId }));
-        });
-        ws.addEventListener('message', (event) => {
-          try {
-            const msg = JSON.parse(String(event.data)) as { type?: string; name?: string };
-            if (msg.type === 'error') {
-              clearTimeout(timer);
-              reject(new Error(`WS error: ${msg.name ?? 'unknown'}`));
-            }
-            if (msg.type !== 'error') {
-              clearTimeout(timer);
-              resolve(ws);
-            }
-          } catch {
-            // ignore non-JSON frames
-          }
-        });
-        ws.addEventListener('error', () => {
-          clearTimeout(timer);
-          reject(new Error('WS connection error'));
-        });
-      });
-
     const readPresenceIds = async (): Promise<string[]> => {
       const res = await request.get(`${BASE_URL}/api/v1/boards/${boardId}/presence`, {
         headers: { Authorization: `Bearer ${tokenA}` },
@@ -181,8 +166,8 @@ test.describe('Board Presence', () => {
     const idA = await idOf(tokenA);
     const idB = await idOf(tokenB);
 
-    const socketA = await openSocket(tokenA);
-    const socketB = await openSocket(tokenB);
+    const socketA = await subscribeToBoard(tokenA, boardId);
+    const socketB = await subscribeToBoard(tokenB, boardId);
 
     try {
       // Both subscribers are recorded, by id.


### PR DESCRIPTION
## Summary

Two accuracy defects flagged by the #328 review, both now live on `main`. Neither was a merge blocker, but both were real:

## 1. An over-broad comment

The comment above the removed REST tests claimed:

> the real join/leave behaviour is covered by Test 2 below

Test 2 covers **join only** — leave is covered by Test 3. The comment now names both tests correctly.

## 2. The join test did not assert identity

It asserted `body.data.length >= 2`, which proves only that *two viewers exist* — not that the two specific subscribers are the ones listed. It now resolves both user ids via `/api/v1/users/me` and asserts the presence list contains **both by id**.

## 3. Duplication removed

Test 2 and Test 3 carried byte-identical inline WebSocket subscribe helpers. One is hoisted to module scope.

## Proof the assertions are not vacuous

This is the part that matters — an assertion that can never fail is the exact problem this whole batch of work exists to fix. So I fault-injected against the real server:

| Injected fault | Result |
|---|---|
| Disable the presence **write** in `rooms/subscribe.ts` | join test fails: `Expected: ArrayContaining [<idA>, <idB>]` / `Received: []` |
| Disable the presence **delete** in `rooms/unsubscribe.ts` | leave test fails: `Expected: false` / `Received: true` |

Both product files were restored afterwards (`git diff server/` is empty), and the suite re-run clean to confirm.

## Verification

- **4 passed / 0 failed / 0 skipped**, three consecutive runs
- ESLint clean
- No product code changed
