### PR TITLE
test(e2e): drag reorder asserts the change persisted to the API

### DIFF
--- a/tests/e2e/list-management.spec.ts
+++ b/tests/e2e/list-management.spec.ts
@@ -244,8 +244,22 @@ test.describe('List Management', () => {
     const uiToken = uiCreds.token;
     const uiWorkspaceId = await createWorkspace(request, uiToken);
     const uiBoardId = await createBoard(request, uiToken, uiWorkspaceId);
-    await createList(request, uiToken, uiBoardId, `Drag A ${run}`);
-    await createList(request, uiToken, uiBoardId, `Drag B ${run}`);
+    const nameA = `Drag A ${run}`;
+    const nameB = `Drag B ${run}`;
+    await createList(request, uiToken, uiBoardId, nameA);
+    await createList(request, uiToken, uiBoardId, nameB);
+
+    // Order as the API sees it — the drag must change THIS, not just the DOM.
+    const apiOrder = async (): Promise<string[]> => {
+      const res = await request.get(`${BASE_URL}/api/v1/boards/${uiBoardId}/lists`, {
+        headers: { Authorization: `Bearer ${uiToken}` },
+      });
+      expect(res.status()).toBe(200);
+      const body = await res.json() as { data: Array<{ title: string }> };
+      return body.data.map((l) => l.title);
+    };
+    const apiOrderBefore = await apiOrder();
+    expect(apiOrderBefore.slice(0, 2)).toEqual([nameA, nameB]);
 
     await loginViaCookie(page, UI_URL, uiCreds);
     await gotoBoard(page, uiBoardId);
@@ -282,5 +296,11 @@ test.describe('List Management', () => {
     const orderAfter = (await renameButtons.allInnerTexts()).filter((x) => x.trim());
     expect(orderAfter.length).toBe(orderBefore.length);
     expect(orderAfter[0]).not.toBe(orderBefore[0]);
+
+    // And the change reached the server. Without this the test would pass even
+    // if the drag only mutated local state and never called the reorder endpoint.
+    await expect
+      .poll(apiOrder, { timeout: 8000 })
+      .toEqual([nameB, nameA]);
   });
 });


### PR DESCRIPTION
## Summary

The #327 review flagged that the drag test asserted **UI order only**. A drag that mutated local React state but never called the reorder endpoint would have passed — so a persistence regression could slip through. That is the same class of gap as the soft-skips this batch exists to remove.

## The two layers

In `BoardCanvas.tsx`, `onListReorder` updates local state; `onDragCommit` is what hits the reorder endpoint and persists. The old assertion read only the DOM, so it could not distinguish them.

## What changed

Test 8 now:

1. Captures the API list order **before** the drag and asserts the seeded order as a precondition (so a wrong starting order fails loudly rather than silently).
2. Asserts the UI order changed.
3. **Polls `GET /boards/:id/lists` until it shows the swapped order** — the persistence check that was missing.

## Proven non-vacuous by fault injection

Replacing `await onDragCommit(...)` in `BoardCanvas.tsx` with a no-op — local state only, nothing persisted — makes the test **fail** on a deep-equality mismatch of the API order.

The product file was restored afterwards; `git diff src/ server/` is empty.

This is the third assertion in this batch verified this way. "The test goes green" is not evidence of coverage — it was exactly the evidence that hid 16 dead tests — so a new assertion gets fault-injected before I claim it works.

## Verification

- **9 passed / 0 failed / 0 skipped**, three consecutive runs
- ESLint clean
- No product code changed
