### PR TITLE
test(e2e): close presence sockets on failure and drain teardown

### DIFF
--- a/tests/e2e/presence-board.spec.ts
+++ b/tests/e2e/presence-board.spec.ts
@@ -4,7 +4,7 @@
 // Based on: specs/tests/presence-board.md
 // Soft-skips when the server is not reachable.
 
-import { test, expect } from '@playwright/test';
+import { test, expect, type APIRequestContext } from '@playwright/test';
 import { BASE_URL, registerAndGetCredentials, createWorkspace, createBoard, createList, type Credentials } from './_helpers';
 
 const WS_URL = (process.env.TEST_BASE_URL ?? 'http://localhost:3000').replace(/^http/, 'ws');
@@ -14,7 +14,18 @@ const WS_URL = (process.env.TEST_BASE_URL ?? 'http://localhost:3000').replace(/^
 function subscribeToBoard(token: string, boardId: string): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(`${WS_URL}/api/v1/ws?token=${encodeURIComponent(token)}`);
-    const timer = setTimeout(() => reject(new Error('WS subscribe timed out')), 8000);
+    // Every failure path closes the socket: otherwise a rejected subscribe
+    // leaks an open connection holding a presence key.
+    const fail = (err: Error): void => {
+      clearTimeout(timer);
+      try {
+        ws.close();
+      } catch {
+        // already closing
+      }
+      reject(err);
+    };
+    const timer = setTimeout(() => fail(new Error('WS subscribe timed out')), 8000);
     ws.addEventListener('open', () => {
       ws.send(JSON.stringify({ type: 'subscribe', board_id: boardId }));
     });
@@ -22,8 +33,7 @@ function subscribeToBoard(token: string, boardId: string): Promise<WebSocket> {
       try {
         const msg = JSON.parse(String(event.data)) as { type?: string; name?: string };
         if (msg.type === 'error') {
-          clearTimeout(timer);
-          reject(new Error(`WS error: ${msg.name ?? 'unknown'}`));
+          fail(new Error(`WS error: ${msg.name ?? 'unknown'}`));
         }
         // Any non-error message after subscribe means the subscription was accepted.
         if (msg.type !== 'error') {
@@ -35,10 +45,31 @@ function subscribeToBoard(token: string, boardId: string): Promise<WebSocket> {
       }
     });
     ws.addEventListener('error', () => {
-      clearTimeout(timer);
-      reject(new Error('WS connection error'));
+      fail(new Error('WS connection error'));
     });
   });
+}
+
+// Close a socket and wait until its presence key is gone. Without this, a
+// test's async unsubscribe can land while the NEXT test on the same board is
+// subscribing, dropping that test's count and causing a flaky false failure.
+async function closeAndDrain(
+  request: APIRequestContext,
+  ws: WebSocket,
+  boardId: string,
+  viewerToken: string,
+  userId: string,
+): Promise<void> {
+  ws.close();
+  await expect
+    .poll(async () => {
+      const res = await request.get(`${BASE_URL}/api/v1/boards/${boardId}/presence`, {
+        headers: { Authorization: `Bearer ${viewerToken}` },
+      });
+      const body = await res.json() as { data: Array<{ id: string }> };
+      return body.data.map((u) => u.id).includes(userId);
+    }, { timeout: 8000 })
+    .toBe(false);
 }
 
 test.describe('Board Presence', () => {
@@ -133,8 +164,9 @@ test.describe('Board Presence', () => {
         .poll(readPresenceIds, { timeout: 8000 })
         .toEqual(expect.arrayContaining([idA, idB]));
     } finally {
-      socketA.close();
-      socketB.close();
+      // Drain both so this test's unsubscribe cannot race the next test.
+      await closeAndDrain(request, socketA, boardId, tokenA, idA).catch(() => {});
+      await closeAndDrain(request, socketB, boardId, tokenA, idB).catch(() => {});
     }
   });
 
@@ -183,7 +215,9 @@ test.describe('Board Presence', () => {
         .toBe(false);
       expect(await readPresenceIds()).toContain(idA);
     } finally {
-      socketA.close();
+      // Drain A (B already left and been asserted gone) so the next test that
+      // uses this board starts from a clean presence list.
+      await closeAndDrain(request, socketA, boardId, tokenA, idA).catch(() => {});
       socketB.close();
     }
   });

--- a/tests/e2e/presence-board.spec.ts
+++ b/tests/e2e/presence-board.spec.ts
@@ -13,10 +13,26 @@ const WS_URL = (process.env.TEST_BASE_URL ?? 'http://localhost:3000').replace(/^
 // accepts the subscription. Used by the join and leave tests.
 function subscribeToBoard(token: string, boardId: string): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
-    const ws = new WebSocket(`${WS_URL}/api/v1/ws?token=${encodeURIComponent(token)}`);
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(`${WS_URL}/api/v1/ws?token=${encodeURIComponent(token)}`);
+    } catch (err) {
+      // A malformed URL throws synchronously; fail the promise instead of
+      // letting the exception escape the executor.
+      reject(err instanceof Error ? err : new Error('WS construction failed'));
+      return;
+    }
+
+    // settled guards against double-settling: an error frame followed by an
+    // error event must not reject twice.
+    let settled = false;
+
     // Every failure path closes the socket: otherwise a rejected subscribe
-    // leaks an open connection holding a presence key.
+    // leaks an open connection holding a presence key. Declared before the
+    // timer so it is initialised by the time any async event can call it.
     const fail = (err: Error): void => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timer);
       try {
         ws.close();
@@ -25,6 +41,9 @@ function subscribeToBoard(token: string, boardId: string): Promise<WebSocket> {
       }
       reject(err);
     };
+
+    // fail() closes over `timer`, but every caller is an async WebSocket event or
+    // the timer itself, so `timer` is always assigned before fail can run.
     const timer = setTimeout(() => fail(new Error('WS subscribe timed out')), 8000);
     ws.addEventListener('open', () => {
       ws.send(JSON.stringify({ type: 'subscribe', board_id: boardId }));
@@ -36,7 +55,8 @@ function subscribeToBoard(token: string, boardId: string): Promise<WebSocket> {
           fail(new Error(`WS error: ${msg.name ?? 'unknown'}`));
         }
         // Any non-error message after subscribe means the subscription was accepted.
-        if (msg.type !== 'error') {
+        if (msg.type !== 'error' && !settled) {
+          settled = true;
           clearTimeout(timer);
           resolve(ws);
         }


### PR DESCRIPTION
## Summary

Two socket-hygiene nits from the #328 review. Both are flake sources rather than correctness bugs, but this spec creates real WebSocket connections and runs against shared state, so they matter.

## 1. Sockets leaked on every rejection path

`subscribeToBoard` rejected on timeout, on a WS `error` frame, and on the `error` event — **without closing the WebSocket it created**. Each leak holds an open connection holding a `presence:<boardId>:<userId>` key.

Worse: if the *second* subscribe failed, the caller never reached its `finally`, so the *first* socket leaked too. That is exactly the shape of a test that leaves a phantom viewer behind.

Every rejection path now closes the socket.

## 2. Teardown raced the next test

Tests 2 and 3 share `boardId` and both tokens from `beforeAll`. Their `finally` blocks called `socket.close()` — which only *initiates* the close — without awaiting the server-side async unsubscribe. So a late `cache.del` could land while the next test was subscribing on the same board, dropping its presence count and failing nondeterministically.

Added `closeAndDrain()`: closes a socket and polls `GET /boards/:id/presence` until that viewer's id is gone. Both tests drain in `finally`, so a test cannot leave state behind.

This is the false-*failure* direction — a flake, not a masked pass — but it would have shown up as an intermittent red run, which is how test suites lose trust.

## Verification

- **4 passed / 0 failed / 0 skipped, five consecutive runs** (most runs I've done on this spec)
- ESLint clean
- No product code changed
